### PR TITLE
Add global preferences with accessibility controls

### DIFF
--- a/about.html
+++ b/about.html
@@ -2,8 +2,12 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>About - RouteFlow London</title>
+  <link rel="icon" href="images/New_Routflow_London_Logo.png" type="image/png" />
+  <link href="https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible:wght@400;600&family=Inter:wght@400;600;800&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="style.css">
+  <script src="theme.js" defer></script>
 </head>
 <body>
 <div id="navbar-container"></div>
@@ -26,7 +30,6 @@
     </div>
     <small>© 2025 RouteFlow London</small>
   </footer>
-  <script src="theme.js"></script>
-  <script src="navbar-loader.js"></script>
+  <script src="navbar-loader.js" defer></script>
 </body>
 </html>

--- a/blog.html
+++ b/blog.html
@@ -2,8 +2,12 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Blog - RouteFlow London</title>
+  <link rel="icon" href="images/New_Routflow_London_Logo.png" type="image/png" />
+  <link href="https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible:wght@400;600&family=Inter:wght@400;600;800&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="style.css">
+  <script src="theme.js" defer></script>
 </head>
 <body>
   <header class="navbar">
@@ -550,6 +554,5 @@ function signOut() {
     </div>
     <small>© 2025 RouteFlow London</small>
   </footer>
-  <script src="theme.js"></script>
 </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -2,8 +2,12 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Contact - RouteFlow London</title>
+  <link rel="icon" href="images/New_Routflow_London_Logo.png" type="image/png" />
+  <link href="https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible:wght@400;600&family=Inter:wght@400;600;800&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="style.css">
+  <script src="theme.js" defer></script>
 </head>
 <body>
 <div id="navbar-container"></div>
@@ -24,7 +28,6 @@
     </div>
     <small>© 2025 RouteFlow London</small>
   </footer>
-  <script src="theme.js"></script>
-  <script src="navbar-loader.js"></script>
+  <script src="navbar-loader.js" defer></script>
 </body>
 </html>

--- a/dashboard.css
+++ b/dashboard.css
@@ -93,3 +93,251 @@ body.dark-mode .recents-list li { border-color: #444; }
   margin: 2rem auto;
   padding: 0 1rem;
 }
+
+.settings-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.settings-card {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.settings-card h2 {
+  margin: 0;
+  font-size: 1.35rem;
+}
+
+.settings-description {
+  margin: 0;
+  font-size: 0.95rem;
+  color: rgba(23, 23, 23, 0.72);
+}
+
+body.dark-mode .settings-description {
+  color: rgba(250, 250, 250, 0.72);
+}
+
+.settings-lead {
+  margin-top: 0.5rem;
+  margin-bottom: 2rem;
+  max-width: 60ch;
+}
+
+.setting-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  padding: 0.75rem 0;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+}
+
+body.dark-mode .setting-row {
+  border-color: rgba(255, 255, 255, 0.12);
+}
+
+.setting-row:last-child {
+  border-bottom: none;
+}
+
+.setting-row--stacked {
+  flex-direction: column;
+  align-items: stretch;
+}
+
+.setting-label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-weight: 600;
+}
+
+.setting-hint {
+  font-weight: 400;
+  font-size: 0.9rem;
+  opacity: 0.7;
+}
+
+.setting-control {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.switch {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  width: 52px;
+  height: 28px;
+  cursor: pointer;
+}
+
+.switch input {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  margin: 0;
+  cursor: pointer;
+}
+
+.switch-slider {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.25);
+  border-radius: 999px;
+  transition: background var(--transition), box-shadow var(--transition);
+}
+
+body.dark-mode .switch-slider {
+  background: rgba(255, 255, 255, 0.3);
+}
+
+.switch-slider::before {
+  content: '';
+  position: absolute;
+  left: 3px;
+  top: 3px;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: #fff;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.25);
+  transition: transform var(--transition);
+}
+
+.switch input:checked + .switch-slider {
+  background: var(--accent-blue);
+}
+
+.switch input:checked + .switch-slider::before {
+  transform: translateX(24px);
+}
+
+.switch input:focus-visible + .switch-slider {
+  box-shadow: 0 0 0 3px rgba(41, 121, 255, 0.35);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent-blue) 35%, transparent);
+}
+
+body.high-contrast .switch input:focus-visible + .switch-slider {
+  box-shadow: 0 0 0 3px var(--accent-blue);
+}
+
+.accent-palette {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 0.75rem;
+}
+
+.accent-choice {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.65rem 0.75rem;
+  border-radius: 0.9rem;
+  background: var(--card-bg-light);
+  border: 2px solid transparent;
+  cursor: pointer;
+  transition: border var(--transition), box-shadow var(--transition), transform var(--transition);
+}
+
+body.dark-mode .accent-choice {
+  background: var(--card-bg-dark);
+}
+
+.accent-choice input {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.accent-choice .accent-swatch {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, var(--accent-swatch), var(--accent-swatch-contrast));
+  border: 2px solid rgba(0, 0, 0, 0.2);
+}
+
+body.dark-mode .accent-choice .accent-swatch {
+  border-color: rgba(255, 255, 255, 0.25);
+}
+
+.accent-choice .accent-name {
+  font-weight: 600;
+}
+
+.accent-choice[data-selected="true"],
+.accent-choice:focus-within {
+  border-color: var(--accent-blue);
+  box-shadow: 0 0 0 3px rgba(41, 121, 255, 0.2);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent-blue) 25%, transparent);
+}
+
+.accent-choice[data-selected="true"] {
+  transform: translateY(-1px);
+}
+
+.text-size-control {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.text-size-control input[type="range"] {
+  width: 100%;
+  accent-color: var(--accent-blue);
+}
+
+.text-scale-preview {
+  font-size: 0.9rem;
+  opacity: 0.75;
+}
+
+.settings-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.settings-actions button {
+  border-radius: 999px;
+  border: 1.5px solid var(--accent-blue);
+  background: transparent;
+  color: var(--accent-blue);
+  font-weight: 600;
+  padding: 0.65rem 1.2rem;
+  cursor: pointer;
+  transition: background var(--transition), color var(--transition), transform var(--transition);
+}
+
+.settings-actions button:hover {
+  background: var(--accent-blue);
+  color: #fff;
+  transform: translateY(-1px);
+}
+
+body.dark-mode .settings-actions button {
+  color: var(--accent-blue);
+}
+
+@media (max-width: 640px) {
+  .setting-row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .switch {
+    align-self: flex-start;
+  }
+}

--- a/dashboard.html
+++ b/dashboard.html
@@ -5,9 +5,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Dashboard | RouteFlow London</title>
   <link rel="icon" href="images/New_Routflow_London_Logo.png" type="image/png" />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible:wght@400;600&family=Inter:wght@400;600;800&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="style.css" />
   <link rel="stylesheet" href="dashboard.css" />
+  <script src="theme.js" defer></script>
 </head>
 <body>
   <div id="navbar-container"></div>
@@ -51,7 +52,6 @@
       firebase.initializeApp(firebaseConfig);
     }
   </script>
