### PR TITLE
Add admin tools for withdrawn routes and route tags

### DIFF
--- a/data-store.js
+++ b/data-store.js
@@ -1,0 +1,139 @@
+const STORAGE_PREFIX = 'routeflow';
+
+export const STORAGE_KEYS = {
+  withdrawnRoutes: `${STORAGE_PREFIX}.withdrawnRoutes`,
+  routeTagOverrides: `${STORAGE_PREFIX}.routeTagOverrides`
+};
+
+const resolveStorage = () => {
+  if (typeof window === 'undefined' || !('localStorage' in window)) {
+    return null;
+  }
+  try {
+    const testKey = `${STORAGE_PREFIX}.test`;
+    window.localStorage.setItem(testKey, '1');
+    window.localStorage.removeItem(testKey);
+    return window.localStorage;
+  } catch (error) {
+    console.warn('Local storage is not available for admin data:', error);
+    return null;
+  }
+};
+
+const storage = resolveStorage();
+
+const readItem = (key) => {
+  if (!storage) return null;
+  try {
+    return storage.getItem(key);
+  } catch (error) {
+    console.warn('Failed to read admin data from storage:', error);
+    return null;
+  }
+};
+
+const writeItem = (key, value) => {
+  if (!storage) return false;
+  try {
+    storage.setItem(key, value);
+    return true;
+  } catch (error) {
+    console.warn('Failed to write admin data to storage:', error);
+    return false;
+  }
+};
+
+const parseJson = (value, fallback) => {
+  if (typeof value !== 'string' || !value) return fallback;
+  try {
+    return JSON.parse(value);
+  } catch (error) {
+    console.warn('Failed to parse stored admin data:', error);
+    return fallback;
+  }
+};
+
+const normaliseText = (value) => (typeof value === 'string' ? value.trim() : '');
+
+export const storageAvailable = Boolean(storage);
+
+export const createId = () => `id-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+
+const sanitiseWithdrawnEntry = (entry) => {
+  if (!entry || typeof entry !== 'object') return null;
+  const route = normaliseText(entry.route);
+  if (!route) return null;
+  const id = normaliseText(entry.id) || createId();
+  return {
+    id,
+    route,
+    start: normaliseText(entry.start),
+    end: normaliseText(entry.end),
+    launched: normaliseText(entry.launched),
+    withdrawn: normaliseText(entry.withdrawn),
+    operator: normaliseText(entry.operator),
+    replacedBy: normaliseText(entry.replacedBy)
+  };
+};
+
+const sanitiseRouteTagOverride = (entry) => {
+  if (!entry || typeof entry !== 'object') return null;
+  const route = normaliseText(entry.route);
+  if (!route) return null;
+  const tags = Array.isArray(entry.tags)
+    ? entry.tags
+        .map((tag) => normaliseText(tag))
+        .filter((tag, index, source) => tag && source.indexOf(tag) === index)
+    : [];
+  if (!tags.length) return null;
+  const id = normaliseText(entry.id) || createId();
+  return { id, route, tags };
+};
+
+const sortByRoute = (a, b) => a.route.localeCompare(b.route, 'en', { numeric: true });
+
+const sanitiseCollection = (collection, sanitiser, sort = false) => {
+  if (!Array.isArray(collection)) return [];
+  const cleaned = collection
+    .map((item) => sanitiser(item))
+    .filter(Boolean);
+  if (sort) {
+    cleaned.sort(sortByRoute);
+  }
+  return cleaned;
+};
+
+export const getStoredWithdrawnRoutes = () => {
+  const raw = readItem(STORAGE_KEYS.withdrawnRoutes);
+  return sanitiseCollection(parseJson(raw, []), sanitiseWithdrawnEntry, true);
+};
+
+export const setStoredWithdrawnRoutes = (routes) => {
+  const cleaned = sanitiseCollection(routes, sanitiseWithdrawnEntry, true);
+  writeItem(STORAGE_KEYS.withdrawnRoutes, JSON.stringify(cleaned));
+  return cleaned;
+};
+
+export const getRouteTagOverrides = () => {
+  const raw = readItem(STORAGE_KEYS.routeTagOverrides);
+  return sanitiseCollection(parseJson(raw, []), sanitiseRouteTagOverride, true);
+};
+
+export const setRouteTagOverrides = (overrides) => {
+  const cleaned = sanitiseCollection(overrides, sanitiseRouteTagOverride, true);
+  writeItem(STORAGE_KEYS.routeTagOverrides, JSON.stringify(cleaned));
+  return cleaned;
+};
+
+export const normaliseRouteKey = (value) => normaliseText(value).toUpperCase();
+
+export const getRouteTagOverrideMap = (overrides = getRouteTagOverrides()) => {
+  const map = new Map();
+  overrides.forEach((entry) => {
+    const key = normaliseRouteKey(entry.route);
+    if (!key) return;
+    map.set(key, [...entry.tags]);
+  });
+  return map;
+};
+

--- a/style.css
+++ b/style.css
@@ -780,6 +780,352 @@ body.dark-mode .btn:hover {
   background: var(--primary-dark);
 }
 
+/*-------------------------------
+  Admin console
+-------------------------------*/
+.admin-dashboard {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 2rem 1rem 3rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.admin-dashboard__intro {
+  font-size: 1.05rem;
+  color: rgba(17, 24, 39, 0.74);
+}
+
+body.dark-mode .admin-dashboard__intro {
+  color: rgba(255, 255, 255, 0.74);
+}
+
+.admin-warning {
+  background: rgba(250, 204, 21, 0.18);
+  border-left: 4px solid #f59e0b;
+  border-radius: 12px;
+  padding: 0.9rem 1.1rem;
+  font-weight: 600;
+  color: #7c4103;
+}
+
+body.dark-mode .admin-warning {
+  background: rgba(253, 224, 71, 0.2);
+  border-color: #facc15;
+  color: #fcd34d;
+}
+
+.admin-panels {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.admin-panel {
+  background: var(--card-bg-light);
+  border-radius: 20px;
+  box-shadow: 0 18px 46px rgba(15, 23, 42, 0.14);
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+body.dark-mode .admin-panel {
+  background: var(--card-bg-dark);
+  box-shadow: 0 20px 48px rgba(0, 0, 0, 0.6);
+}
+
+.admin-panel__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.admin-panel__header h2 {
+  margin: 0;
+  font-size: 1.4rem;
+}
+
+.admin-panel__description {
+  margin: 0;
+  color: rgba(17, 24, 39, 0.72);
+  line-height: 1.5;
+}
+
+body.dark-mode .admin-panel__description {
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.admin-feedback {
+  margin: 0;
+  padding: 0.85rem 1rem;
+  border-radius: 14px;
+  background: rgba(41, 121, 255, 0.12);
+  border-left: 4px solid var(--accent-blue);
+  color: #0f3d8c;
+  font-weight: 600;
+}
+
+body.dark-mode .admin-feedback {
+  background: rgba(59, 130, 246, 0.22);
+  color: #93c5fd;
+  border-color: #60a5fa;
+}
+
+.admin-feedback[data-tone='success'] {
+  background: rgba(34, 197, 94, 0.12);
+  border-color: #16a34a;
+  color: #166534;
+}
+
+body.dark-mode .admin-feedback[data-tone='success'] {
+  background: rgba(34, 197, 94, 0.18);
+  color: #86efac;
+  border-color: #4ade80;
+}
+
+.admin-feedback[data-tone='error'] {
+  background: rgba(239, 68, 68, 0.12);
+  border-color: #dc2626;
+  color: #7f1d1d;
+}
+
+body.dark-mode .admin-feedback[data-tone='error'] {
+  background: rgba(239, 68, 68, 0.22);
+  border-color: #f87171;
+  color: #fecaca;
+}
+
+.admin-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.admin-form__grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.admin-form__group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.admin-form__group label,
+.admin-form__group legend {
+  font-weight: 600;
+  color: rgba(17, 24, 39, 0.82);
+}
+
+body.dark-mode .admin-form__group label,
+body.dark-mode .admin-form__group legend {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.admin-form__group--fieldset {
+  border: 1px solid rgba(15, 23, 42, 0.16);
+  border-radius: 14px;
+  padding: 1rem 1.1rem 1.1rem;
+  gap: 0.75rem;
+}
+
+body.dark-mode .admin-form__group--fieldset {
+  border-color: rgba(255, 255, 255, 0.18);
+}
+
+.admin-form__group--fieldset legend {
+  padding: 0 0.4rem;
+  font-size: 0.95rem;
+}
+
+.admin-checkboxes {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
+}
+
+.admin-checkbox {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.admin-checkbox input {
+  width: auto;
+  height: auto;
+  accent-color: var(--accent-blue);
+}
+
+body.dark-mode .admin-checkbox input {
+  accent-color: var(--primary);
+}
+
+.admin-form__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.admin-button {
+  margin: 0.2rem 0.25rem;
+}
+
+.admin-button--secondary {
+  background: transparent;
+  color: var(--accent-blue);
+  border: 1.5px solid currentColor;
+  transform: none;
+}
+
+.admin-button--secondary:hover,
+.admin-button--secondary:focus-visible {
+  background: rgba(41, 121, 255, 0.12);
+  transform: none;
+}
+
+body.dark-mode .admin-button--secondary {
+  color: var(--primary);
+  border-color: var(--primary);
+  background: transparent;
+}
+
+body.dark-mode .admin-button--secondary:hover,
+body.dark-mode .admin-button--secondary:focus-visible {
+  background: rgba(59, 130, 246, 0.22);
+}
+
+.admin-button--ghost {
+  background: transparent;
+  color: var(--accent-blue);
+  border: 1.5px solid rgba(41, 121, 255, 0.4);
+  transform: none;
+}
+
+.admin-button--ghost:hover,
+.admin-button--ghost:focus-visible {
+  background: rgba(41, 121, 255, 0.1);
+  transform: translateY(-1px);
+}
+
+body.dark-mode .admin-button--ghost {
+  color: #bfdbfe;
+  border-color: rgba(96, 165, 250, 0.6);
+}
+
+body.dark-mode .admin-button--ghost:hover,
+body.dark-mode .admin-button--ghost:focus-visible {
+  background: rgba(96, 165, 250, 0.2);
+}
+
+.admin-button--danger {
+  background: #dc2626;
+  transform: none;
+}
+
+.admin-button--danger:hover,
+.admin-button--danger:focus-visible {
+  background: #b91c1c;
+}
+
+body.dark-mode .admin-button--danger {
+  background: #ef4444;
+  color: #0b0b0b;
+}
+
+body.dark-mode .admin-button--danger:hover,
+body.dark-mode .admin-button--danger:focus-visible {
+  background: #dc2626;
+  color: #fff;
+}
+
+.admin-table-wrapper {
+  padding: 0.25rem;
+}
+
+.admin-table {
+  min-width: 0;
+  font-size: 0.95rem;
+}
+
+.admin-table th {
+  font-size: 0.78rem;
+  letter-spacing: 0.06em;
+}
+
+.admin-table__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.admin-table__actions .admin-button {
+  padding: 0.5rem 0.9rem;
+  font-size: 0.88rem;
+}
+
+.admin-empty {
+  padding: 1.1rem;
+  text-align: center;
+  border: 1px dashed rgba(15, 23, 42, 0.2);
+  border-radius: 12px;
+  color: rgba(15, 23, 42, 0.65);
+  font-style: italic;
+}
+
+body.dark-mode .admin-empty {
+  border-color: rgba(255, 255, 255, 0.25);
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.admin-tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.admin-tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.3rem 0.7rem;
+  border-radius: 999px;
+  background: rgba(41, 121, 255, 0.16);
+  color: #0f3d8c;
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+
+body.dark-mode .admin-tag {
+  background: rgba(96, 165, 250, 0.22);
+  color: #dbeafe;
+}
+
+@media (max-width: 640px) {
+  .admin-form__actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .admin-form__actions .admin-button {
+    width: 100%;
+    text-align: center;
+  }
+}
+
+.withdrawn-row--custom {
+  background: rgba(41, 121, 255, 0.08);
+}
+
+body.dark-mode .withdrawn-row--custom {
+  background: rgba(59, 130, 246, 0.18);
+}
+
 /* Journey planner layout */
 .planner {
   max-width: 700px;


### PR DESCRIPTION
## Summary
- add a reusable data store helper to persist custom withdrawn routes and route tag overrides in browser storage
- expand the admin console with management panels to add, edit, and remove withdrawn routes and service tag overrides with instant feedback
- load stored withdrawn routes and service tag overrides on the public pages and style the new admin tooling for clarity and dark-mode support

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68ca4f0ae5a88322b43c0f072251b9d7