### PR TITLE
Add admin portal protected by Firebase claims

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Admin | RouteFlow London</title>
+  <link rel="icon" href="images/New_Routflow_London_Logo.png" type="image/png">
+  <link href="https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible:wght@400;600&family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="stylesheet" href="style.css">
+  <script src="theme.js" defer></script>
+  <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-app-compat.js" defer></script>
+  <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-auth-compat.js" defer></script>
+  <script src="main.js" defer></script>
+</head>
+<body>
+  <div id="navbar-container"></div>
+  <main id="adminContent" class="admin-page" aria-live="polite"></main>
+  <script src="navbar-loader.js" defer></script>
+  <script type="module" src="admin.js"></script>
+</body>
+</html>

--- a/admin.js
+++ b/admin.js
@@ -1,0 +1,157 @@
+const adminContent = document.getElementById('adminContent');
+const firebaseConfig = {
+  apiKey: "AIzaSyDuedLuagA4IXc9ZMG9wvoak-sRrhtFZfo",
+  authDomain: "routeflow-london.firebaseapp.com",
+  projectId: "routeflow-london",
+  storageBucket: "routeflow-london.firebasestorage.app",
+  messagingSenderId: "368346241440",
+  appId: "1:368346241440:web:7cc87d551420459251ecc5"
+};
+
+const FIREBASE_WAIT_TIMEOUT = 10000;
+const FIREBASE_POLL_INTERVAL = 100;
+const REDIRECT_DELAY = 4000;
+let redirectTimer = null;
+
+function replaceContent(...nodes) {
+  if (!adminContent) return;
+  adminContent.replaceChildren(...nodes);
+}
+
+function createMessageSection(text, role = 'status', modifier = '') {
+  const section = document.createElement('section');
+  section.className = ['admin-message', modifier ? `admin-message--${modifier}` : ''].filter(Boolean).join(' ');
+  if (role) {
+    section.setAttribute('role', role);
+  }
+  const paragraph = document.createElement('p');
+  paragraph.textContent = text;
+  section.append(paragraph);
+  return section;
+}
+
+function setBusy(isBusy) {
+  if (!adminContent) return;
+  if (isBusy) {
+    adminContent.setAttribute('aria-busy', 'true');
+  } else {
+    adminContent.removeAttribute('aria-busy');
+  }
+}
+
+function showInfo(message) {
+  setBusy(true);
+  if (!adminContent) return;
+  replaceContent(createMessageSection(message, 'status', 'info'));
+}
+
+function showError(message) {
+  setBusy(false);
+  if (!adminContent) return;
+  replaceContent(createMessageSection(message, 'alert', 'error'));
+}
+
+function handleUnauthorized(message) {
+  showError(message);
+  if (redirectTimer !== null) return;
+  redirectTimer = window.setTimeout(() => {
+    window.location.href = 'index.html';
+  }, REDIRECT_DELAY);
+}
+
+function clearPendingRedirect() {
+  if (redirectTimer !== null) {
+    window.clearTimeout(redirectTimer);
+    redirectTimer = null;
+  }
+}
+
+function renderAdminDashboard(user) {
+  if (!adminContent) return;
+  clearPendingRedirect();
+  setBusy(false);
+  const section = document.createElement('section');
+  section.className = 'admin-dashboard';
+
+  const heading = document.createElement('h1');
+  heading.id = 'adminDashboardHeading';
+  heading.textContent = 'Admin Console';
+  section.append(heading);
+
+  const welcome = document.createElement('p');
+  const displayName = user.displayName || user.email || 'Administrator';
+  welcome.textContent = `Welcome, ${displayName}.`;
+  section.append(welcome);
+
+  const placeholder = document.createElement('p');
+  placeholder.textContent = 'Administrative tools will appear here when they are available.';
+  section.append(placeholder);
+
+  replaceContent(section);
+}
+
+function ensureFirebaseAuth() {
+  return new Promise((resolve, reject) => {
+    const start = Date.now();
+
+    const attempt = () => {
+      const fb = window.firebase;
+      if (fb && typeof fb.auth === 'function') {
+        try {
+          if (!fb.apps.length) {
+            fb.initializeApp(firebaseConfig);
+          }
+          const authInstance = fb.auth();
+          resolve(authInstance);
+        } catch (error) {
+          reject(error);
+        }
+        return;
+      }
+
+      if (Date.now() - start >= FIREBASE_WAIT_TIMEOUT) {
+        reject(new Error('Timed out waiting for Firebase Auth to load.'));
+        return;
+      }
+
+      window.setTimeout(attempt, FIREBASE_POLL_INTERVAL);
+    };
+
+    attempt();
+  });
+}
+
+if (!adminContent) {
+  console.error('Admin content container not found.');
+} else {
+  showInfo('Checking your administrator access…');
+}
+
+ensureFirebaseAuth()
+  .then((auth) => {
+    auth.onAuthStateChanged(async (user) => {
+      if (!user) {
+        handleUnauthorized('You must be signed in as an administrator to view this page.');
+        return;
+      }
+
+      showInfo('Verifying your administrator permissions…');
+
+      try {
+        const tokenResult = await user.getIdTokenResult();
+        if (tokenResult?.claims?.admin) {
+          renderAdminDashboard(user);
+        } else {
+          handleUnauthorized('You are not authorized to access this page.');
+        }
+      } catch (error) {
+        console.error('Failed to retrieve administrator claims:', error);
+        showError('We could not verify your administrator permissions. Please try again later.');
+      }
+    });
+  })
+  .catch((error) => {
+    console.error('Failed to initialise Firebase authentication for the admin page:', error);
+    showError('Authentication is currently unavailable. Please try again later.');
+  });
+

--- a/components/navbar.html
+++ b/components/navbar.html
@@ -41,6 +41,7 @@
           <div class="navbar__profile-menu" data-profile-menu aria-hidden="true" data-open="false">
             <a href="profile.html" class="navbar__profile-link" data-auth-action="profile">Profile</a>
             <a href="settings.html" class="navbar__profile-link" data-auth-action="settings">Settings</a>
+            <a href="admin.html" class="navbar__profile-link" data-auth-action="admin">Admin</a>
             <button type="button" class="navbar__profile-link navbar__profile-link--destructive" data-auth-action="logout">Logout</button>
           </div>
         </div>
@@ -82,6 +83,7 @@
         <div class="navbar__drawer-section" data-auth-state="signed-in" hidden>
           <a href="profile.html" class="navbar__drawer-action" data-auth-action="profile">Profile</a>
           <a href="settings.html" class="navbar__drawer-action" data-auth-action="settings">Settings</a>
+          <a href="admin.html" class="navbar__drawer-action" data-auth-action="admin">Admin</a>
           <button type="button" class="navbar__drawer-action navbar__drawer-action--destructive" data-auth-action="logout">Logout</button>
         </div>
       </div>

--- a/main.js
+++ b/main.js
@@ -174,6 +174,15 @@ document.addEventListener('DOMContentLoaded', function () {
         }
         break;
       }
+      case 'admin': {
+        const user = auth?.currentUser;
+        if (user) {
+          window.location.href = 'admin.html';
+        } else {
+          alert('Not signed in');
+        }
+        break;
+      }
       default:
         break;
     }


### PR DESCRIPTION
## Summary
- add a new admin landing page that loads the shared navbar and Firebase dependencies
- implement an admin.js module that verifies the signed-in user has the admin custom claim before rendering content
- expose an Admin navigation action for signed-in users and route it through the existing auth action handler

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68c996db799083228cb024f75bcf3e43