-  <script src="theme.js"></script>
   <script src="navbar-loader.js"></script>
   <script type="module">
     import {getFavourites, removeFavourite} from './favourites.js';

--- a/disruptions.html
+++ b/disruptions.html
@@ -5,9 +5,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Disruptions | Routeflow London</title>
   <link rel="icon" href="images/New_Routflow_London_Logo.png" type="image/png">
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible:wght@400;600&family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
   <link rel="stylesheet" href="style.css">
+  <script src="theme.js" defer></script>
 </head>
   <body>
   <header class="navbar">

--- a/fleet.html
+++ b/fleet.html
@@ -5,9 +5,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Fleet | Routeflow London</title>
   <link rel="icon" href="images/New_Routflow_London_Logo.png" type="image/png">
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible:wght@400;600&family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
   <link rel="stylesheet" href="style.css">
+  <script src="theme.js" defer></script>
 </head>
   <body>
   <header class="navbar">

--- a/index.html
+++ b/index.html
@@ -5,9 +5,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="icon" href="images/New_Routflow_London_Logo.png" type="image/png">
   <title>RouteFlow London</title>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible:wght@400;600&family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
   <link rel="stylesheet" href="style.css">
+  <script src="theme.js" defer></script>
 </head>
 <body>
   <div id="navbar-container"></div>

--- a/password-reset.html
+++ b/password-reset.html
@@ -2,8 +2,12 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Reset Password - RouteFlow London</title>
+  <link rel="icon" href="images/New_Routflow_London_Logo.png" type="image/png" />
+  <link href="https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible:wght@400;600&family=Inter:wght@400;600;800&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="style.css"> <!-- Optional styling -->
+  <script src="theme.js" defer></script>
   <script src="https://www.gstatic.com/firebasejs/9.0.0/firebase-app.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.0.0/firebase-auth.js"></script>
   <header class="navbar">

