### PR TITLE
Improve planner page and unify navbar across site

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -554,5 +554,6 @@ function signOut() {
     </div>
     <small>© 2025 RouteFlow London</small>
   </footer>
+  <script src="navbar-loader.js"></script>
 </body>
 </html>

--- a/disruptions.html
+++ b/disruptions.html
@@ -716,6 +716,7 @@ function signOut() {
     loadAll();
     setInterval(loadAll, refreshInterval); // Auto-refresh
   </script>
+  <script src="navbar-loader.js"></script>
 </body>
 </html>
 

--- a/fleet.html
+++ b/fleet.html
@@ -543,5 +543,6 @@ function signOut() {
   <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-auth-compat.js"></script>
   <script src="main.js"></script>
+  <script src="navbar-loader.js"></script>
 </body>
 </html>

--- a/navbar-loader.js
+++ b/navbar-loader.js
@@ -74,10 +74,17 @@ function bootstrapNavbar() {
     console.error('Failed to load authentication modal:', error);
   });
 
-  const container = document.getElementById('navbar-container');
+  let container = document.getElementById('navbar-container');
   if (!container) {
-    return;
+    container = document.createElement('div');
+    container.id = 'navbar-container';
+    document.body.insertBefore(container, document.body.firstChild);
   }
+
+  document.querySelectorAll('header.navbar, nav.navbar').forEach(el => el.remove());
+  document.getElementById('authModal')?.remove();
+  document.querySelector('.mobile-drawer')?.remove();
+  document.querySelector('.drawer-backdrop')?.remove();
 
   fetch(NAVBAR_SOURCE)
     .then(response => {

--- a/password-reset.html
+++ b/password-reset.html
@@ -564,5 +564,6 @@ function signOut() {
         });
     });
   </script>
+  <script src="navbar-loader.js"></script>
 </body>
 </html>

--- a/planning.html
+++ b/planning.html
@@ -18,24 +18,36 @@
   </section>
   <main class="planner">
     <form id="journey-form" class="planner-form">
-      <input type="text" id="from" placeholder="From" required>
-      <input type="text" id="to" placeholder="To" required>
+      <div class="form-row">
+        <div class="input-group">
+          <label for="from">From</label>
+          <input type="text" id="from" placeholder="Start location" required>
+        </div>
+        <div class="input-group">
+          <label for="to">To</label>
+          <input type="text" id="to" placeholder="Destination" required>
+        </div>
+      </div>
       <fieldset class="filters">
         <legend>Modes</legend>
-        <label><input type="checkbox" name="mode" value="bus" checked> Bus</label>
-        <label><input type="checkbox" name="mode" value="tube" checked> Tube</label>
-        <label><input type="checkbox" name="mode" value="dlr" checked> DLR</label>
-        <label><input type="checkbox" name="mode" value="overground" checked> Overground</label>
-        <label><input type="checkbox" name="mode" value="tram" checked> Tram</label>
-        <label><input type="checkbox" name="mode" value="river-bus" checked> River Bus</label>
+        <div class="checkbox-group">
+          <label><input type="checkbox" name="mode" value="bus" checked> Bus</label>
+          <label><input type="checkbox" name="mode" value="tube" checked> Tube</label>
+          <label><input type="checkbox" name="mode" value="dlr" checked> DLR</label>
+          <label><input type="checkbox" name="mode" value="overground" checked> Overground</label>
+          <label><input type="checkbox" name="mode" value="tram" checked> Tram</label>
+          <label><input type="checkbox" name="mode" value="river-bus" checked> River Bus</label>
+        </div>
       </fieldset>
       <fieldset class="filters">
         <legend>Accessibility</legend>
-        <label><input type="checkbox" name="accessibility" value="NoSolidStairs"> No solid stairs</label>
-        <label><input type="checkbox" name="accessibility" value="NoEscalators"> No escalators</label>
-        <label><input type="checkbox" name="accessibility" value="NoElevators"> No elevators</label>
-        <label><input type="checkbox" name="accessibility" value="StepFreeToVehicle"> Step-free to vehicle</label>
-        <label><input type="checkbox" name="accessibility" value="StepFreeToPlatform"> Step-free to platform</label>
+        <div class="checkbox-group">
+          <label><input type="checkbox" name="accessibility" value="NoSolidStairs"> No solid stairs</label>
+          <label><input type="checkbox" name="accessibility" value="NoEscalators"> No escalators</label>
+          <label><input type="checkbox" name="accessibility" value="NoElevators"> No elevators</label>
+          <label><input type="checkbox" name="accessibility" value="StepFreeToVehicle"> Step-free to vehicle</label>
+          <label><input type="checkbox" name="accessibility" value="StepFreeToPlatform"> Step-free to platform</label>
+        </div>
       </fieldset>
       <button type="submit">Search</button>
     </form>

--- a/privacy.html
+++ b/privacy.html
@@ -526,8 +526,6 @@ function signOut() {
   alert('Signed out (demo)');
 }
 </script>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">S
-    </div>
-  </div>
-</div>
+<script src="navbar-loader.js"></script>
+</body>
 </html>

--- a/profile.html
+++ b/profile.html
@@ -98,5 +98,6 @@ function signOut() {
     renderNotes();
   });
   </script>
+  <script src="navbar-loader.js"></script>
 </body>
 </html>

--- a/routes.html
+++ b/routes.html
@@ -950,5 +950,6 @@ function closeModal(id) {
 }
 window.closeModal = closeModal;
 </script>
+<script src="navbar-loader.js"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -782,19 +782,37 @@ body.dark-mode .btn:hover {
 
 /* Journey planner layout */
 .planner {
-  max-width: 600px;
+  max-width: 700px;
   margin: 2rem auto;
   padding: 0 1rem;
 }
 .planner-form {
   display: flex;
-  gap: 0.5rem;
-  justify-content: center;
+  flex-direction: column;
+  gap: 1rem;
 }
-.planner-form input {
-  flex: 1;
+.form-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+.input-group {
+  flex: 1 1 240px;
+  display: flex;
+  flex-direction: column;
+}
+.planner-form fieldset {
+  border: 1px solid #ccc;
+  border-radius: var(--border-radius);
+  padding: 0.75rem 1rem 1rem;
+}
+.checkbox-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem 1rem;
 }
 .planner-form button {
+  align-self: flex-start;
   background: var(--accent-blue);
   color: #fff;
   border: none;

--- a/terms.html
+++ b/terms.html
@@ -568,6 +568,7 @@ function signOut() {
     </div>
   </div>
 </div>
+          <script src="navbar-loader.js"></script>
           </body>
 </html>
 

--- a/withdrawn table.html
+++ b/withdrawn table.html
@@ -6573,5 +6573,6 @@ function searchTable() {
   <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-auth-compat.js"></script>
   <script src="main.js"></script>
+  <script src="navbar-loader.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- redesign Journey Planner form for clearer inputs and grouped filters
- load common navbar on every page with automatic container injection
- clean planner styles and update navbar loader

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python3 -m http.server 8000` then loaded `planning.html`

------
https://chatgpt.com/codex/tasks/task_e_68c9815740b48322bc9120311c705472