### PR TITLE
feat: add dynamic profile page

### DIFF
--- a/profile.html
+++ b/profile.html
@@ -8,17 +8,6 @@
   <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
 </head>
 <body>
- 
-
-/* Dummy sign out */
-function signOut() {
-  closeModal();
-  alert('Signed out (demo)');
-}
-</script>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
-  </header>
-
   <!-- Profile Content -->
   <main class="profile-container">
     <section class="profile-header">
@@ -58,6 +47,9 @@ function signOut() {
     </section>
   </main>
 
+  <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-app-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-auth-compat.js"></script>
   <script src="main.js"></script>
+  <script src="profile.js"></script>
 </body>
 </html>

--- a/profile.js
+++ b/profile.js
@@ -1,0 +1,41 @@
+// Handles profile display and editing for logged-in users
+
+document.addEventListener('DOMContentLoaded', () => {
+  const nameEl = document.querySelector('.profile-details h1');
+  const avatarEl = document.querySelector('.profile-avatar img');
+  const editNameBtn = document.querySelector('.edit-profile-btn');
+  const editAvatarBtn = document.querySelector('.edit-avatar-btn');
+
+  function renderProfile(user) {
+    const displayName = user?.displayName || localStorage.getItem('displayName') || 'Anonymous';
+    const photoURL = user?.photoURL || localStorage.getItem('photoURL') || 'images/default-avatar.png';
+    nameEl.textContent = displayName;
+    avatarEl.src = photoURL;
+  }
+
+  firebase.auth().onAuthStateChanged(renderProfile);
+
+  editNameBtn.addEventListener('click', () => {
+    const newName = prompt('Enter a new display name:');
+    if (!newName) return;
+    const user = firebase.auth().currentUser;
+    if (user) {
+      user.updateProfile({ displayName: newName }).then(() => renderProfile(user));
+    } else {
+      localStorage.setItem('displayName', newName);
+      renderProfile(null);
+    }
+  });
+
+  editAvatarBtn.addEventListener('click', () => {
+    const newUrl = prompt('Enter a new avatar URL:');
+    if (!newUrl) return;
+    const user = firebase.auth().currentUser;
+    if (user) {
+      user.updateProfile({ photoURL: newUrl }).then(() => renderProfile(user));
+    } else {
+      localStorage.setItem('photoURL', newUrl);
+      renderProfile(null);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- tidy profile HTML and remove stray scripts
- load current user details into profile via Firebase
- allow editing name and avatar with Firebase or localStorage persistence

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7347f09f4832281dcfd10a1fd56ab