--- a/planning.html
+++ b/planning.html
@@ -5,9 +5,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Journey Planning | Routeflow London</title>
   <link rel="icon" href="images/New_Routflow_London_Logo.png" type="image/png">
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible:wght@400;600&family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
   <link rel="stylesheet" href="style.css">
+  <script src="theme.js" defer></script>
 </head>
 <body>
   <div id="navbar-container"></div>

--- a/privacy.html
+++ b/privacy.html
@@ -5,9 +5,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="icon" href="images/New_Routflow_London_Logo.png" type="image/png">
   <title>Privacy | Routeflow London</title>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible:wght@400;600&family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
   <link rel="stylesheet" href="style.css">
+  <script src="theme.js" defer></script>
 </head>
 <body>
    <header class="navbar">

--- a/profile.html
+++ b/profile.html
@@ -4,8 +4,11 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Profile | RouteFlow London</title>
+  <link rel="icon" href="images/New_Routflow_London_Logo.png" type="image/png">
+  <link href="https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible:wght@400;600&family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
   <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
+  <script src="theme.js" defer></script>
 </head>
 <body>
  

--- a/routes.html
+++ b/routes.html
@@ -5,9 +5,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="icon" href="images/New_Routflow_London_Logo.png" type="image/png">
   <title>Routes | Routeflow London</title>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible:wght@400;600&family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
   <link rel="stylesheet" href="style.css">
+  <script src="theme.js" defer></script>
 </head>
 <body>
     <header class="navbar">

--- a/settings.html
+++ b/settings.html
@@ -5,21 +5,102 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Settings | RouteFlow London</title>
   <link rel="icon" href="images/New_Routflow_London_Logo.png" type="image/png" />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible:wght@400;600&family=Inter:wght@400;600;800&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="style.css" />
   <link rel="stylesheet" href="dashboard.css" />
+  <script src="theme.js" defer></script>
+  <script src="settings.js" defer></script>
 </head>
 <body>
   <div id="navbar-container"></div>
