### PR TITLE
Improve auth modal flow and admin login UX

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Admin | RouteFlow London</title>
+  <link rel="icon" href="images/New_Routflow_London_Logo.png" type="image/png">
+  <link href="https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible:wght@400;600&family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="stylesheet" href="style.css">
+  <script src="theme.js" defer></script>
+  <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-app-compat.js" defer></script>
+  <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-auth-compat.js" defer></script>
+  <script src="main.js" defer></script>
+</head>
+<body>
+  <div id="navbar-container"></div>
+  <main id="adminContent" class="admin-page" aria-live="polite"></main>
+  <script src="navbar-loader.js" defer></script>
+  <script type="module" src="admin.js"></script>
+</body>
+</html>

--- a/admin.js
+++ b/admin.js
@@ -1,0 +1,211 @@
+const adminContent = document.getElementById('adminContent');
+const firebaseConfig = {
+  apiKey: "AIzaSyDuedLuagA4IXc9ZMG9wvoak-sRrhtFZfo",
+  authDomain: "routeflow-london.firebaseapp.com",
+  projectId: "routeflow-london",
+  storageBucket: "routeflow-london.firebasestorage.app",
+  messagingSenderId: "368346241440",
+  appId: "1:368346241440:web:7cc87d551420459251ecc5"
+};
+
+const FIREBASE_WAIT_TIMEOUT = 10000;
+const FIREBASE_POLL_INTERVAL = 100;
+const REDIRECT_DELAY = 4000;
+let redirectTimer = null;
+
+function replaceContent(...nodes) {
+  if (!adminContent) return;
+  adminContent.replaceChildren(...nodes);
+}
+
+function createMessageSection(text, role = 'status', modifier = '') {
+  const section = document.createElement('section');
+  section.className = ['admin-message', modifier ? `admin-message--${modifier}` : ''].filter(Boolean).join(' ');
+  if (role) {
+    section.setAttribute('role', role);
+  }
+  const paragraph = document.createElement('p');
+  paragraph.textContent = text;
+  section.append(paragraph);
+  return section;
+}
+
+function setBusy(isBusy) {
+  if (!adminContent) return;
+  if (isBusy) {
+    adminContent.setAttribute('aria-busy', 'true');
+  } else {
+    adminContent.removeAttribute('aria-busy');
+  }
+}
+
+function showInfo(message) {
+  setBusy(true);
+  if (!adminContent) return;
+  clearPendingRedirect();
+  replaceContent(createMessageSection(message, 'status', 'info'));
+}
+
+function showError(message) {
+  setBusy(false);
+  if (!adminContent) return;
+  clearPendingRedirect();
+  replaceContent(createMessageSection(message, 'alert', 'error'));
+}
+
+function clearPendingRedirect() {
+  if (redirectTimer !== null) {
+    window.clearTimeout(redirectTimer);
+    redirectTimer = null;
+  }
+}
+
+function renderUnauthorized(message, options = {}) {
+  const { showLoginButton = false, redirectToHome = false, hint = '' } = options;
+  setBusy(false);
+  if (!adminContent) return;
+  clearPendingRedirect();
+
+  const section = createMessageSection(message, 'alert', 'error');
+
+  if (hint) {
+    const hintParagraph = document.createElement('p');
+    hintParagraph.className = 'admin-message__hint';
+    hintParagraph.textContent = hint;
+    section.append(hintParagraph);
+  }
+
+  const actions = document.createElement('div');
+  actions.className = 'admin-message__actions';
+
+  if (showLoginButton) {
+    const loginButton = document.createElement('button');
+    loginButton.type = 'button';
+    loginButton.className = 'admin-message__action';
+    loginButton.dataset.authAction = 'login';
+    loginButton.textContent = 'Admin login';
+    actions.append(loginButton);
+  }
+
+  if (redirectToHome) {
+    const homeLink = document.createElement('a');
+    homeLink.href = 'index.html';
+    homeLink.className = 'admin-message__action admin-message__action--ghost';
+    homeLink.textContent = 'Go back home';
+    actions.append(homeLink);
+  }
+
+  if (actions.childElementCount > 0) {
+    section.append(actions);
+  }
+
+  replaceContent(section);
+
+  if (redirectToHome) {
+    redirectTimer = window.setTimeout(() => {
+      window.location.href = 'index.html';
+    }, REDIRECT_DELAY);
+  }
+}
+
+function renderAdminDashboard(user) {
+  if (!adminContent) return;
+  clearPendingRedirect();
+  setBusy(false);
+  const section = document.createElement('section');
+  section.className = 'admin-dashboard';
+
+  const heading = document.createElement('h1');
+  heading.id = 'adminDashboardHeading';
+  heading.textContent = 'Admin Console';
+  section.append(heading);
+
+  const welcome = document.createElement('p');
+  const displayName = user.displayName || user.email || 'Administrator';
+  welcome.textContent = `Welcome, ${displayName}.`;
+  section.append(welcome);
+
+  const placeholder = document.createElement('p');
+  placeholder.textContent = 'Administrative tools will appear here when they are available.';
+  section.append(placeholder);
+
+  replaceContent(section);
+}
+
+function ensureFirebaseAuth() {
+  return new Promise((resolve, reject) => {
+    const start = Date.now();
+
+    const attempt = () => {
+      const fb = window.firebase;
+      if (fb && typeof fb.auth === 'function') {
+        try {
+          if (!fb.apps.length) {
+            fb.initializeApp(firebaseConfig);
+          }
+          const authInstance = fb.auth();
+          resolve(authInstance);
+        } catch (error) {
+          reject(error);
+        }
+        return;
+      }
+
+      if (Date.now() - start >= FIREBASE_WAIT_TIMEOUT) {
+        reject(new Error('Timed out waiting for Firebase Auth to load.'));
+        return;
+      }
+
+      window.setTimeout(attempt, FIREBASE_POLL_INTERVAL);
+    };
+
+    attempt();
+  });
+}
+
+if (!adminContent) {
+  console.error('Admin content container not found.');
+} else {
+  showInfo('Checking your administrator access…');
+}
+
+ensureFirebaseAuth()
+  .then((auth) => {
+    auth.onAuthStateChanged(async (user) => {
+      if (!user) {
+        renderUnauthorized(
+          'You must be signed in as an administrator to view this page.',
+          {
+            showLoginButton: true,
+            hint: 'Select “Admin login” to sign in with an administrator account.',
+          }
+        );
+        return;
+      }
+
+      showInfo('Verifying your administrator permissions…');
+
+      try {
+        const tokenResult = await user.getIdTokenResult();
+        if (tokenResult?.claims?.admin) {
+          renderAdminDashboard(user);
+        } else {
+          renderUnauthorized(
+            'You are not authorized to access this page. You will be redirected to the homepage shortly.',
+            {
+              redirectToHome: true,
+              hint: 'If you believe this is an error, please contact your RouteFlow London administrator.',
+            }
+          );
+        }
+      } catch (error) {
+        console.error('Failed to retrieve administrator claims:', error);
+        showError('We could not verify your administrator permissions. Please try again later.');
+      }
+    });
+  })
+  .catch((error) => {
+    console.error('Failed to initialise Firebase authentication for the admin page:', error);
+    showError('Authentication is currently unavailable. Please try again later.');
+  });
+

