### PR TITLE
Add favourites and notes management

### DIFF
--- a/favourites.js
+++ b/favourites.js
@@ -1,0 +1,25 @@
+export function getFavourites(uid) {
+  try {
+    const data = localStorage.getItem(`favourites_${uid}`);
+    return data ? JSON.parse(data) : [];
+  } catch (e) {
+    return [];
+  }
+}
+
+export function saveFavourites(uid, favs) {
+  localStorage.setItem(`favourites_${uid}`, JSON.stringify(favs));
+}
+
+export function addFavourite(uid, fav) {
+  const favs = getFavourites(uid);
+  if (!favs.some(f => f.id === fav.id)) {
+    favs.push(fav);
+    saveFavourites(uid, favs);
+  }
+}
+
+export function removeFavourite(uid, id) {
+  const favs = getFavourites(uid).filter(f => f.id !== id);
+  saveFavourites(uid, favs);
+}

--- a/notes.js
+++ b/notes.js
@@ -1,0 +1,32 @@
+export function getNotes(uid) {
+  try {
+    const data = localStorage.getItem(`notes_${uid}`);
+    return data ? JSON.parse(data) : [];
+  } catch (e) {
+    return [];
+  }
+}
+
+export function saveNotes(uid, notes) {
+  localStorage.setItem(`notes_${uid}`, JSON.stringify(notes));
+}
+
+export function addNote(uid, note) {
+  const notes = getNotes(uid);
+  notes.push(note);
+  saveNotes(uid, notes);
+}
+
+export function updateNote(uid, index, text) {
+  const notes = getNotes(uid);
+  if (notes[index]) {
+    notes[index].text = text;
+    saveNotes(uid, notes);
+  }
+}
+
+export function removeNote(uid, index) {
+  const notes = getNotes(uid);
+  notes.splice(index, 1);
+  saveNotes(uid, notes);
+}

--- a/profile.html
+++ b/profile.html
@@ -36,28 +36,64 @@ function signOut() {
 
     <!-- Profile Info -->
     <section class="profile-info">
-      <h2>Profile Summary</h2>
-      <div class="info-grid">
-        <div class="info-card">
-          <h3>Favorite Route</h3>
-          <p>Route 25</p>
-        </div>
-        <div class="info-card">
-          <h3>Saved Stops</h3>
-          <p>Oxford Circus, Aldgate</p>
-        </div>
-        <div class="info-card">
-          <h3>Followers</h3>
-          <p>54</p>
-        </div>
-        <div class="info-card">
-          <h3>Following</h3>
-          <p>22</p>
-        </div>
-      </div>
+      <h2>Your Favourites</h2>
+      <ul id="favList"></ul>
+      <h2>Your Notes</h2>
+      <ul id="noteList"></ul>
     </section>
   </main>
-
+  <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-app-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-auth-compat.js"></script>
   <script src="main.js"></script>
+  <script type="module">
+  import { getFavourites, removeFavourite } from './favourites.js';
+  import { getNotes, updateNote, removeNote } from './notes.js';
+
+  const favList = document.getElementById('favList');
+  const noteList = document.getElementById('noteList');
+
+  firebase.auth().onAuthStateChanged(user => {
+    if (!user) return;
+
+    function renderFavs() {
+      const favs = getFavourites(user.uid);
+      favList.innerHTML = favs.map(f => `<li data-id="${f.id}">${f.name} <button class="delete-fav">Delete</button></li>`).join('');
+    }
+
+    function renderNotes() {
+      const notes = getNotes(user.uid);
+      noteList.innerHTML = notes.map((n,i)=>`<li data-index="${i}"><strong>${n.name}</strong>: ${n.text} <button class="edit-note">Edit</button> <button class="delete-note">Delete</button></li>`).join('');
+    }
+
+    favList.addEventListener('click', e => {
+      if (e.target.classList.contains('delete-fav')) {
+        const id = e.target.parentElement.getAttribute('data-id');
+        removeFavourite(user.uid, id);
+        renderFavs();
+      }
+    });
+
+    noteList.addEventListener('click', e => {
+      if (e.target.classList.contains('delete-note')) {
+        const idx = Number(e.target.parentElement.getAttribute('data-index'));
+        removeNote(user.uid, idx);
+        renderNotes();
+      }
+      if (e.target.classList.contains('edit-note')) {
+        const idx = Number(e.target.parentElement.getAttribute('data-index'));
+        const notes = getNotes(user.uid);
+        const current = notes[idx].text;
+        const updatedText = prompt('Edit note:', current);
+        if (updatedText !== null) {
+          updateNote(user.uid, idx, updatedText);
+          renderNotes();
+        }
+      }
+    });
+
+    renderFavs();
+    renderNotes();
+  });
+  </script>
 </body>
 </html>

--- a/tracking.html
+++ b/tracking.html
@@ -117,6 +117,8 @@
   .board-head{display:flex; justify-content:space-between; align-items:center; padding:14px 16px; background:#fbfbfc; border-bottom:1px solid var(--ring);}
   .board-title{font-weight:800}
   .meta{font-size:12px; color:var(--muted)}
+  .actions{display:flex; align-items:center; gap:8px}
+  .action-btn{background:var(--accent); color:#fff; border:0; border-radius:6px; padding:6px 8px; font-size:12px; cursor:pointer}
   .rows{display:flex; flex-direction:column}
   .row{
     display:grid; grid-template-columns: 110px 1fr 110px; gap:12px;
@@ -165,7 +167,11 @@
           <div class="board-title" id="boardTitle">No stop selected</div>
           <div class="meta" id="boardMeta">Type a station name and choose a stop from the list.</div>
         </div>
-        <div class="meta" id="updated"></div>
+        <div class="actions">
+          <button class="action-btn" id="favBtn">☆ Favourite</button>
+          <button class="action-btn" id="noteBtn">📝 Add note</button>
+          <div class="meta" id="updated"></div>
+        </div>
       </div>
       <div class="rows" id="rows">
         <div class="empty">Nothing to show yet.</div>
@@ -398,9 +404,31 @@ q.addEventListener('keydown', (e)=>{
 goBtn.addEventListener('click', ()=> runSearch());
 
 </script>
-</body>
- </main>
-  <script src="navbar-loader.js"></script>
-<style src="navbar.css"></style>  <!-- see next -->
+<script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-app-compat.js"></script>
+<script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-auth-compat.js"></script>
+<script src="main.js"></script>
+<script type="module">
+import { addFavourite } from './favourites.js';
+import { addNote } from './notes.js';
+
+const favBtn = document.getElementById('favBtn');
+const noteBtn = document.getElementById('noteBtn');
+
+favBtn.addEventListener('click', () => {
+  const user = firebase.auth().currentUser;
+  if (!user || !currentStop) { alert('Select a stop and sign in first'); return; }
+  addFavourite(user.uid, currentStop);
+  favBtn.textContent = '★ Favourited';
+});
+
+noteBtn.addEventListener('click', () => {
+  const user = firebase.auth().currentUser;
+  if (!user || !currentStop) { alert('Select a stop and sign in first'); return; }
+  const text = prompt('Enter a note for this stop:');
+  if (text) addNote(user.uid, { id: currentStop.id, name: currentStop.name, text });
+});
+</script>
+<script src="navbar-loader.js"></script>
+<link rel="stylesheet" href="navbar.css" />
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add `favourites.js` and `notes.js` helpers for per-user localStorage
- allow marking stops as favourites and adding notes in tracking view
- surface saved favourites and notes in profile with edit/delete support

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c73479cae083229cb787f743fefd7b