-  <main class="settings-page">
-    <h1>Settings</h1>
-    <section class="card">
-      <label class="setting-item" for="darkModeToggle">
-        <span>Dark Mode</span>
-        <input type="checkbox" id="darkModeToggle" />
-      </label>
-    </section>
+  <main class="settings-page" aria-labelledby="settingsTitle">
+    <h1 id="settingsTitle">Settings</h1>
+    <p class="settings-description settings-lead">
+      Personalise RouteFlow London with appearance and accessibility preferences that follow you across every page.
+    </p>
+
+    <form id="preferencesForm" class="settings-form">
+      <section class="card settings-card" aria-labelledby="appearanceHeading">
+        <h2 id="appearanceHeading">Appearance</h2>
+        <p class="settings-description">Fine-tune the interface to match your environment.</p>
+
+        <div class="setting-row">
+          <div class="setting-label">
+            <span id="prefDarkModeLabel">Dark mode</span>
+            <span class="setting-hint" id="prefDarkModeHint">Use a darker palette to reduce glare.</span>
+          </div>
+          <label class="switch" aria-labelledby="prefDarkModeLabel prefDarkModeHint">
+            <input type="checkbox" id="prefDarkMode" aria-labelledby="prefDarkModeLabel" aria-describedby="prefDarkModeHint" />
+            <span class="switch-slider" aria-hidden="true"></span>
+          </label>
+        </div>
+
+        <div class="setting-row setting-row--stacked">
+          <div class="setting-label">
+            <span id="prefAccentLabel">Accent colour</span>
+            <span class="setting-hint" id="prefAccentHint">Choose the hue used for buttons and highlights.</span>
+          </div>
+          <div class="setting-control">
+            <div class="accent-palette" id="accentPalette" role="radiogroup" aria-labelledby="prefAccentLabel" aria-describedby="prefAccentHint"></div>
+          </div>
+        </div>
+
+        <div class="setting-row setting-row--stacked">
+          <div class="setting-label">
+            <label id="prefTextScaleLabel" for="prefTextScale">Text size</label>
+            <span class="setting-hint" id="prefTextScaleHint">Increase text across the site for easier reading.</span>
+          </div>
+          <div class="setting-control text-size-control">
+            <input type="range" id="prefTextScale" min="90" max="130" step="5" aria-labelledby="prefTextScaleLabel" aria-describedby="prefTextScaleHint textScaleValue" />
+            <div class="text-scale-preview">Current size: <span id="textScaleValue"></span></div>
+          </div>
+        </div>
+      </section>
+
+      <section class="card settings-card" aria-labelledby="accessibilityHeading">
+        <h2 id="accessibilityHeading">Accessibility</h2>
+        <p class="settings-description">Enhance clarity and reduce eye strain with additional options.</p>
+
+        <div class="setting-row">
+          <div class="setting-label">
+            <span id="prefHighContrastLabel">High contrast</span>
+            <span class="setting-hint" id="prefHighContrastHint">Boost contrast and emphasise focus states.</span>
+          </div>
+          <label class="switch" aria-labelledby="prefHighContrastLabel prefHighContrastHint">
+            <input type="checkbox" id="prefHighContrast" aria-labelledby="prefHighContrastLabel" aria-describedby="prefHighContrastHint" />
+            <span class="switch-slider" aria-hidden="true"></span>
+          </label>
+        </div>
+
+        <div class="setting-row">
+          <div class="setting-label">
+            <span id="prefReadableFontLabel">Readable font</span>
+            <span class="setting-hint" id="prefReadableFontHint">Swap to Atkinson Hyperlegible for improved character clarity.</span>
+          </div>
+          <label class="switch" aria-labelledby="prefReadableFontLabel prefReadableFontHint">
+            <input type="checkbox" id="prefReadableFont" aria-labelledby="prefReadableFontLabel" aria-describedby="prefReadableFontHint" />
+            <span class="switch-slider" aria-hidden="true"></span>
+          </label>
+        </div>
+
+        <div class="setting-row">
+          <div class="setting-label">
+            <span id="prefReduceMotionLabel">Reduce motion</span>
+            <span class="setting-hint" id="prefReduceMotionHint">Minimise animations and transitions for sensitive users.</span>
+          </div>
+          <label class="switch" aria-labelledby="prefReduceMotionLabel prefReduceMotionHint">
+            <input type="checkbox" id="prefReduceMotion" aria-labelledby="prefReduceMotionLabel" aria-describedby="prefReduceMotionHint" />
+            <span class="switch-slider" aria-hidden="true"></span>
+          </label>
+        </div>
+      </section>
+
+      <div class="settings-actions">
+        <button type="button" id="resetPreferences">Reset to defaults</button>
+      </div>
+    </form>
   </main>
+
   <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-auth-compat.js"></script>
   <script>
@@ -35,14 +116,6 @@
       firebase.initializeApp(firebaseConfig);
     }
   </script>
-  <script src="theme.js"></script>
-  <script src="navbar-loader.js"></script>
-  <script>
-    document.addEventListener('DOMContentLoaded', () => {
-      const toggle = document.getElementById('darkModeToggle');
-      toggle.checked = document.body.classList.contains('dark-mode');
-      toggle.addEventListener('change', () => toggleTheme());
-    });
-  </script>
+  <script src="navbar-loader.js" defer></script>
 </body>
 </html>