--- a/components/navbar.html
+++ b/components/navbar.html
@@ -41,6 +41,7 @@
           <div class="navbar__profile-menu" data-profile-menu aria-hidden="true" data-open="false">
             <a href="profile.html" class="navbar__profile-link" data-auth-action="profile">Profile</a>
             <a href="settings.html" class="navbar__profile-link" data-auth-action="settings">Settings</a>
+            <a href="admin.html" class="navbar__profile-link" data-auth-action="admin">Admin</a>
             <button type="button" class="navbar__profile-link navbar__profile-link--destructive" data-auth-action="logout">Logout</button>
           </div>
         </div>
@@ -82,6 +83,7 @@
         <div class="navbar__drawer-section" data-auth-state="signed-in" hidden>
           <a href="profile.html" class="navbar__drawer-action" data-auth-action="profile">Profile</a>
           <a href="settings.html" class="navbar__drawer-action" data-auth-action="settings">Settings</a>
+          <a href="admin.html" class="navbar__drawer-action" data-auth-action="admin">Admin</a>
           <button type="button" class="navbar__drawer-action navbar__drawer-action--destructive" data-auth-action="logout">Logout</button>
         </div>
       </div>

--- a/style.css
+++ b/style.css
@@ -1066,6 +1066,140 @@ body.dark-mode #authModal .auth-modal__link {
 }
 
 /*-------------------------------
+  Admin experience
+-------------------------------*/
+.admin-page {
+  padding: 4rem 1.5rem 6rem;
+  min-height: 60vh;
+}
+
+.admin-page .admin-message,
+.admin-page .admin-dashboard {
+  width: min(100%, 720px);
+}
+
+.admin-message,
+.admin-dashboard {
+  margin: 0 auto;
+  padding: 2.5rem 2.25rem;
+  border-radius: var(--border-radius);
+  background: var(--card-bg-light);
+  box-shadow: 0 24px 60px rgba(23, 23, 23, 0.12);
+  line-height: 1.65;
+}
+
+body.dark-mode .admin-message,
+body.dark-mode .admin-dashboard {
+  background: var(--card-bg-dark);
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.55);
+}
+
+.admin-message--info {
+  border-left: 4px solid var(--accent-blue);
+}
+
+.admin-message--error {
+  border-left: 4px solid var(--primary);
+}
+
+.admin-message > p:first-of-type,
+.admin-dashboard > p:first-of-type {
+  margin-top: 0;
+}
+
+.admin-message__hint {
+  margin: 1rem 0 0;
+  color: #4a4a4a;
+}
+
+body.dark-mode .admin-message__hint {
+  color: #d0d0d0;
+}
+
+.admin-message__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 1.75rem;
+}
+
+.admin-message__action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 1.6rem;
+  border-radius: 999px;
+  border: none;
+  background: var(--primary);
+  color: #fff;
+  font-weight: 600;
+  font-size: 0.95rem;
+  letter-spacing: 0.01em;
+  cursor: pointer;
+  text-decoration: none;
+  transition: background var(--transition), box-shadow var(--transition), transform var(--transition);
+  outline: none;
+}
+
+.admin-message__action:hover,
+.admin-message__action:focus-visible {
+  background: var(--primary-dark);
+  transform: translateY(-1px);
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.18);
+  text-decoration: none;
+}
+
+.admin-message__action:focus-visible {
+  outline: 3px solid var(--accent-blue);
+  outline-offset: 2px;
+}
+
+.admin-message__action--ghost {
+  background: transparent;
+  color: inherit;
+  border: 2px solid currentColor;
+  box-shadow: none;
+}
+
+.admin-message__action--ghost:hover,
+.admin-message__action--ghost:focus-visible {
+  background: rgba(0, 0, 0, 0.05);
+  box-shadow: none;
+}
+
+body.dark-mode .admin-message__action--ghost:hover,
+body.dark-mode .admin-message__action--ghost:focus-visible {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.admin-dashboard h1 {
+  font-size: 2rem;
+  font-weight: 700;
+  margin: 0 0 1rem;
+}
+
+.admin-dashboard p {
+  margin: 0.75rem 0 0;
+}
+
+@media (max-width: 640px) {
+  .admin-message,
+  .admin-dashboard {
+    padding: 2rem 1.5rem;
+  }
+
+  .admin-message__actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .admin-message__action,
+  .admin-message__action--ghost {
+    width: 100%;
+  }
+}
+
+/*-------------------------------
   Utility Classes
 -------------------------------*/
 .text-center { text-align: center; }


### PR DESCRIPTION
## Summary
- wait for the injected authentication modal before wiring handlers so navbar login/sign-up buttons reliably open the popup and process Firebase auth forms after lazy load
- show an admin login prompt with a modal trigger when unauthenticated and provide friendly messaging for non-admin accounts on the admin page
- add styling for the admin dashboard and message states so prompts and actions render consistently

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68c996db799083228cb024f75bcf3e43