--- a/settings.js
+++ b/settings.js
@@ -1,0 +1,134 @@
+(function () {
+  const formatPercent = (value) => `${Math.round(value * 100)}%`;
+
+  const bindSwitch = (element, getter) => {
+    if (!element) return () => {};
+    return (prefsApi) => {
+      element.addEventListener('change', () => {
+        const next = getter(element.checked);
+        prefsApi.setPreferences(next);
+      });
+    };
+  };
+
+  const renderAccentOptions = (container, prefsApi) => {
+    if (!container) return [];
+
+    const accents = prefsApi.getAccentOptions();
+    container.innerHTML = '';
+
+    return Object.entries(accents).map(([key, value]) => {
+      const label = document.createElement('label');
+      label.className = 'accent-choice';
+      label.dataset.accentKey = key;
+      label.style.setProperty('--accent-swatch', value.accent);
+      label.style.setProperty('--accent-swatch-contrast', value.accentDark);
+
+      const input = document.createElement('input');
+      input.type = 'radio';
+      input.name = 'accent';
+      input.value = key;
+      input.setAttribute('aria-label', value.label);
+
+      const swatch = document.createElement('span');
+      swatch.className = 'accent-swatch';
+      swatch.setAttribute('aria-hidden', 'true');
+
+      const text = document.createElement('span');
+      text.className = 'accent-name';
+      text.textContent = value.label;
+
+      label.append(input, swatch, text);
+      container.append(label);
+      return input;
+    });
+  };
+
+  const updateAccentSelection = (container, selectedKey) => {
+    if (!container) return;
+    container.querySelectorAll('.accent-choice').forEach((choice) => {
+      const isSelected = choice.dataset.accentKey === selectedKey;
+      choice.dataset.selected = String(isSelected);
+      const radio = choice.querySelector('input[type="radio"]');
+      if (radio) {
+        radio.checked = isSelected;
+      }
+    });
+  };
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const prefsApi = window.RouteflowPreferences;
+    if (!prefsApi) return;
+
+    const form = document.getElementById('preferencesForm');
+    if (!form) return;
+
+    const darkModeToggle = document.getElementById('prefDarkMode');
+    const highContrastToggle = document.getElementById('prefHighContrast');
+    const readableFontToggle = document.getElementById('prefReadableFont');
+    const reduceMotionToggle = document.getElementById('prefReduceMotion');
+    const textScaleSlider = document.getElementById('prefTextScale');
+    const textScaleLabel = document.getElementById('textScaleValue');
+    const accentPalette = document.getElementById('accentPalette');
+    const resetButton = document.getElementById('resetPreferences');
+
+    const accentInputs = renderAccentOptions(accentPalette, prefsApi);
+
+    accentInputs.forEach((input) => {
+      input.addEventListener('change', () => {
+        if (input.checked) {
+          prefsApi.setPreference('accent', input.value);
+        }
+      });
+    });
+
+    if (textScaleSlider) {
+      textScaleSlider.addEventListener('input', () => {
+        const scale = Number(textScaleSlider.value) / 100;
+        prefsApi.setPreference('textScale', scale);
+        if (textScaleLabel) {
+          textScaleLabel.textContent = formatPercent(scale);
+        }
+      });
+    }
+
+    bindSwitch(darkModeToggle, (checked) => ({ theme: checked ? 'dark' : 'light' }))(prefsApi);
+    bindSwitch(highContrastToggle, (checked) => ({ highContrast: checked }))(prefsApi);
+    bindSwitch(readableFontToggle, (checked) => ({ readableFont: checked }))(prefsApi);
+    bindSwitch(reduceMotionToggle, (checked) => ({ reduceMotion: checked }))(prefsApi);
+
+    if (resetButton) {
+      resetButton.addEventListener('click', () => {
+        prefsApi.resetPreferences();
+      });
+    }
+
+    const syncUi = (preferences) => {
+      if (darkModeToggle) {
+        darkModeToggle.checked = preferences.theme === 'dark';
+      }
+      if (highContrastToggle) {
+        highContrastToggle.checked = preferences.highContrast;
+      }
+      if (readableFontToggle) {
+        readableFontToggle.checked = preferences.readableFont;
+      }
+      if (reduceMotionToggle) {
+        reduceMotionToggle.checked = preferences.reduceMotion;
+      }
+      if (textScaleSlider) {
+        const scaleValue = Math.round(clamp(preferences.textScale, 0.9, 1.3) * 100);
+        textScaleSlider.value = String(scaleValue);
+        if (textScaleLabel) {
+          textScaleLabel.textContent = formatPercent(scaleValue / 100);
+        }
+      }
+      updateAccentSelection(accentPalette, preferences.accent);
+    };
+
+    const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
+
+    syncUi(prefsApi.getPreferences());
+    prefsApi.onChange(syncUi);
+  });
+})();

--- a/style.css
+++ b/style.css
@@ -31,6 +31,54 @@ body.dark-mode {
   color: var(--foreground-dark);
 }
 
+body.high-contrast {
+  --background-light: #ffffff;
+  --foreground-light: #000000;
+  --card-bg-light: #ffffff;
+}
+
+body.dark-mode.high-contrast {
+  --background-dark: #000000;
+  --foreground-dark: #ffffff;
+  --card-bg-dark: #040404;
+}
+
+body.high-contrast a {
+  text-decoration: underline;
+}
+
+body.high-contrast .card {
+  box-shadow: none;
+  border: 2px solid currentColor;
+}
+
+body.dark-mode.high-contrast .card {
+  border-color: var(--foreground-dark);
+}
+
+body.high-contrast header {
+  box-shadow: none;
+  border-bottom: 3px solid currentColor;
+}
+
+body.high-contrast *:focus-visible {
+  outline: 3px solid var(--accent-blue);
+  outline-offset: 2px;
+}
+
+body.readable-font {
+  font-family: 'Atkinson Hyperlegible', 'Inter', 'Segoe UI', Arial, sans-serif;
+}
+
+body.reduced-motion *,
+body.reduced-motion *::before,
+body.reduced-motion *::after {
+  animation-duration: 0.01ms !important;
+  animation-iteration-count: 1 !important;
+  transition-duration: 0.01ms !important;
+  scroll-behavior: auto !important;
+}
+
 /*-------------------------------
   Header & Navigation
 -------------------------------*/

--- a/terms.html
+++ b/terms.html
@@ -5,9 +5,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="icon" href="images/New_Routflow_London_Logo.png" type="image/png">
   <title>Routeflow London</title>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible:wght@400;600&family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
   <link rel="stylesheet" href="style.css">
+  <script src="theme.js" defer></script>
 </head>
 <body>
     <header class="navbar">

--- a/theme.js
+++ b/theme.js
@@ -1,14 +1,285 @@
-// Persistent light/dark mode switcher
-function applyStoredTheme() {
-  const theme = localStorage.getItem('theme');
-  if (theme === 'dark') {
-    document.body.classList.add('dark-mode');
+(function () {
+  const STORAGE_KEY = 'routeflow:preferences';
+  const DEFAULT_PREFERENCES = {
+    theme: 'light',
+    accent: 'crimson',
+    textScale: 1,
+    highContrast: false,
+    readableFont: false,
+    reduceMotion: false
+  };
+
+  const DEFAULT_TOKENS = {
+    '--primary': '#d32f2f',
+    '--primary-dark': '#b71c1c',
+    '--accent-blue': '#2979ff',
+    '--accent-blue-dark': '#1565c0',
+    '--background-light': '#ffffff',
+    '--foreground-light': '#171717',
+    '--background-dark': '#121212',
+    '--foreground-dark': '#fafafa',
+    '--card-bg-light': '#f6f8fa',
+    '--card-bg-dark': '#232323',
+    '--transition': '0.2s cubic-bezier(.46,.03,.52,.96)'
+  };
+
+  const ACCENTS = {
+    crimson: {
+      label: 'TfL Red',
+      accent: '#d32f2f',
+      accentDark: '#9a1b1b'
+    },
+    skyline: {
+      label: 'Skyline Blue',
+      accent: '#2979ff',
+      accentDark: '#0f4ed8'
+    },
+    emerald: {
+      label: 'Emerald Green',
+      accent: '#2e7d32',
+      accentDark: '#1b5e20'
+    },
+    amber: {
+      label: 'Amber Glow',
+      accent: '#ff8f00',
+      accentDark: '#c56000'
+    },
+    graphite: {
+      label: 'Graphite Grey',
+      accent: '#546e7a',
+      accentDark: '#37474f'
+    }
+  };
+
+  const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
+
+  const safeParse = (value) => {
+    if (typeof value !== 'string') return null;
+    try {
+      const parsed = JSON.parse(value);
+      return parsed && typeof parsed === 'object' ? parsed : null;
+    } catch (error) {
+      console.warn('Routeflow preferences: failed to parse stored value', error);
+      return null;
+    }
+  };
+
+  const readStorage = () => {
+    try {
+      return typeof localStorage !== 'undefined' ? localStorage.getItem(STORAGE_KEY) : null;
+    } catch (error) {
+      console.warn('Routeflow preferences: unable to access localStorage', error);
+      return null;
+    }
+  };
+
+  const writeStorage = (data) => {
+    try {
+      if (typeof localStorage === 'undefined') return;
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+    } catch (error) {
+      console.warn('Routeflow preferences: unable to persist preferences', error);
+    }
+  };
+
+  const sanitise = (partial) => {
+    const result = {};
+
+    if (partial && typeof partial === 'object') {
+      if (Object.prototype.hasOwnProperty.call(partial, 'theme')) {
+        result.theme = partial.theme === 'dark' ? 'dark' : 'light';
+      }
+
+      if (Object.prototype.hasOwnProperty.call(partial, 'accent')) {
+        result.accent = Object.prototype.hasOwnProperty.call(ACCENTS, partial.accent)
+          ? partial.accent
+          : DEFAULT_PREFERENCES.accent;
+      }
+
+      if (Object.prototype.hasOwnProperty.call(partial, 'textScale')) {
+        const numeric = Number(partial.textScale);
+        result.textScale = Number.isFinite(numeric)
+          ? clamp(numeric, 0.9, 1.3)
+          : DEFAULT_PREFERENCES.textScale;
+      }
+
+      if (Object.prototype.hasOwnProperty.call(partial, 'highContrast')) {
+        result.highContrast = Boolean(partial.highContrast);
+      }
+
+      if (Object.prototype.hasOwnProperty.call(partial, 'readableFont')) {
+        result.readableFont = Boolean(partial.readableFont);
+      }
+
+      if (Object.prototype.hasOwnProperty.call(partial, 'reduceMotion')) {
+        result.reduceMotion = Boolean(partial.reduceMotion);
+      }
+    }
+
+    return result;
+  };
+
+  const mergePreferences = (base, updates) => ({
+    theme: updates.theme ?? base.theme,
+    accent: updates.accent ?? base.accent,
+    textScale: updates.textScale ?? base.textScale,
+    highContrast: updates.highContrast ?? base.highContrast,
+    readableFont: updates.readableFont ?? base.readableFont,
+    reduceMotion: updates.reduceMotion ?? base.reduceMotion
+  });
+
+  const loadPreferences = () => {
+    const stored = safeParse(readStorage());
+    return mergePreferences(DEFAULT_PREFERENCES, sanitise(stored));
+  };
+
+  let state = loadPreferences();
+  const listeners = new Set();
+
+  const notify = () => {
+    const snapshot = { ...state };
+    listeners.forEach((listener) => {
+      try {
+        listener(snapshot);
+      } catch (error) {
+        console.error('Routeflow preferences: listener error', error);
+      }
+    });
+    document.dispatchEvent(new CustomEvent('routeflow:preferences-changed', {
+      detail: snapshot
+    }));
+  };
+
+  const applyThemeVariables = (root, accent) => {
+    const palette = accent ?? ACCENTS[state.accent] ?? ACCENTS[DEFAULT_PREFERENCES.accent];
+    if (!palette) return;
+
+    root.style.setProperty('--accent-blue', palette.accent);
+    root.style.setProperty('--accent-blue-dark', palette.accentDark);
+    root.style.setProperty('--primary', palette.accent);
+    root.style.setProperty('--primary-dark', palette.accentDark);
+    root.style.setProperty('--navbar-accent', palette.accent);
+    root.style.setProperty('--navbar-accent-dark', palette.accentDark);
+  };
+
+  const resetVariable = (root, name) => {
+    if (Object.prototype.hasOwnProperty.call(DEFAULT_TOKENS, name)) {
+      root.style.setProperty(name, DEFAULT_TOKENS[name]);
+    } else {
+      root.style.removeProperty(name);
+    }
+  };
+
+  const applyHighContrast = (root, body, enabled) => {
+    if (enabled) {
+      root.style.setProperty('--background-light', '#ffffff');
+      root.style.setProperty('--foreground-light', '#000000');
+      root.style.setProperty('--card-bg-light', '#ffffff');
+      root.style.setProperty('--background-dark', '#000000');
+      root.style.setProperty('--foreground-dark', '#ffffff');
+      root.style.setProperty('--card-bg-dark', '#040404');
+    } else {
+      resetVariable(root, '--background-light');
+      resetVariable(root, '--foreground-light');
+      resetVariable(root, '--card-bg-light');
+      resetVariable(root, '--background-dark');
+      resetVariable(root, '--foreground-dark');
+      resetVariable(root, '--card-bg-dark');
+    }
+
+    body.classList.toggle('high-contrast', enabled);
+  };
+
+  const applyReduceMotion = (root, body, enabled) => {
+    if (enabled) {
+      root.style.setProperty('--transition', '0s');
+    } else {
+      resetVariable(root, '--transition');
+    }
+    body.classList.toggle('reduced-motion', enabled);
+  };
+
+  const applyPreferences = () => {
+    const root = document.documentElement;
+    const body = document.body;
+
+    if (!root || !body) return;
+
+    const palette = ACCENTS[state.accent] ?? ACCENTS[DEFAULT_PREFERENCES.accent];
+
+    applyThemeVariables(root, palette);
+
+    body.classList.toggle('dark-mode', state.theme === 'dark');
+    document.documentElement.style.colorScheme = state.theme === 'dark' ? 'dark light' : 'light dark';
+
+    applyHighContrast(root, body, state.highContrast);
+    body.classList.toggle('readable-font', state.readableFont);
+    applyReduceMotion(root, body, state.reduceMotion);
+
+    const fontScale = clamp(Number(state.textScale) || DEFAULT_PREFERENCES.textScale, 0.9, 1.3);
+    document.documentElement.style.fontSize = `${Math.round(fontScale * 100)}%`;
+    root.style.setProperty('--font-scale', fontScale);
+  };
+
+  const persist = () => {
+    writeStorage(state);
+  };
+
+  const setPreferences = (updates) => {
+    const safeUpdates = sanitise(updates);
+    state = mergePreferences(state, safeUpdates);
+    persist();
+    applyPreferences();
+    notify();
+  };
+
+  const resetPreferences = () => {
+    state = { ...DEFAULT_PREFERENCES };
+    persist();
+    applyPreferences();
+    notify();
+  };
+
+  window.RouteflowPreferences = {
+    getPreferences: () => ({ ...state }),
+    setPreferences,
+    setPreference: (key, value) => setPreferences({ [key]: value }),
+    resetPreferences,
+    getAccentOptions: () => {
+      const copy = {};
+      Object.keys(ACCENTS).forEach((key) => {
+        copy[key] = { ...ACCENTS[key] };
+      });
+      return copy;
+    },
+    onChange: (listener) => {
+      if (typeof listener !== 'function') {
+        return () => {};
+      }
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    }
+  };
+
+  const refreshFromStorage = () => {
+    const latest = loadPreferences();
+    const hasChanged = Object.keys(DEFAULT_PREFERENCES).some((key) => latest[key] !== state[key]);
+    if (hasChanged) {
+      state = latest;
+      applyPreferences();
+      notify();
+    }
+  };
+
+  window.addEventListener('storage', (event) => {
+    if (event.key === STORAGE_KEY) {
+      refreshFromStorage();
+    }
+  });
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', applyPreferences, { once: true });
   }
-}
 
-function toggleTheme() {
-  const isDark = document.body.classList.toggle('dark-mode');
-  localStorage.setItem('theme', isDark ? 'dark' : 'light');
-}
-
-document.addEventListener('DOMContentLoaded', applyStoredTheme);
+  applyPreferences();
+})();

--- a/tracking.html
+++ b/tracking.html
@@ -5,8 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Tracking | RouteFlow London</title>
   <link rel="icon" href="images/New_Routflow_London_Logo.png" type="image/png">
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible:wght@400;600&family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
+  <script src="theme.js" defer></script>
 <body>
 
 <!-- Font Awesome -->

--- a/withdrawn table.html
+++ b/withdrawn table.html
@@ -5,10 +5,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Withdrawn Routes | Routeflow London</title>
   <link rel="icon" href="images/New_Routflow_London_Logo.png" type="image/png">
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible:wght@400;600&family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
   <link rel="stylesheet" href="style.css">
-	<link rel="stylesheet" href="withdrawn-table.css">
+  <link rel="stylesheet" href="withdrawn-table.css">
+  <script src="theme.js" defer></script>
 </head>
   <body>
   

--- a/withdrawn.html
+++ b/withdrawn.html
@@ -5,9 +5,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="icon" href="images/New_Routflow_London_Logo.png" type="image/png" />
   <title>Withdrawn Routes | Routeflow London</title>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible:wght@400;600&family=Inter:wght@400;600;800&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" />
   <link rel="stylesheet" href="style.css" />
+  <script src="theme.js" defer></script>
   <style>
     .controls {
       max-width: 95vw;


### PR DESCRIPTION
## Summary
- replace the legacy theme toggle with a RouteflowPreferences module that persists theme, accent palette, text scaling, high contrast, readable font, and reduced motion across pages
- redesign the settings page and add a companion script so users can adjust appearance and accessibility controls with live previews and reset support
- extend shared styles for high-contrast/readable modes and ensure site pages load the shared font stack and preference script to keep the experience consistent everywhere

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68c92e6feccc8322943179412bf3d14f