### PR TITLE
Add TfL arrivals ingestion and rare working logic

### DIFF
--- a/fleet.css
+++ b/fleet.css
@@ -1,0 +1,1013 @@
+:root {
+  --fleet-border-light: rgba(15, 23, 42, 0.08);
+  --fleet-border-dark: rgba(148, 163, 184, 0.25);
+  --fleet-surface-shadow: 0 20px 45px -25px rgba(15, 23, 42, 0.35);
+  --fleet-surface-shadow-dark: 0 22px 55px -30px rgba(15, 23, 42, 0.75);
+  --fleet-card-radius: 20px;
+}
+
+.fleet-page {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2.5rem 1.5rem 4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.fleet-card {
+  background: var(--card-bg-light, #ffffff);
+  border-radius: var(--fleet-card-radius);
+  padding: 2rem;
+  box-shadow: var(--fleet-surface-shadow);
+  border: 1px solid var(--fleet-border-light);
+}
+
+body.dark-mode .fleet-card {
+  background: var(--card-bg-dark, rgba(17, 24, 39, 0.85));
+  border-color: var(--fleet-border-dark);
+  box-shadow: var(--fleet-surface-shadow-dark);
+}
+
+.fleet-hero {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 2rem;
+  align-items: start;
+}
+
+.fleet-hero__eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: var(--accent-blue);
+  margin: 0 0 0.75rem;
+}
+
+body.dark-mode .fleet-hero__eyebrow {
+  color: var(--foreground-dark);
+  opacity: 0.8;
+}
+
+.fleet-hero h1 {
+  margin: 0 0 1rem;
+  font-size: clamp(2rem, 2.5vw + 1.3rem, 2.85rem);
+  line-height: 1.1;
+}
+
+.fleet-hero__lead {
+  font-size: 1.05rem;
+  line-height: 1.65;
+  margin: 0 0 0.75rem;
+}
+
+.fleet-hero__note {
+  margin: 0;
+  color: rgba(15, 23, 42, 0.7);
+}
+
+body.dark-mode .fleet-hero__note {
+  color: rgba(226, 232, 240, 0.8);
+}
+
+.fleet-stats {
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 1rem;
+}
+
+.fleet-stats__item {
+  background: linear-gradient(
+    135deg,
+    rgba(41, 121, 255, 0.12),
+    rgba(41, 121, 255, 0.05)
+  );
+  border-radius: 16px;
+  padding: 1.15rem 1.25rem;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.5);
+}
+
+body.dark-mode .fleet-stats__item {
+  background: linear-gradient(
+    135deg,
+    rgba(41, 121, 255, 0.25),
+    rgba(41, 121, 255, 0.12)
+  );
+  box-shadow: inset 0 1px 0 rgba(148, 163, 184, 0.35);
+}
+
+.fleet-stats__item dt {
+  margin: 0 0 0.5rem;
+  font-size: 0.8rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(15, 23, 42, 0.65);
+}
+
+body.dark-mode .fleet-stats__item dt {
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.fleet-stats__item dd {
+  margin: 0;
+  font-size: 2.1rem;
+  font-weight: 700;
+  color: var(--foreground-light);
+}
+
+body.dark-mode .fleet-stats__item dd {
+  color: var(--foreground-dark);
+}
+
+.fleet-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.fleet-controls__intro {
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+  justify-content: space-between;
+  flex-wrap: wrap;
+}
+
+.fleet-controls__intro h2 {
+  margin: 0 0 0.35rem;
+}
+
+.fleet-controls__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.25rem;
+  align-items: start;
+}
+
+.fleet-controls__search {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  font-weight: 600;
+}
+
+.fleet-controls__search input {
+  padding: 0.85rem 1rem;
+  border-radius: 12px;
+  border: 1px solid var(--fleet-border-light);
+  font: inherit;
+  transition:
+    border-color 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.fleet-controls__search input:focus-visible {
+  border-color: var(--accent-blue);
+  box-shadow: 0 0 0 4px rgba(41, 121, 255, 0.18);
+  outline: none;
+}
+
+body.dark-mode .fleet-controls__search input {
+  background: rgba(15, 23, 42, 0.55);
+  border-color: var(--fleet-border-dark);
+  color: var(--foreground-dark);
+}
+
+.fleet-controls__toggles {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.fleet-checkbox {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-weight: 600;
+}
+
+.fleet-checkbox input[type="checkbox"] {
+  width: 1.1rem;
+  height: 1.1rem;
+  accent-color: var(--accent-blue);
+}
+
+.button-primary,
+.button-secondary,
+.button-tertiary {
+  font: inherit;
+  font-weight: 600;
+  border-radius: 12px;
+  padding: 0.75rem 1.4rem;
+  border: none;
+  cursor: pointer;
+  transition:
+    transform 0.18s ease,
+    box-shadow 0.18s ease,
+    background 0.2s ease;
+}
+
+.button-primary {
+  background: var(--accent-blue);
+  color: #fff;
+  box-shadow: 0 10px 20px -12px rgba(41, 121, 255, 0.8);
+}
+
+.button-primary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 25px -18px rgba(41, 121, 255, 0.9);
+}
+
+.button-secondary {
+  background: rgba(41, 121, 255, 0.1);
+  color: var(--accent-blue);
+  border: 1px solid rgba(41, 121, 255, 0.35);
+}
+
+.button-secondary:hover {
+  background: rgba(41, 121, 255, 0.18);
+}
+
+.button-tertiary {
+  background: transparent;
+  color: rgba(15, 23, 42, 0.75);
+  border: 1px solid rgba(15, 23, 42, 0.35);
+}
+
+.button-tertiary:hover {
+  background: rgba(15, 23, 42, 0.08);
+}
+
+body.dark-mode .button-secondary,
+body.dark-mode .button-tertiary {
+  color: var(--foreground-dark);
+  border-color: rgba(148, 163, 184, 0.45);
+}
+
+body.dark-mode .button-secondary {
+  background: rgba(41, 121, 255, 0.25);
+}
+
+body.dark-mode .button-secondary:hover {
+  background: rgba(41, 121, 255, 0.32);
+}
+
+body.dark-mode .button-tertiary:hover {
+  background: rgba(148, 163, 184, 0.2);
+}
+
+.fleet-highlights__header {
+  margin-bottom: 1.5rem;
+}
+
+.fleet-highlight-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.5rem;
+}
+
+.fleet-highlight {
+  background: rgba(15, 23, 42, 0.04);
+  border-radius: 16px;
+  padding: 1.4rem;
+  border: 1px dashed rgba(15, 23, 42, 0.12);
+}
+
+body.dark-mode .fleet-highlight {
+  background: rgba(148, 163, 184, 0.1);
+  border-color: rgba(148, 163, 184, 0.35);
+}
+
+.fleet-highlight h3 {
+  margin-top: 0;
+  margin-bottom: 1rem;
+}
+
+.fleet-highlight__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.fleet-highlight__list li {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  font-size: 0.95rem;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+  padding-bottom: 0.4rem;
+}
+
+.fleet-highlight__list li:last-child {
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+body.dark-mode .fleet-highlight__list li {
+  border-color: rgba(148, 163, 184, 0.2);
+}
+
+.fleet-highlight__list span {
+  font-weight: 600;
+}
+
+.fleet-highlight__list small {
+  color: rgba(15, 23, 42, 0.6);
+}
+
+body.dark-mode .fleet-highlight__list small {
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.fleet-table__header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: flex-end;
+}
+
+.fleet-table__hint {
+  max-width: 460px;
+  margin: 0;
+  color: rgba(15, 23, 42, 0.65);
+}
+
+body.dark-mode .fleet-table__hint {
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.fleet-table__scroll {
+  overflow-x: auto;
+  margin-top: 1.5rem;
+}
+
+.fleet-table table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 980px;
+}
+
+.fleet-table th,
+.fleet-table td {
+  padding: 0.75rem 1rem;
+  text-align: left;
+  border-bottom: 1px solid var(--fleet-border-light);
+  vertical-align: top;
+  background: transparent;
+}
+
+body.dark-mode .fleet-table th,
+body.dark-mode .fleet-table td {
+  border-color: var(--fleet-border-dark);
+}
+
+.fleet-table thead th {
+  font-size: 0.8rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(15, 23, 42, 0.7);
+}
+
+body.dark-mode .fleet-table thead th {
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.fleet-table tbody tr {
+  transition: background 0.2s ease;
+}
+
+.fleet-table tbody tr:hover {
+  background: rgba(41, 121, 255, 0.05);
+}
+
+body.dark-mode .fleet-table tbody tr:hover {
+  background: rgba(41, 121, 255, 0.18);
+}
+
+.fleet-row__reg {
+  font-weight: 700;
+  font-size: 1rem;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.25rem 0.55rem;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 700;
+  margin-right: 0.35rem;
+}
+
+.badge--new {
+  background: rgba(41, 121, 255, 0.16);
+  color: var(--accent-blue);
+}
+
+.badge--rare {
+  background: rgba(215, 31, 90, 0.18);
+  color: #c2185b;
+}
+
+.badge--pending {
+  background: rgba(255, 193, 7, 0.22);
+  color: #8a5800;
+}
+
+body.dark-mode .badge--new {
+  background: rgba(41, 121, 255, 0.28);
+}
+
+body.dark-mode .badge--rare {
+  background: rgba(215, 31, 90, 0.28);
+  color: #ff7ca5;
+}
+
+body.dark-mode .badge--pending {
+  background: rgba(255, 193, 7, 0.28);
+  color: #ffda79;
+}
+
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.65rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.status-badge--active {
+  background: rgba(46, 204, 113, 0.18);
+  color: #1b5e20;
+}
+
+.status-badge--inactive {
+  background: rgba(239, 83, 80, 0.18);
+  color: #b71c1c;
+}
+
+body.dark-mode .status-badge--active {
+  color: #b9f6ca;
+}
+
+body.dark-mode .status-badge--inactive {
+  color: #ff8a80;
+}
+
+.chip-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.chip {
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.08);
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+body.dark-mode .chip {
+  background: rgba(148, 163, 184, 0.28);
+}
+
+.fleet-table__empty {
+  margin: 1rem 0 0;
+  font-weight: 600;
+}
+
+.fleet-form__intro {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.fleet-form__intro h2 {
+  margin-top: 0.35rem;
+}
+
+.fleet-form__hint {
+  margin: 0;
+  max-width: 360px;
+  color: rgba(15, 23, 42, 0.65);
+}
+
+body.dark-mode .fleet-form__hint {
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.fleet-form form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.fleet-form__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+  gap: 1rem 1.25rem;
+}
+
+.fleet-form label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  font-weight: 600;
+}
+
+.fleet-form label span {
+  font-size: 0.9rem;
+}
+
+.fleet-form input,
+.fleet-form select {
+  font: inherit;
+  padding: 0.8rem 0.9rem;
+  border-radius: 12px;
+  border: 1px solid var(--fleet-border-light);
+  background: #fff;
+  transition:
+    border-color 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.fleet-form select[multiple] {
+  min-height: 9rem;
+}
+
+.fleet-form input:focus-visible,
+.fleet-form select:focus-visible {
+  border-color: var(--accent-blue);
+  box-shadow: 0 0 0 3px rgba(41, 121, 255, 0.18);
+  outline: none;
+}
+
+body.dark-mode .fleet-form input,
+body.dark-mode .fleet-form select {
+  background: rgba(15, 23, 42, 0.55);
+  color: var(--foreground-dark);
+  border-color: var(--fleet-border-dark);
+}
+
+.fleet-form__extras small {
+  color: rgba(15, 23, 42, 0.6);
+}
+
+body.dark-mode .fleet-form__extras small {
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.fleet-form__toggles {
+  display: flex;
+  gap: 1.25rem;
+  flex-wrap: wrap;
+}
+
+.fleet-form__actions {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.fleet-form__feedback {
+  margin: 0;
+  font-weight: 600;
+  min-height: 1.2rem;
+}
+
+.fleet-form__feedback[data-state="success"] {
+  color: #1b5e20;
+}
+
+.fleet-form__feedback[data-state="error"] {
+  color: #b71c1c;
+}
+
+.fleet-form__feedback[data-state="pending"] {
+  color: #8a5800;
+}
+
+.fleet-admin__intro {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.fleet-admin__actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  align-items: flex-end;
+}
+
+.fleet-admin__hint {
+  color: rgba(15, 23, 42, 0.6);
+}
+
+body.dark-mode .fleet-admin__hint {
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.fleet-admin__panel {
+  margin-top: 1.75rem;
+  border-top: 1px solid var(--fleet-border-light);
+  padding-top: 1.75rem;
+}
+
+body.dark-mode .fleet-admin__panel {
+  border-color: var(--fleet-border-dark);
+}
+
+.fleet-admin__panel[hidden] {
+  display: none;
+}
+
+.fleet-admin__grid {
+  display: grid;
+  grid-template-columns: 1.6fr 1fr;
+  gap: 1.75rem;
+}
+
+.fleet-admin__ingest {
+  grid-column: 1 / -1;
+  border: 1px solid var(--fleet-border-light);
+  border-radius: 16px;
+  padding: 1.5rem;
+  background: rgba(15, 23, 42, 0.02);
+  display: grid;
+  gap: 1.25rem;
+}
+
+body.dark-mode .fleet-admin__ingest {
+  border-color: var(--fleet-border-dark);
+  background: rgba(148, 163, 184, 0.14);
+}
+
+.fleet-admin__ingest-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.fleet-admin__ingest-header p {
+  margin-bottom: 0;
+}
+
+.ingest-fetch,
+.ingest-form {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.ingest-fetch__credentials {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.75rem;
+}
+
+.ingest-fetch__credentials label {
+  font-size: 0.85rem;
+  color: rgba(15, 23, 42, 0.75);
+}
+
+body.dark-mode .ingest-fetch__credentials label {
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.ingest-form textarea {
+  min-height: 12rem;
+  font-family: var(--font-mono, "JetBrains Mono", monospace);
+  font-size: 0.9rem;
+  line-height: 1.5;
+  padding: 0.75rem;
+  border-radius: 12px;
+  border: 1px solid var(--fleet-border-light);
+  resize: vertical;
+}
+
+body.dark-mode .ingest-form textarea {
+  background: rgba(15, 23, 42, 0.55);
+  color: var(--foreground-dark);
+  border-color: var(--fleet-border-dark);
+}
+
+.ingest-form__actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.fleet-admin__ingest-feedback {
+  margin: 0;
+  font-weight: 600;
+  min-height: 1.2rem;
+}
+
+.fleet-admin__ingest-feedback[data-state="success"] {
+  color: #1b5e20;
+}
+
+.fleet-admin__ingest-feedback[data-state="error"] {
+  color: #b71c1c;
+}
+
+.fleet-admin__ingest-feedback[data-state="pending"] {
+  color: #8a5800;
+}
+
+.ingest-help {
+  border-top: 1px solid var(--fleet-border-light);
+  padding-top: 0.75rem;
+}
+
+.ingest-help summary {
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.ingest-help p {
+  margin-top: 0.75rem;
+  font-size: 0.9rem;
+  color: rgba(15, 23, 42, 0.75);
+}
+
+body.dark-mode .ingest-help {
+  border-color: var(--fleet-border-dark);
+}
+
+body.dark-mode .ingest-help p {
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.fleet-admin__section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.fleet-admin__badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.35rem 0.7rem;
+  border-radius: 999px;
+  background: rgba(41, 121, 255, 0.16);
+  color: var(--accent-blue);
+  font-weight: 700;
+  font-size: 0.8rem;
+}
+
+.pending-list {
+  display: grid;
+  gap: 1rem;
+}
+
+.pending-card {
+  border: 1px solid var(--fleet-border-light);
+  border-radius: 16px;
+  padding: 1.25rem;
+  background: rgba(15, 23, 42, 0.02);
+}
+
+body.dark-mode .pending-card {
+  border-color: var(--fleet-border-dark);
+  background: rgba(148, 163, 184, 0.14);
+}
+
+.pending-card__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-bottom: 0.75rem;
+}
+
+.pending-card__header h4 {
+  margin: 0;
+}
+
+.pending-card__meta {
+  font-size: 0.85rem;
+  color: rgba(15, 23, 42, 0.65);
+}
+
+body.dark-mode .pending-card__meta {
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.pending-card__changes {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 1rem;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.pending-card__changes li {
+  display: grid;
+  grid-template-columns: 0.9fr 1.1fr;
+  gap: 0.6rem;
+  align-items: baseline;
+}
+
+.pending-card__label {
+  font-weight: 600;
+  color: rgba(15, 23, 42, 0.8);
+}
+
+body.dark-mode .pending-card__label {
+  color: rgba(226, 232, 240, 0.9);
+}
+
+.pending-card__value {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.pending-card__value span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.pending-card__value span strong {
+  font-weight: 700;
+}
+
+.pending-card__value span .arrow {
+  opacity: 0.6;
+}
+
+.pending-card__actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.pending-card__actions .button-primary {
+  flex: 0 0 auto;
+}
+
+.pending-card__actions .button-tertiary {
+  border-color: rgba(239, 83, 80, 0.45);
+  color: #b71c1c;
+}
+
+body.dark-mode .pending-card__actions .button-tertiary {
+  color: #ff8a80;
+  border-color: rgba(255, 138, 128, 0.6);
+}
+
+.option-form {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.option-list {
+  list-style: none;
+  padding: 0;
+  margin: 1rem 0 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.option-list li {
+  background: rgba(15, 23, 42, 0.05);
+  border-radius: 999px;
+  padding: 0.35rem 0.75rem;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+}
+
+body.dark-mode .option-list li {
+  background: rgba(148, 163, 184, 0.25);
+}
+
+.option-empty,
+.pending-empty {
+  margin: 0;
+  color: rgba(15, 23, 42, 0.6);
+  font-weight: 600;
+}
+
+body.dark-mode .option-empty,
+body.dark-mode .pending-empty {
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.fleet-toast {
+  position: fixed;
+  bottom: 2rem;
+  right: 2rem;
+  background: var(--accent-blue);
+  color: #fff;
+  padding: 0.9rem 1.4rem;
+  border-radius: 999px;
+  box-shadow: 0 18px 35px -25px rgba(41, 121, 255, 0.9);
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(16px);
+  transition:
+    opacity 0.25s ease,
+    transform 0.25s ease;
+  max-width: 320px;
+  font-weight: 600;
+}
+
+.fleet-toast[data-visible="true"] {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.fleet-toast[data-variant="success"] {
+  background: #2e7d32;
+}
+
+.fleet-toast[data-variant="error"] {
+  background: #c62828;
+}
+
+body.dark-mode .fleet-toast[data-variant="success"] {
+  background: #43a047;
+}
+
+body.dark-mode .fleet-toast[data-variant="error"] {
+  background: #ef5350;
+}
+
+@media (max-width: 960px) {
+  .fleet-admin__grid {
+    grid-template-columns: 1fr;
+  }
+
+  .pending-card__changes li {
+    grid-template-columns: 1fr;
+  }
+
+  .pending-card__value span {
+    flex-wrap: wrap;
+  }
+}
+
+@media (max-width: 720px) {
+  .fleet-card {
+    padding: 1.5rem;
+  }
+
+  .fleet-page {
+    padding: 2rem 1rem 3rem;
+  }
+
+  .fleet-stats {
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  }
+
+  .fleet-highlight-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .fleet-controls__toggles,
+  .fleet-form__actions,
+  .fleet-form__toggles {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .fleet-toast {
+    right: 1rem;
+    left: 1rem;
+    bottom: 1.25rem;
+  }
+}
+
+@media (max-width: 520px) {
+  .fleet-table table {
+    min-width: 860px;
+  }
+
+  .fleet-stats__item dd {
+    font-size: 1.75rem;
+  }
+}

--- a/fleet.html
+++ b/fleet.html
@@ -1,548 +1,501 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Fleet | Routeflow London</title>
-  <link rel="icon" href="images/New_Routflow_London_Logo.png" type="image/png">
-  <link href="https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible:wght@400;600&family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-  <link rel="stylesheet" href="style.css">
-  <script src="theme.js" defer></script>
-</head>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Fleet | RouteFlow London</title>
+    <link
+      rel="icon"
+      href="images/New_Routflow_London_Logo.png"
+      type="image/png"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible:wght@400;600&family=Inter:wght@400;600;800&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"
+    />
+    <link rel="stylesheet" href="style.css" />
+    <link rel="stylesheet" href="fleet.css" />
+    <script src="theme.js" defer></script>
+  </head>
   <body>
-  <header class="navbar">
-  <div class="navbar__container">
-    <a href="index.html" class="navbar__logo" aria-label="RouteFlow London Home">
-      <img src="images/Routeflow London permanent logo.png" alt="RouteFlow London Logo" />
-      <strong>RouteFlow London</strong>
-    </a>
-    <nav class="navbar__links" id="navbarLinks">
-      <a href="index.html">Home</a>
-      <a href="dashboard.html">Dashboard</a>
-      <a href="tracking.html">Tracking</a>
-      <a href="planning.html">Planning</a>
-      <a href="routes.html">Routes</a>
-      <a href="withdrawn.html">Withdrawn</a>
-      <a href="disruptions.html">Disruptions</a>
-      <a href="fleet.html">Fleet</a>
-    </nav>
-    <div class="navbar__controls">
-      <button class="hamburger" id="hamburgerBtn" aria-label="Open mobile menu">
-        <i class="fa-solid fa-bars"></i>
-      </button>
-      <div class="account-menu" id="accountMenu">
-        <button aria-label="Account" id="profileIcon" type="button">
-          <i class="fa-regular fa-user"></i>
-        </button>
-        <div class="account-dropdown" id="dropdownContent">
-          <a href="profile.html">Profile</a>
-          <a href="settings.html">Settings</a>
-          <button onclick="openModal('login')" type="button">Login</button>
-          <button onclick="openModal('signup')" type="button">Sign Up</button>
-          <button onclick="signOut()" type="button">Sign out</button>
+    <div id="navbar-container"></div>
+
+    <main class="fleet-page">
+      <section class="fleet-card fleet-hero">
+        <div class="fleet-hero__heading">
+          <p class="fleet-hero__eyebrow">Fleet database</p>
+          <h1>London buses organised by registration</h1>
+          <p class="fleet-hero__lead">
+            Build and maintain a live catalogue of the London fleet. New
+            registrations automatically generate profiles, while enthusiast
+            changes stay in review until an admin approves them.
+          </p>
+          <p class="fleet-hero__note">
+            Every vehicle profile supports fleet numbers, liveries, engineering
+            details and enthusiast tags including new buses and rare workings.
+          </p>
         </div>
-      </div>
-    </div>
-  </div>
-  <!-- Mobile nav drawer -->
-  <nav class="mobile-drawer" id="mobileDrawer" aria-label="Mobile Navigation">
-    <button class="close-drawer" id="closeDrawerBtn" aria-label="Close menu">
-      <i class="fa-solid fa-times"></i>
-    </button>
-    <a href="index.html">Home</a>
-    <a href="dashboard.html">Dashboard</a>
-    <a href="tracking.html">Tracking</a>
-    <a href="planning.html">Planning</a>
-    <a href="routes.html">Routes</a>
-    <a href="withdrawn.html">Withdrawn</a>
-    <a href="disruptions.html">Disruptions</a>
-    <a href="fleet.html">Fleet</a>
-    <hr>
-    <a href="profile.html">Profile</a>
-    <a href="settings.html">Settings</a>
-    <button onclick="openModal('login')" type="button">Login</button>
-    <button onclick="openModal('signup')" type="button">Sign Up</button>
-    <button onclick="signOut()" type="button">Sign out</button>
-  </nav>
-  <div class="drawer-backdrop" id="drawerBackdrop"></div>
+        <dl class="fleet-stats" aria-label="Fleet summary">
+          <div class="fleet-stats__item">
+            <dt>Total vehicles</dt>
+            <dd id="fleetTotal">0</dd>
+          </div>
+          <div class="fleet-stats__item">
+            <dt>New buses</dt>
+            <dd id="fleetNew">0</dd>
+          </div>
+          <div class="fleet-stats__item">
+            <dt>Rare workings</dt>
+            <dd id="fleetRare">0</dd>
+          </div>
+          <div class="fleet-stats__item">
+            <dt>Pending reviews</dt>
+            <dd id="fleetPending">0</dd>
+          </div>
+        </dl>
+      </section>
 
-  <!-- Modal for login/signup/reset -->
-  <div id="authModal" class="modal" aria-modal="true" role="dialog">
-    <div class="modal-content">
-      <span class="close" id="closeModal" title="Close">&times;</span>
-      <!-- Login Form -->
-      <div id="loginFormContainer">
-        <h2>Login</h2>
-        <form id="loginForm" autocomplete="off">
-          <input type="email" id="loginEmail" placeholder="Email" required autocomplete="username">
-          <input type="password" id="loginPassword" placeholder="Password" required autocomplete="current-password">
-          <button type="submit">Login</button>
-          <button type="button" class="google-btn">Sign in with Google</button>
-          <p><a href="#" class="reset-password" id="showReset">Forgot Password?</a></p>
-          <div class="error-message" id="loginError" style="display:none;"></div>
+      <section class="fleet-card fleet-controls" aria-labelledby="fleetFilters">
+        <div class="fleet-controls__intro">
+          <div>
+            <h2 id="fleetFilters">Search and filter</h2>
+            <p>
+              Look up any registration and focus the table on new additions or
+              rare workings.
+            </p>
+          </div>
+          <button id="resetFilters" class="button-secondary" type="button">
+            Reset filters
+          </button>
+        </div>
+        <div class="fleet-controls__grid">
+          <label class="fleet-controls__search" for="searchReg">
+            <span>Registration</span>
+            <input
+              id="searchReg"
+              type="search"
+              placeholder="e.g. LTZ1000"
+              autocomplete="off"
+            />
+          </label>
+          <div
+            class="fleet-controls__toggles"
+            role="group"
+            aria-label="Highlight filters"
+          >
+            <label class="fleet-checkbox">
+              <input type="checkbox" id="filterNew" />
+              <span>New buses only</span>
+            </label>
+            <label class="fleet-checkbox">
+              <input type="checkbox" id="filterRare" />
+              <span>Rare workings only</span>
+            </label>
+          </div>
+        </div>
+      </section>
+
+      <section
+        class="fleet-card fleet-highlights"
+        aria-labelledby="fleetHighlightsHeading"
+      >
+        <header class="fleet-highlights__header">
+          <div>
+            <p class="fleet-hero__eyebrow">Highlights</p>
+            <h2 id="fleetHighlightsHeading">
+              Spotlight on new buses and rare workings
+            </h2>
+            <p>Recently updated profiles tagged by the community.</p>
+          </div>
+        </header>
+        <div class="fleet-highlight-grid">
+          <article class="fleet-highlight" aria-labelledby="newBusHighlight">
+            <h3 id="newBusHighlight">New buses</h3>
+            <ul id="newBusList" class="fleet-highlight__list"></ul>
+          </article>
+          <article
+            class="fleet-highlight"
+            aria-labelledby="rareWorkingHighlight"
+          >
+            <h3 id="rareWorkingHighlight">Rare workings</h3>
+            <ul id="rareWorkingList" class="fleet-highlight__list"></ul>
+          </article>
+        </div>
+      </section>
+
+      <section
+        class="fleet-card fleet-table"
+        aria-labelledby="fleetTableHeading"
+      >
+        <div class="fleet-table__header">
+          <div>
+            <p class="fleet-hero__eyebrow">Fleet profiles</p>
+            <h2 id="fleetTableHeading">Complete database by registration</h2>
+          </div>
+          <p class="fleet-table__hint">
+            Submit a change request to update an existing vehicle. Admins review
+            pending updates.
+          </p>
+        </div>
+        <div class="fleet-table__scroll">
+          <table>
+            <thead>
+              <tr>
+                <th scope="col">Registration</th>
+                <th scope="col">Fleet number</th>
+                <th scope="col">Operator</th>
+                <th scope="col">Status</th>
+                <th scope="col">Vehicle type</th>
+                <th scope="col">Garage</th>
+                <th scope="col">Wrap</th>
+                <th scope="col">Doors</th>
+                <th scope="col">Engine type</th>
+                <th scope="col">Engine</th>
+                <th scope="col">Chassis</th>
+                <th scope="col">Body type</th>
+                <th scope="col">Registration date</th>
+                <th scope="col">Extras</th>
+                <th scope="col">Length</th>
+                <th scope="col">Last updated</th>
+              </tr>
+            </thead>
+            <tbody id="fleetTableBody"></tbody>
+          </table>
+        </div>
+        <p id="fleetEmpty" class="fleet-table__empty" hidden>
+          No vehicles match your filters yet.
+        </p>
+      </section>
+
+      <section class="fleet-card fleet-form" aria-labelledby="fleetFormHeading">
+        <div class="fleet-form__intro">
+          <div>
+            <p class="fleet-hero__eyebrow">Community updates</p>
+            <h2 id="fleetFormHeading">Add a new vehicle or request a change</h2>
+            <p>
+              Registrations that are new to the database generate a fresh
+              profile automatically. Updates to existing buses are held for
+              admin approval.
+            </p>
+          </div>
+          <p class="fleet-form__hint">
+            All vehicle attributes use dropdowns so admins can curate consistent
+            values.
+          </p>
+        </div>
+        <form id="fleetForm" autocomplete="off">
+          <div class="fleet-form__grid">
+            <label for="busRegistration">
+              <span>Registration<span aria-hidden="true">*</span></span>
+              <input
+                id="busRegistration"
+                name="registration"
+                type="text"
+                required
+                placeholder="Enter registration"
+                autocomplete="off"
+              />
+            </label>
+            <label for="fleetNumber">
+              <span>Fleet number</span>
+              <input
+                id="fleetNumber"
+                name="fleetNumber"
+                type="text"
+                placeholder="e.g. LT1"
+              />
+            </label>
+            <label for="operatorSelect">
+              <span>Operator</span>
+              <select id="operatorSelect" name="operator"></select>
+            </label>
+            <label for="statusSelect">
+              <span>Status</span>
+              <select id="statusSelect" name="status"></select>
+            </label>
+            <label for="wrapSelect">
+              <span>Wrap / livery</span>
+              <select id="wrapSelect" name="wrap"></select>
+            </label>
+            <label for="vehicleTypeSelect">
+              <span>Vehicle type</span>
+              <select id="vehicleTypeSelect" name="vehicleType"></select>
+            </label>
+            <label for="doorsSelect">
+              <span>Doors</span>
+              <select id="doorsSelect" name="doors"></select>
+            </label>
+            <label for="engineTypeSelect">
+              <span>Engine type</span>
+              <select id="engineTypeSelect" name="engineType"></select>
+            </label>
+            <label for="engineSelect">
+              <span>Engine</span>
+              <select id="engineSelect" name="engine"></select>
+            </label>
+            <label for="chassisSelect">
+              <span>Chassis</span>
+              <select id="chassisSelect" name="chassis"></select>
+            </label>
+            <label for="bodyTypeSelect">
+              <span>Body type</span>
+              <select id="bodyTypeSelect" name="bodyType"></select>
+            </label>
+            <label for="registrationDate">
+              <span>Registration date</span>
+              <input
+                id="registrationDate"
+                name="registrationDate"
+                type="date"
+              />
+            </label>
+            <label for="garageSelect">
+              <span>Garage</span>
+              <select id="garageSelect" name="garage"></select>
+            </label>
+            <label for="extrasSelect" class="fleet-form__extras">
+              <span>Extras (tags)</span>
+              <select
+                id="extrasSelect"
+                name="extras"
+                multiple
+                size="6"
+                aria-describedby="extrasHelp"
+              ></select>
+              <small id="extrasHelp"
+                >Hold Ctrl (Windows) or Command (Mac) to choose multiple
+                tags.</small
+              >
+            </label>
+            <label for="lengthSelect">
+              <span>Length</span>
+              <select id="lengthSelect" name="length"></select>
+            </label>
+          </div>
+          <div class="fleet-form__toggles">
+            <label class="fleet-checkbox">
+              <input type="checkbox" id="isNewBus" name="isNewBus" />
+              <span>Mark as new bus</span>
+            </label>
+            <label class="fleet-checkbox">
+              <input type="checkbox" id="isRareWorking" name="isRareWorking" />
+              <span>Mark as rare working</span>
+            </label>
+          </div>
+          <div class="fleet-form__actions">
+            <button type="submit" class="button-primary">Submit update</button>
+            <button type="button" id="clearForm" class="button-tertiary">
+              Clear form
+            </button>
+          </div>
+          <p
+            id="formFeedback"
+            class="fleet-form__feedback"
+            role="status"
+            aria-live="polite"
+          ></p>
         </form>
-        <p>Don't have an account? <a href="#" id="showSignup">Sign up</a></p>
+      </section>
+
+      <section
+        class="fleet-card fleet-admin"
+        aria-labelledby="adminPortalHeading"
+      >
+        <header class="fleet-admin__intro">
+          <div>
+            <p class="fleet-hero__eyebrow">Admin portal</p>
+            <h2 id="adminPortalHeading">
+              Approve community changes and manage dropdowns
+            </h2>
+            <p>
+              Use the admin tools to vet pending edits and curate the lists that
+              power each dropdown menu.
+            </p>
+          </div>
+          <div class="fleet-admin__actions">
+            <button
+              id="adminToggle"
+              class="button-primary"
+              type="button"
+              aria-expanded="false"
+              aria-controls="adminPanel"
+            >
+              Access admin tools
+            </button>
+            <small class="fleet-admin__hint"
+              >Demo access code: <code>fleet-admin</code></small
+            >
+          </div>
+        </header>
+        <div id="adminPanel" class="fleet-admin__panel" hidden>
+          <div class="fleet-admin__grid">
+            <section
+              aria-labelledby="pendingHeading"
+              class="fleet-admin__pending"
+            >
+              <div class="fleet-admin__section-header">
+                <h3 id="pendingHeading">Pending approvals</h3>
+                <span id="pendingCount" class="fleet-admin__badge"
+                  >0 pending</span
+                >
+              </div>
+              <div id="pendingContainer" class="pending-list"></div>
+            </section>
+            <section
+              aria-labelledby="optionsHeading"
+              class="fleet-admin__options"
+            >
+              <h3 id="optionsHeading">Manage dropdown options</h3>
+              <form id="optionForm" class="option-form">
+                <label for="optionCategory">Field</label>
+                <select id="optionCategory" name="category">
+                  <option value="operator">Operator</option>
+                  <option value="status">Status</option>
+                  <option value="wrap">Wrap</option>
+                  <option value="vehicleType">Vehicle type</option>
+                  <option value="doors">Doors</option>
+                  <option value="engineType">Engine type</option>
+                  <option value="engine">Engine</option>
+                  <option value="chassis">Chassis</option>
+                  <option value="bodyType">Body type</option>
+                  <option value="garage">Garage</option>
+                  <option value="extras">Extras</option>
+                  <option value="length">Length</option>
+                </select>
+                <label for="optionValue">New option</label>
+                <input
+                  id="optionValue"
+                  name="value"
+                  type="text"
+                  placeholder="Enter new option"
+                />
+                <button type="submit" class="button-primary">Add option</button>
+              </form>
+              <div>
+                <h4 id="optionListHeading">Current options</h4>
+                <ul
+                  id="optionList"
+                  class="option-list"
+                  aria-labelledby="optionListHeading"
+                ></ul>
+              </div>
+            </section>
+            <section
+              aria-labelledby="ingestHeading"
+              class="fleet-admin__ingest"
+            >
+              <div class="fleet-admin__ingest-header">
+                <div>
+                  <h3 id="ingestHeading">Sync TfL arrivals data</h3>
+                  <p>
+                    Paste a response from the TfL Vehicle Arrivals API or fetch
+                    it directly to keep sightings, new registrations, and rare
+                    workings up to date.
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  id="fetchArrivals"
+                  class="button-secondary"
+                >
+                  Fetch from TfL
+                </button>
+              </div>
+              <form class="ingest-fetch" aria-label="TfL request options">
+                <label for="ingestIds">Vehicle registrations</label>
+                <input
+                  id="ingestIds"
+                  type="text"
+                  placeholder="e.g. LX11AZB,LX58CFV"
+                  autocomplete="off"
+                />
+                <div class="ingest-fetch__credentials">
+                  <label for="ingestAppId">app_id (optional)</label>
+                  <input id="ingestAppId" type="text" autocomplete="off" />
+                  <label for="ingestAppKey">app_key (optional)</label>
+                  <input id="ingestAppKey" type="password" autocomplete="off" />
+                </div>
+              </form>
+              <form id="ingestForm" class="ingest-form" autocomplete="off">
+                <label for="ingestInput">Vehicle arrivals JSON</label>
+                <textarea
+                  id="ingestInput"
+                  placeholder="Paste the TfL /Vehicle/{ids}/Arrivals response here"
+                  spellcheck="false"
+                ></textarea>
+                <div class="ingest-form__actions">
+                  <button type="submit" class="button-primary">
+                    Process JSON
+                  </button>
+                  <button
+                    type="button"
+                    id="clearIngest"
+                    class="button-tertiary"
+                  >
+                    Clear
+                  </button>
+                </div>
+                <p
+                  id="ingestFeedback"
+                  class="fleet-admin__ingest-feedback"
+                  role="status"
+                  aria-live="polite"
+                ></p>
+              </form>
+              <details class="ingest-help">
+                <summary>How the TfL arrivals feed works</summary>
+                <p>
+                  The endpoint <code>/Vehicle/{ids}/Arrivals</code> accepts a
+                  comma-separated list of registrations. Provide your TfL
+                  <code>app_id</code> and <code>app_key</code> if required, then
+                  paste the JSON response above to update the database. New
+                  registrations will get a profile automatically and a rare
+                  working is logged whenever a bus appears on a route after more
+                  than 30 days away.
+                </p>
+              </details>
+            </section>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <div class="footer-links">
+        <a href="about.html">About</a> | <a href="privacy.html">Privacy</a> |
+        <a href="terms.html">Terms</a> |
+        <a href="contact.html">Contact</a>
       </div>
-      <!-- Signup Form -->
-      <div id="signupFormContainer" style="display:none;">
-        <h2>Sign Up</h2>
-        <form id="signupForm" autocomplete="off">
-          <input type="email" id="signupEmail" placeholder="Email" required autocomplete="username">
-          <input type="password" id="signupPassword" placeholder="Password" required autocomplete="new-password">
-          <button type="submit">Sign Up</button>
-          <button type="button" class="google-btn">Sign Up with Google</button>
-          <div class="error-message" id="signupError" style="display:none;"></div>
-        </form>
-        <p>Already have an account? <a href="#" id="showLogin">Login</a></p>
+      <div class="social-icons">
+        <a href="https://discord.gg/qVf3nN4Mgq"
+          ><i class="fa-brands fa-discord"></i
+        ></a>
+        <a href="https://www.tiktok.com/@the_bus_father"
+          ><i class="fab fa-tiktok"></i
+        ></a>
+        <a
+          href="https://www.instagram.com/thebusfatherofficial/profilecard/?igsh=NXcybzV3cTA2azBo"
+          ><i class="fab fa-instagram"></i
+        ></a>
       </div>
-      <!-- Reset Password Form -->
-      <div id="resetFormContainer" style="display:none;">
-        <h2>Reset Password</h2>
-        <form id="resetForm" autocomplete="off">
-          <input type="email" id="resetEmail" placeholder="Enter your email" required autocomplete="username">
-          <button type="submit">Send Reset Link</button>
-          <div class="error-message" id="resetError" style="display:none;"></div>
-        </form>
-        <p>Remembered? <a href="#" id="showLoginFromReset">Back to Login</a></p>
-      </div>
-    </div>
-  </div>
-</header>
+      <small>Made for London. Built from scratch.</small>
+    </footer>
 
-<style>
-.navbar {
-  background: #fff;
-  border-bottom: 1px solid #e5e5e5;
-  position: sticky;
-  top: 0;
-  z-index: 1000;
-  font-family: 'Segoe UI', Arial, sans-serif;
-}
+    <div
+      id="fleetToast"
+      class="fleet-toast"
+      role="status"
+      aria-live="polite"
+    ></div>
 
-.navbar__container {
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 0.7rem 2vw;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1.2rem;
-}
-
-.navbar__logo {
-  display: flex;
-  align-items: center;
-  gap: 0.6rem;
-  text-decoration: none;
-  color: #c62828;
-}
-.navbar__logo img {
-  height: 38px;
-}
-.navbar__logo strong {
-  font-size: 1.25rem;
-  font-weight: bold;
-  letter-spacing: 1px;
-}
-
-/* Desktop nav links */
-.navbar__links {
-  display: flex;
-  gap: 1rem;
-}
-.navbar__links a {
-  color: #333;
-  text-decoration: none;
-  padding: 0.45rem 0.9rem;
-  border-radius: 6px;
-  font-weight: 500;
-  font-size: 1.05rem;
-  transition: background .18s, color .18s;
-}
-.navbar__links a.active,
-.navbar__links a:hover {
-  background: #2979ff;
-  color: #fff;
-}
-
-.navbar__controls {
-  display: flex;
-  align-items: center;
-  gap: 0.4rem;
-}
-
-/* Hamburger button */
-.hamburger {
-  background: none;
-  border: none;
-  font-size: 1.55rem;
-  color: #c62828;
-  cursor: pointer;
-  display: none;
-}
-.account-menu {
-  position: relative;
-}
-.account-menu button {
-  background: none;
-  border: none;
-  font-size: 1.5rem;
-  color: #333;
-  padding: 0.15rem 0.4rem;
-  border-radius: 50%;
-  cursor: pointer;
-  transition: background 0.17s;
-}
-.account-menu button:hover {
-  background: #f0f0f0;
-}
-.account-dropdown {
-  display: none;
-  flex-direction: column;
-  position: absolute;
-  right: 0;
-  top: 125%;
-  background: #fff;
-  border-radius: 8px;
-  box-shadow: 0 4px 18px #0002;
-  min-width: 150px;
-  z-index: 10;
-  padding: 0.5rem 0;
-}
-.account-dropdown a,
-.account-dropdown button {
-  background: none;
-  border: none;
-  color: #333;
-  padding: 0.7rem 1rem;
-  text-align: left;
-  text-decoration: none;
-  font-size: 1rem;
-  font-weight: 500;
-  cursor: pointer;
-  transition: background 0.16s;
-}
-.account-dropdown a:hover,
-.account-dropdown button:hover {
-  background: #2979ff;
-  color: #fff;
-}
-.account-menu.open .account-dropdown {
-  display: flex;
-}
-
-/* Mobile Nav Drawer */
-.mobile-drawer {
-  display: flex;
-  flex-direction: column;
-  position: fixed;
-  top: 0; left: 0;
-  width: 80vw;
-  max-width: 340px;
-  height: 100vh;
-  background: #fff;
-  box-shadow: 2px 0 32px #0005;
-  padding: 2rem 1.1rem 1.1rem 1.1rem;
-  z-index: 1200;
-  transform: translateX(-100%);
-  transition: transform 0.3s cubic-bezier(.7,.3,.3,1);
-  gap: 0.7rem;
-  overflow-y: auto;
-}
-.mobile-drawer.open {
-  transform: translateX(0);
-}
-.mobile-drawer a,
-.mobile-drawer button {
-  color: #333;
-  text-decoration: none;
-  padding: 0.75rem 0.7rem;
-  border-radius: 6px;
-  font-weight: 500;
-  background: none;
-  border: none;
-  text-align: left;
-  font-size: 1.08rem;
-  transition: background .18s;
-  cursor: pointer;
-}
-.mobile-drawer a:hover,
-.mobile-drawer button:hover {
-  background: #2979ff;
-  color: #fff;
-}
-.mobile-drawer hr {
-  margin: 1rem 0;
-  border: none;
-  border-top: 1px solid #eee;
-}
-.close-drawer {
-  align-self: flex-end;
-  margin-bottom: 1.2rem;
-  color: #c62828;
-  font-size: 1.3rem;
-  background: none;
-  border: none;
-  cursor: pointer;
-}
-
-/* Drawer backdrop */
-.drawer-backdrop {
-  display: none;
-  position: fixed;
-  top: 0; left: 0;
-  width: 100vw; height: 100vh;
-  background: rgba(30,30,30,0.28);
-  z-index: 1100;
-  transition: opacity 0.2s;
-}
-.drawer-backdrop.open {
-  display: block;
-  opacity: 1;
-}
-
-/* Responsive */
-@media (max-width: 950px) {
-  .navbar__links {
-    display: none;
-  }
-  .hamburger {
-    display: block;
-  }
-}
-
-/* Hide mobile drawer on desktop */
-@media (min-width: 951px) {
-  .mobile-drawer, .drawer-backdrop { display: none !important; }
-}
-.modal {
-  display: none;
-  position: fixed;
-  z-index: 2000;
-  left: 0; top: 0;
-  width: 100vw; height: 100vh;
-  background: rgba(0,0,0,0.38);
-}
-.modal-content {
-  background: #fff;
-  margin: 7% auto;
-  border-radius: 14px;
-  width: 94%;
-  max-width: 375px;
-  padding: 2.2rem 1.7rem 1.2rem 1.7rem;
-  position: relative;
-  box-shadow: 0 8px 44px #2979ff22;
-  color: #2d3a4a;
-  display: flex;
-  flex-direction: column;
-  gap: 0.7rem;
-}
-.close {
-  position: absolute;
-  right: 1.1rem;
-  top: 1.1rem;
-  font-size: 2rem;
-  color: #888;
-  background: none;
-  border: none;
-  cursor: pointer;
-  transition: color .18s;
-}
-.close:hover { color: #d32f2f; }
-/* Form elements */
-.modal-content input {
-  width: 100%;
-  margin: 0.5rem 0;
-  border-radius: 8px;
-  border: 1.5px solid #bbb;
-  padding: 0.8rem;
-  font-size: 1.07rem;
-  background: #fff;
-  color: #222;
-  transition: border .17s;
-}
-.modal-content input:focus {
-  outline: none;
-  border: 2px solid #2979ff;
-}
-.modal-content button[type="submit"], .google-btn {
-  width: 100%;
-  margin: 0.7rem 0 0.2rem 0;
-  background: #2979ff;
-  color: #fff;
-  border: none;
-  border-radius: 8px;
-  padding: 0.8rem 0;
-  font-size: 1.08rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition: background .18s;
-}
-.modal-content button[type="submit"]:hover, .google-btn:hover {
-  background: #1565c0;
-}
-.google-btn {
-  background: #4285F4;
-  margin-bottom: 0.5rem;
-}
-.google-btn:hover {
-  background: #357ae8;
-}
-.error-message {
-  color: #d32f2f;
-  font-size: 0.98rem;
-  text-align: left;
-  margin-top: 0.4rem;
-}
-.reset-password {
-  color: #2979ff;
-  text-decoration: underline;
-  cursor: pointer;
-  font-size: 0.98rem;
-  transition: color .18s;
-}
-.reset-password:hover { color: #d32f2f; }
-</style>
-
-<script>
-/* Account dropdown */
-document.getElementById('profileIcon').addEventListener('click', function(e) {
-  e.stopPropagation();
-  const menu = document.getElementById('accountMenu');
-  menu.classList.toggle('open');
-});
-document.addEventListener('click', function(e) {
-  document.getElementById('accountMenu').classList.remove('open');
-});
-
-/* Mobile drawer open/close */
-const hamburger = document.getElementById('hamburgerBtn');
-const drawer = document.getElementById('mobileDrawer');
-const backdrop = document.getElementById('drawerBackdrop');
-const closeBtn = document.getElementById('closeDrawerBtn');
-function openDrawer() {
-  drawer.classList.add('open');
-  backdrop.classList.add('open');
-  document.body.style.overflow = 'hidden';
-}
-function closeDrawer() {
-  drawer.classList.remove('open');
-  backdrop.classList.remove('open');
-  document.body.style.overflow = '';
-}
-hamburger.addEventListener('click', function(e) {
-  e.stopPropagation(); openDrawer();
-});
-closeBtn.addEventListener('click', closeDrawer);
-backdrop.addEventListener('click', closeDrawer);
-
-/* Highlight active nav link */
-const setActiveLink = (selector) => {
-  const links = document.querySelectorAll(selector);
-  const path = window.location.pathname.split('/').pop();
-  links.forEach(link => {
-    if (link.getAttribute('href') === path) {
-      link.classList.add('active');
-    }
-  });
-};
-setActiveLink('.navbar__links a');
-setActiveLink('.mobile-drawer a');
-
-/* Modal logic */
-function clearFormMessages() {
-  document.getElementById('loginError').style.display = 'none';
-  document.getElementById('signupError').style.display = 'none';
-  document.getElementById('resetError').style.display = 'none';
-}
-function openModal(mode) {
-  document.getElementById('authModal').style.display = 'block';
-  document.getElementById('loginFormContainer').style.display = (mode==='login') ? '' : 'none';
-  document.getElementById('signupFormContainer').style.display = (mode==='signup') ? '' : 'none';
-  document.getElementById('resetFormContainer').style.display = 'none';
-  clearFormMessages();
-}
-function closeModal() {
-  document.getElementById('authModal').style.display = 'none';
-  clearFormMessages();
-}
-document.getElementById('closeModal').onclick = closeModal;
-window.onclick = function(event) {
-  if (event.target === document.getElementById('authModal')) closeModal();
-};
-document.addEventListener('keydown', function(event) {
-  if (event.key === "Escape") closeModal();
-});
-
-/* Switch between forms */
-document.getElementById('showSignup').onclick = function(e) {
-  e.preventDefault(); openModal('signup');
-};
-document.getElementById('showLogin').onclick = function(e) {
-  e.preventDefault(); openModal('login');
-};
-document.getElementById('showLoginFromReset').onclick = function(e) {
-  e.preventDefault(); openModal('login');
-};
-document.getElementById('showReset').onclick = function(e) {
-  e.preventDefault();
-  document.getElementById('loginFormContainer').style.display = 'none';
-  document.getElementById('signupFormContainer').style.display = 'none';
-  document.getElementById('resetFormContainer').style.display = '';
-  clearFormMessages();
-};
-
-/* Dummy handlers for forms (replace with your own backend/auth logic) */
-document.getElementById('loginForm').onsubmit = function(e) {
-  e.preventDefault();
-  // Replace with actual login logic
-  closeModal();
-  alert('Logged in (demo)');
-};
-document.getElementById('signupForm').onsubmit = function(e) {
-  e.preventDefault();
-  // Replace with actual signup logic
-  closeModal();
-  alert('Signed up (demo)');
-};
-document.getElementById('resetForm').onsubmit = function(e) {
-  e.preventDefault();
-  // Replace with actual reset logic
-  closeModal();
-  alert('Password reset link sent (demo)');
-};
-document.querySelectorAll('.google-btn').forEach(btn => {
-  btn.onclick = function(e) {
-    e.preventDefault();
-    closeModal();
-    alert('Google sign-in (demo)');
-  };
-});
-
-/* Dummy sign out */
-function signOut() {
-  closeModal();
-  alert('Signed out (demo)');
-}
-</script>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
-      
-    </div>
-  </div>
-</div>
-<body>
-  <!-- Header -->
-  <!-- ... -->
-  <main style="padding: 3rem 1rem; text-align: center;">
-    <h1>Fleet</h1>
-    <p>All about the London bus fleet. Feature coming soon!</p>
-  </main>
-  <!-- Footer -->
-  <!-- ... -->
-  <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-app-compat.js"></script>
-  <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-auth-compat.js"></script>
-  <script src="main.js"></script>
-  <script src="navbar-loader.js"></script>
-</body>
+    <script src="navbar-loader.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-app-compat.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-auth-compat.js"></script>
+    <script src="main.js"></script>
+    <script src="fleet.js"></script>
+  </body>
 </html>

--- a/fleet.js
+++ b/fleet.js
@@ -1,0 +1,1835 @@
+(function () {
+  "use strict";
+
+  const STORAGE_KEY = "routeflow:fleet-state:v1";
+  const ADMIN_CODE = "fleet-admin";
+  const RARE_WORKING_THRESHOLD_MS = 30 * 24 * 60 * 60 * 1000;
+
+  const DROPDOWN_FIELDS = [
+    "operator",
+    "status",
+    "wrap",
+    "vehicleType",
+    "doors",
+    "engineType",
+    "engine",
+    "chassis",
+    "bodyType",
+    "garage",
+    "extras",
+    "length",
+  ];
+
+  const FIELD_LABELS = {
+    registration: "Registration",
+    fleetNumber: "Fleet number",
+    operator: "Operator",
+    status: "Status",
+    wrap: "Wrap",
+    vehicleType: "Vehicle type",
+    doors: "Doors",
+    engineType: "Engine type",
+    engine: "Engine",
+    chassis: "Chassis",
+    bodyType: "Body type",
+    registrationDate: "Registration date",
+    garage: "Garage",
+    extras: "Extras",
+    length: "Length",
+    isNewBus: "New bus",
+    isRareWorking: "Rare working",
+    lastUpdated: "Last updated",
+  };
+
+  const DEFAULT_STATE = {
+    options: {
+      operator: [
+        "Abellio London",
+        "Arriva London",
+        "Go-Ahead London",
+        "Metroline",
+        "Stagecoach London",
+      ],
+      status: ["Active", "Inactive", "Stored"],
+      wrap: ["Standard", "Heritage", "Advertising wrap", "Special event"],
+      vehicleType: ["Double Decker", "Single Decker"],
+      doors: ["1", "2", "3"],
+      engineType: ["Diesel", "Hybrid", "Electric", "Hydrogen"],
+      engine: [
+        "Alexander Dennis Enviro400EV",
+        "Volvo B5LH",
+        "Scania N250UD",
+        "Wrightbus Hydrogen",
+      ],
+      chassis: [
+        "Alexander Dennis",
+        "Scania N-series",
+        "Volvo B5LH",
+        "Wrightbus StreetDeck",
+      ],
+      bodyType: [
+        "Alexander Dennis Enviro400 MMC",
+        "Wright Gemini 3",
+        "Wright StreetDeck",
+        "Caetano e.City Gold",
+      ],
+      garage: [
+        "QB (Battersea)",
+        "HT (Holloway)",
+        "LI (Leyton)",
+        "NX (New Cross)",
+        "WJ (Waterloo)",
+      ],
+      extras: [
+        "New Bus",
+        "Rare Working",
+        "Heritage Fleet",
+        "Route Branding",
+        "Night Bus Allocation",
+        "Training Vehicle",
+      ],
+      length: ["8.9m", "10.2m", "10.6m", "11.2m", "12.4m"],
+    },
+    buses: {
+      BV72YKD: {
+        regKey: "BV72YKD",
+        registration: "BV72 YKD",
+        fleetNumber: "4032",
+        operator: "Abellio London",
+        status: "Active",
+        wrap: "Standard",
+        vehicleType: "Double Decker",
+        doors: "2",
+        engineType: "Electric",
+        engine: "Alexander Dennis Enviro400EV",
+        chassis: "Alexander Dennis",
+        bodyType: "Alexander Dennis Enviro400 MMC",
+        registrationDate: "2023-01-12",
+        garage: "QB (Battersea)",
+        extras: ["New Bus", "Route Branding"],
+        length: "10.6m",
+        isNewBus: true,
+        isRareWorking: false,
+        createdAt: "2023-01-12T00:00:00.000Z",
+        lastUpdated: "2024-05-12T10:32:00.000Z",
+        lastSeenAt: "2024-05-10T08:12:00.000Z",
+        lastSeenRoute: "Route 344",
+        routeHistory: {
+          344: "2024-05-10T08:12:00.000Z",
+        },
+        rareWorkings: [],
+      },
+      LTZ1000: {
+        regKey: "LTZ1000",
+        registration: "LTZ 1000",
+        fleetNumber: "LT1",
+        operator: "Go-Ahead London",
+        status: "Active",
+        wrap: "Heritage",
+        vehicleType: "Double Decker",
+        doors: "2",
+        engineType: "Hybrid",
+        engine: "Volvo B5LH",
+        chassis: "Volvo B5LH",
+        bodyType: "Wright Gemini 3",
+        registrationDate: "2015-02-28",
+        garage: "QB (Battersea)",
+        extras: ["Heritage Fleet", "Rare Working"],
+        length: "11.2m",
+        isNewBus: false,
+        isRareWorking: true,
+        createdAt: "2015-02-28T00:00:00.000Z",
+        lastUpdated: "2024-03-18T09:15:00.000Z",
+        lastSeenAt: "2024-05-01T06:40:00.000Z",
+        lastSeenRoute: "Route 11",
+        routeHistory: {
+          11: "2024-05-01T06:40:00.000Z",
+          211: "2024-02-19T07:20:00.000Z",
+        },
+        rareWorkings: [
+          {
+            routeKey: "211",
+            route: "211",
+            lastSeen: "2024-02-19T07:20:00.000Z",
+          },
+        ],
+      },
+      SN68AEO: {
+        regKey: "SN68AEO",
+        registration: "SN68 AEO",
+        fleetNumber: "11056",
+        operator: "Stagecoach London",
+        status: "Active",
+        wrap: "Advertising wrap",
+        vehicleType: "Double Decker",
+        doors: "2",
+        engineType: "Hybrid",
+        engine: "Scania N250UD",
+        chassis: "Scania N-series",
+        bodyType: "Alexander Dennis Enviro400 MMC",
+        registrationDate: "2018-11-02",
+        garage: "LI (Leyton)",
+        extras: ["Night Bus Allocation"],
+        length: "10.6m",
+        isNewBus: false,
+        isRareWorking: false,
+        createdAt: "2018-11-02T00:00:00.000Z",
+        lastUpdated: "2024-04-06T15:45:00.000Z",
+        lastSeenAt: "2024-04-06T05:45:00.000Z",
+        lastSeenRoute: "Route 97",
+        routeHistory: {
+          97: "2024-04-06T05:45:00.000Z",
+        },
+        rareWorkings: [],
+      },
+    },
+    pendingChanges: [],
+  };
+
+  const state = loadState();
+  let isAdmin = false;
+  let toastTimeout = null;
+
+  document.addEventListener("DOMContentLoaded", () => {
+    const elements = getElements();
+    if (!elements) {
+      return;
+    }
+
+    synchronizeOptionsWithBuses();
+    sortOptionLists();
+    populateAllSelects(elements);
+    renderOptionList(elements, elements.optionCategory.value);
+    renderTable(elements);
+    renderHighlights(elements);
+    updateStats(elements);
+    updatePendingBadge(elements);
+    renderPendingList(elements);
+
+    attachEvents(elements);
+  });
+
+  function getElements() {
+    const searchInput = document.getElementById("searchReg");
+    const filterNew = document.getElementById("filterNew");
+    const filterRare = document.getElementById("filterRare");
+    const resetFilters = document.getElementById("resetFilters");
+    const tableBody = document.getElementById("fleetTableBody");
+    const emptyState = document.getElementById("fleetEmpty");
+    const fleetForm = document.getElementById("fleetForm");
+    const formFeedback = document.getElementById("formFeedback");
+    const registrationInput = document.getElementById("busRegistration");
+    const clearFormButton = document.getElementById("clearForm");
+    const optionForm = document.getElementById("optionForm");
+    const optionCategory = document.getElementById("optionCategory");
+    const optionList = document.getElementById("optionList");
+    const adminToggle = document.getElementById("adminToggle");
+    const adminPanel = document.getElementById("adminPanel");
+    const pendingContainer = document.getElementById("pendingContainer");
+    const pendingCount = document.getElementById("pendingCount");
+    const toast = document.getElementById("fleetToast");
+    const ingestForm = document.getElementById("ingestForm");
+    const ingestInput = document.getElementById("ingestInput");
+    const ingestFeedback = document.getElementById("ingestFeedback");
+    const clearIngestButton = document.getElementById("clearIngest");
+    const fetchArrivalsButton = document.getElementById("fetchArrivals");
+    const ingestIds = document.getElementById("ingestIds");
+    const ingestAppId = document.getElementById("ingestAppId");
+    const ingestAppKey = document.getElementById("ingestAppKey");
+
+    if (!tableBody || !fleetForm) {
+      return null;
+    }
+
+    return {
+      searchInput,
+      filterNew,
+      filterRare,
+      resetFilters,
+      tableBody,
+      emptyState,
+      fleetForm,
+      formFeedback,
+      registrationInput,
+      clearFormButton,
+      optionForm,
+      optionCategory,
+      optionList,
+      adminToggle,
+      adminPanel,
+      pendingContainer,
+      pendingCount,
+      toast,
+      ingestForm,
+      ingestInput,
+      ingestFeedback,
+      clearIngestButton,
+      fetchArrivalsButton,
+      ingestIds,
+      ingestAppId,
+      ingestAppKey,
+      selects: {
+        fleetNumber: document.getElementById("fleetNumber"),
+        operator: document.getElementById("operatorSelect"),
+        status: document.getElementById("statusSelect"),
+        wrap: document.getElementById("wrapSelect"),
+        vehicleType: document.getElementById("vehicleTypeSelect"),
+        doors: document.getElementById("doorsSelect"),
+        engineType: document.getElementById("engineTypeSelect"),
+        engine: document.getElementById("engineSelect"),
+        chassis: document.getElementById("chassisSelect"),
+        bodyType: document.getElementById("bodyTypeSelect"),
+        registrationDate: document.getElementById("registrationDate"),
+        garage: document.getElementById("garageSelect"),
+        extras: document.getElementById("extrasSelect"),
+        length: document.getElementById("lengthSelect"),
+        isNewBus: document.getElementById("isNewBus"),
+        isRareWorking: document.getElementById("isRareWorking"),
+      },
+    };
+  }
+
+  function attachEvents(elements) {
+    const {
+      searchInput,
+      filterNew,
+      filterRare,
+      resetFilters,
+      fleetForm,
+      formFeedback,
+      registrationInput,
+      clearFormButton,
+      optionForm,
+      optionCategory,
+      adminToggle,
+      adminPanel,
+      pendingContainer,
+      ingestForm,
+      clearIngestButton,
+      fetchArrivalsButton,
+      ingestIds,
+    } = elements;
+
+    if (searchInput) {
+      searchInput.addEventListener("input", () => renderTable(elements));
+    }
+    if (filterNew) {
+      filterNew.addEventListener("change", () => renderTable(elements));
+    }
+    if (filterRare) {
+      filterRare.addEventListener("change", () => renderTable(elements));
+    }
+    if (resetFilters) {
+      resetFilters.addEventListener("click", () => {
+        if (searchInput) searchInput.value = "";
+        if (filterNew) filterNew.checked = false;
+        if (filterRare) filterRare.checked = false;
+        renderTable(elements);
+      });
+    }
+
+    if (registrationInput) {
+      registrationInput.addEventListener("blur", () => prefillForm(elements));
+      registrationInput.addEventListener("input", () =>
+        normalizeRegistrationInput(registrationInput),
+      );
+    }
+
+    fleetForm.addEventListener("submit", (event) => {
+      event.preventDefault();
+      submitForm(elements);
+    });
+
+    if (clearFormButton) {
+      clearFormButton.addEventListener("click", () => {
+        clearForm(elements);
+        if (formFeedback) {
+          setFormFeedback(formFeedback, "", "");
+        }
+      });
+    }
+
+    if (optionForm) {
+      optionForm.addEventListener("submit", (event) => {
+        event.preventDefault();
+        addNewOption(elements);
+      });
+    }
+
+    if (optionCategory) {
+      optionCategory.addEventListener("change", () =>
+        renderOptionList(elements, optionCategory.value),
+      );
+    }
+
+    if (adminToggle && adminPanel) {
+      adminToggle.addEventListener("click", () => {
+        toggleAdmin(elements);
+      });
+    }
+
+    if (pendingContainer) {
+      pendingContainer.addEventListener("click", (event) => {
+        const button = event.target.closest("button[data-action]");
+        if (!button) return;
+        const id = button.getAttribute("data-id");
+        if (!id) return;
+        if (button.dataset.action === "approve") {
+          approvePending(elements, id);
+        } else if (button.dataset.action === "reject") {
+          rejectPending(elements, id);
+        }
+      });
+    }
+
+    if (ingestForm) {
+      ingestForm.addEventListener("submit", (event) => {
+        event.preventDefault();
+        processIngestTextarea(elements);
+      });
+    }
+
+    if (clearIngestButton) {
+      clearIngestButton.addEventListener("click", () => {
+        clearIngest(elements);
+      });
+    }
+
+    if (fetchArrivalsButton) {
+      fetchArrivalsButton.addEventListener("click", () => {
+        fetchArrivalsFromTfL(elements);
+      });
+    }
+
+    if (ingestIds) {
+      ingestIds.addEventListener("blur", () => {
+        ingestIds.value = formatIdsForInput(ingestIds.value);
+      });
+    }
+  }
+
+  function normalizeRegistrationInput(input) {
+    if (!input) return;
+    input.value = input.value.toUpperCase();
+  }
+
+  function loadState() {
+    const base = clone(DEFAULT_STATE);
+    try {
+      const raw = window.localStorage.getItem(STORAGE_KEY);
+      if (!raw) {
+        return base;
+      }
+      const parsed = JSON.parse(raw);
+      if (parsed && typeof parsed === "object") {
+        if (parsed.options) {
+          base.options = mergeOptions(DEFAULT_STATE.options, parsed.options);
+        }
+        if (parsed.buses && typeof parsed.buses === "object") {
+          base.buses = {};
+          Object.keys(parsed.buses).forEach((key) => {
+            const bus = parsed.buses[key];
+            if (!bus) return;
+            const regKey =
+              bus.regKey || normaliseRegKey(bus.registration || key);
+            if (!regKey) return;
+            base.buses[regKey] = {
+              regKey,
+              ...bus,
+              registration: bus.registration || key,
+            };
+          });
+        }
+        if (Array.isArray(parsed.pendingChanges)) {
+          base.pendingChanges = parsed.pendingChanges
+            .map((change) => ({
+              ...change,
+              regKey:
+                change.regKey || normaliseRegKey(change.registration || ""),
+            }))
+            .filter((change) => Boolean(change.regKey));
+        }
+      }
+    } catch (error) {
+      console.warn("Failed to load fleet state:", error);
+    }
+    return base;
+  }
+
+  function saveState() {
+    try {
+      const serialised = JSON.stringify(state);
+      window.localStorage.setItem(STORAGE_KEY, serialised);
+    } catch (error) {
+      console.warn("Unable to save fleet state:", error);
+    }
+  }
+
+  function clone(value) {
+    if (typeof window.structuredClone === "function") {
+      return window.structuredClone(value);
+    }
+    return JSON.parse(JSON.stringify(value));
+  }
+
+  function mergeOptions(defaults, saved) {
+    const merged = {};
+    const keys = new Set([
+      ...Object.keys(defaults || {}),
+      ...Object.keys(saved || {}),
+    ]);
+    keys.forEach((key) => {
+      const defaultList = Array.isArray(defaults?.[key]) ? defaults[key] : [];
+      const savedList = Array.isArray(saved?.[key]) ? saved[key] : [];
+      merged[key] = Array.from(new Set([...defaultList, ...savedList]));
+    });
+    return merged;
+  }
+
+  function normaliseRegKey(value) {
+    return (value || "")
+      .toString()
+      .toUpperCase()
+      .replace(/[^A-Z0-9]/g, "");
+  }
+
+  function synchronizeOptionsWithBuses() {
+    let updated = false;
+    Object.values(state.buses).forEach((bus) => {
+      DROPDOWN_FIELDS.forEach((field) => {
+        if (field === "extras") {
+          if (Array.isArray(bus.extras)) {
+            bus.extras.forEach((tag) => {
+              updated = ensureOption(field, tag) || updated;
+            });
+          }
+        } else {
+          const value = bus[field];
+          if (value) {
+            updated = ensureOption(field, value) || updated;
+          }
+        }
+      });
+    });
+    if (updated) {
+      sortOptionLists();
+      saveState();
+    }
+  }
+
+  function ensureOption(field, value) {
+    if (!value) return false;
+    if (!Array.isArray(state.options[field])) {
+      state.options[field] = [];
+    }
+    if (!state.options[field].includes(value)) {
+      state.options[field].push(value);
+      return true;
+    }
+    return false;
+  }
+
+  function sortOptionLists() {
+    Object.keys(state.options).forEach((key) => {
+      const list = state.options[key];
+      if (Array.isArray(list)) {
+        list.sort((a, b) =>
+          a.localeCompare(b, undefined, { sensitivity: "base" }),
+        );
+      }
+    });
+  }
+
+  function populateAllSelects(elements) {
+    const { selects } = elements;
+    populateSelect(selects.operator, state.options.operator, {
+      placeholder: "Select operator",
+    });
+    populateSelect(selects.status, state.options.status, {
+      placeholder: "Select status",
+    });
+    populateSelect(selects.wrap, state.options.wrap, {
+      placeholder: "Select wrap",
+    });
+    populateSelect(selects.vehicleType, state.options.vehicleType, {
+      placeholder: "Select type",
+    });
+    populateSelect(selects.doors, state.options.doors, {
+      placeholder: "Select doors",
+    });
+    populateSelect(selects.engineType, state.options.engineType, {
+      placeholder: "Select engine type",
+    });
+    populateSelect(selects.engine, state.options.engine, {
+      placeholder: "Select engine",
+    });
+    populateSelect(selects.chassis, state.options.chassis, {
+      placeholder: "Select chassis",
+    });
+    populateSelect(selects.bodyType, state.options.bodyType, {
+      placeholder: "Select body type",
+    });
+    populateSelect(selects.garage, state.options.garage, {
+      placeholder: "Select garage",
+    });
+    populateSelect(selects.length, state.options.length, {
+      placeholder: "Select length",
+    });
+    populateSelect(selects.extras, state.options.extras, { multiple: true });
+  }
+
+  function populateSelect(select, values, options = {}) {
+    if (!select) return;
+    const { placeholder, multiple } = options;
+    const previousSelection = multiple
+      ? Array.from(select.selectedOptions).map((option) => option.value)
+      : [select.value];
+    select.innerHTML = "";
+    if (!multiple && placeholder) {
+      const option = document.createElement("option");
+      option.value = "";
+      option.textContent = placeholder;
+      select.appendChild(option);
+    }
+    (values || []).forEach((value) => {
+      const option = document.createElement("option");
+      option.value = value;
+      option.textContent = value;
+      if (multiple) {
+        option.selected = previousSelection.includes(value);
+      } else if (previousSelection[0] === value) {
+        option.selected = true;
+      }
+      select.appendChild(option);
+    });
+  }
+
+  function renderTable(elements) {
+    const { tableBody, emptyState, searchInput, filterNew, filterRare } =
+      elements;
+    if (!tableBody) return;
+
+    const query = (searchInput?.value || "").trim().toUpperCase();
+    const normalisedQuery = normaliseRegKey(query);
+    const onlyNew = Boolean(filterNew?.checked);
+    const onlyRare = Boolean(filterRare?.checked);
+
+    const rows = [];
+    const entries = Object.values(state.buses)
+      .map((bus) => ({ ...bus }))
+      .sort((a, b) => a.regKey.localeCompare(b.regKey));
+
+    const hasPendingByReg = new Map();
+    state.pendingChanges.forEach((change) => {
+      hasPendingByReg.set(change.regKey, true);
+    });
+
+    entries.forEach((bus) => {
+      if (
+        query &&
+        !bus.registration.toUpperCase().includes(query) &&
+        !bus.regKey.includes(normalisedQuery)
+      ) {
+        return;
+      }
+      if (onlyNew && !bus.isNewBus) {
+        return;
+      }
+      if (onlyRare && !bus.isRareWorking) {
+        return;
+      }
+      const pending = Boolean(hasPendingByReg.get(bus.regKey));
+      rows.push(createTableRow(bus, pending));
+    });
+
+    tableBody.innerHTML = rows.join("");
+    if (emptyState) {
+      emptyState.hidden = rows.length > 0;
+    }
+  }
+
+  function createTableRow(bus, hasPending) {
+    const badges = [];
+    if (bus.isNewBus) {
+      badges.push('<span class="badge badge--new">New bus</span>');
+    }
+    if (bus.isRareWorking) {
+      badges.push('<span class="badge badge--rare">Rare working</span>');
+    }
+    if (hasPending) {
+      badges.push(
+        '<span class="badge badge--pending" title="Awaiting admin approval">Pending</span>',
+      );
+    }
+
+    return `
+      <tr>
+        <th scope="row">
+          <span class="fleet-row__reg">${escapeHtml(bus.registration)}</span>
+          ${badges.join("")}
+        </th>
+        <td>${escapeHtml(bus.fleetNumber || "—")}</td>
+        <td>${escapeHtml(bus.operator || "—")}</td>
+        <td>${renderStatus(bus.status)}</td>
+        <td>${escapeHtml(bus.vehicleType || "—")}</td>
+        <td>${escapeHtml(bus.garage || "—")}</td>
+        <td>${escapeHtml(bus.wrap || "—")}</td>
+        <td>${escapeHtml(bus.doors || "—")}</td>
+        <td>${escapeHtml(bus.engineType || "—")}</td>
+        <td>${escapeHtml(bus.engine || "—")}</td>
+        <td>${escapeHtml(bus.chassis || "—")}</td>
+        <td>${escapeHtml(bus.bodyType || "—")}</td>
+        <td>${formatDate(bus.registrationDate)}</td>
+        <td>${renderExtras(bus.extras)}</td>
+        <td>${escapeHtml(bus.length || "—")}</td>
+        <td>${formatDateTime(bus.lastUpdated)}</td>
+      </tr>
+    `;
+  }
+
+  function renderStatus(status) {
+    if (!status) return "—";
+    const normalised = status.toLowerCase();
+    if (normalised === "active") {
+      return `<span class="status-badge status-badge--active">${escapeHtml(status)}</span>`;
+    }
+    if (normalised === "inactive" || normalised === "stored") {
+      return `<span class="status-badge status-badge--inactive">${escapeHtml(status)}</span>`;
+    }
+    return `<span class="status-badge">${escapeHtml(status)}</span>`;
+  }
+
+  function renderExtras(extras) {
+    if (!Array.isArray(extras) || extras.length === 0) {
+      return "—";
+    }
+    return `<div class="chip-group">${extras
+      .map((tag) => `<span class="chip">${escapeHtml(tag)}</span>`)
+      .join("")}</div>`;
+  }
+
+  function renderHighlights(elements) {
+    const newList = document.getElementById("newBusList");
+    const rareList = document.getElementById("rareWorkingList");
+    if (!newList || !rareList) return;
+
+    const buses = Object.values(state.buses);
+    const newest = buses
+      .filter((bus) => bus.isNewBus)
+      .sort(
+        (a, b) =>
+          new Date(b.createdAt || b.registrationDate || 0) -
+          new Date(a.createdAt || a.registrationDate || 0),
+      );
+    const rare = buses
+      .filter((bus) => bus.isRareWorking)
+      .sort((a, b) => getRareSortTime(b) - getRareSortTime(a));
+
+    newList.innerHTML = newest.length
+      ? newest
+          .slice(0, 6)
+          .map((bus) => highlightItem(bus, "new"))
+          .join("")
+      : '<li class="pending-empty">No vehicles currently flagged as new.</li>';
+
+    rareList.innerHTML = rare.length
+      ? rare
+          .slice(0, 6)
+          .map((bus) => highlightItem(bus, "rare"))
+          .join("")
+      : '<li class="pending-empty">No rare workings logged yet.</li>';
+  }
+
+  function highlightItem(bus, type) {
+    const subtitle =
+      type === "rare" ? formatRareHighlight(bus) : formatNewHighlight(bus);
+    return `<li><span>${escapeHtml(bus.registration)}</span><small>${escapeHtml(subtitle)}</small></li>`;
+  }
+
+  function formatNewHighlight(bus) {
+    const parts = [];
+    if (bus.operator) {
+      parts.push(bus.operator);
+    }
+    const registrationDate = formatDate(bus.registrationDate);
+    if (registrationDate && registrationDate !== "—") {
+      parts.push(`Reg. ${registrationDate}`);
+    }
+    if (!parts.length && bus.garage) {
+      parts.push(bus.garage);
+    }
+    return parts.length ? parts.join(" • ") : "Awaiting details";
+  }
+
+  function formatRareHighlight(bus) {
+    const latest = getLatestRareWorking(bus);
+    if (latest) {
+      const dateLabel = formatDate(latest.lastSeen);
+      const routeLabel = latest.route || latest.routeKey || "Rare working";
+      const parts = [routeLabel];
+      if (dateLabel && dateLabel !== "—") {
+        parts.push(dateLabel);
+      }
+      return parts.join(" • ");
+    }
+    if (bus.lastSeenRoute) {
+      const dateLabel = formatDate(bus.lastSeenAt);
+      const parts = [bus.lastSeenRoute];
+      if (dateLabel && dateLabel !== "—") {
+        parts.push(dateLabel);
+      }
+      return parts.join(" • ");
+    }
+    return "Awaiting live sightings";
+  }
+
+  function getRareSortTime(bus) {
+    const latest = getLatestRareWorking(bus);
+    if (latest) {
+      const date = new Date(latest.lastSeen || 0);
+      if (!Number.isNaN(date.getTime())) {
+        return date.getTime();
+      }
+    }
+    const fallback = new Date(bus.lastUpdated || 0);
+    return Number.isNaN(fallback.getTime()) ? 0 : fallback.getTime();
+  }
+
+  function getLatestRareWorking(bus) {
+    if (!bus || !Array.isArray(bus.rareWorkings) || !bus.rareWorkings.length) {
+      return null;
+    }
+    return bus.rareWorkings
+      .slice()
+      .sort((a, b) => new Date(b.lastSeen || 0) - new Date(a.lastSeen || 0))[0];
+  }
+
+  function updateStats(elements) {
+    const total = Object.keys(state.buses).length;
+    const newCount = Object.values(state.buses).filter(
+      (bus) => bus.isNewBus,
+    ).length;
+    const rareCount = Object.values(state.buses).filter(
+      (bus) => bus.isRareWorking,
+    ).length;
+    const pending = state.pendingChanges.length;
+
+    setText("fleetTotal", total);
+    setText("fleetNew", newCount);
+    setText("fleetRare", rareCount);
+    setText("fleetPending", pending);
+  }
+
+  function updatePendingBadge(elements) {
+    if (!elements.pendingCount) return;
+    const count = state.pendingChanges.length;
+    elements.pendingCount.textContent =
+      count === 1 ? "1 pending" : `${count} pending`;
+  }
+
+  function setText(id, value) {
+    const el = document.getElementById(id);
+    if (el) {
+      el.textContent = String(value);
+    }
+  }
+
+  function submitForm(elements) {
+    const { fleetForm, formFeedback, selects, registrationInput } = elements;
+    if (!fleetForm) return;
+
+    const formData = new FormData(fleetForm);
+    const registrationRaw = (formData.get("registration") || "")
+      .toString()
+      .trim();
+    const registration = registrationRaw.toUpperCase();
+    const regKey = normaliseRegKey(registration);
+
+    if (!registration || !regKey) {
+      setFormFeedback(
+        formFeedback,
+        "Please enter a valid registration.",
+        "error",
+      );
+      return;
+    }
+
+    const existing = state.buses[regKey];
+    const payload = buildPayload(
+      formData,
+      registration,
+      regKey,
+      existing,
+      selects,
+    );
+
+    if (!existing) {
+      state.buses[regKey] = payload;
+      synchronizeOptionsWithBus(payload);
+      sortOptionLists();
+      saveState();
+      populateAllSelects(elements);
+      renderTable(elements);
+      renderHighlights(elements);
+      updateStats(elements);
+      showToast(
+        elements.toast,
+        `Created new profile for ${registration}.`,
+        "success",
+      );
+      setFormFeedback(
+        formFeedback,
+        `Created new profile for ${registration}.`,
+        "success",
+      );
+      prefillForm(elements, payload);
+      return;
+    }
+
+    const pendingChange = {
+      id: `pending-${Date.now()}`,
+      regKey,
+      registration,
+      submittedAt: new Date().toISOString(),
+      data: payload,
+    };
+
+    const existingIndex = state.pendingChanges.findIndex(
+      (change) => change.regKey === regKey,
+    );
+    if (existingIndex >= 0) {
+      state.pendingChanges[existingIndex] = pendingChange;
+    } else {
+      state.pendingChanges.push(pendingChange);
+    }
+
+    saveState();
+    renderTable(elements);
+    updateStats(elements);
+    updatePendingBadge(elements);
+    if (isAdmin) {
+      renderPendingList(elements);
+    }
+    showToast(
+      elements.toast,
+      `Update for ${registration} submitted for approval.`,
+      "info",
+    );
+    setFormFeedback(
+      formFeedback,
+      `Update for ${registration} submitted for approval.`,
+      "pending",
+    );
+  }
+
+  function buildPayload(formData, registration, regKey, existing, selects) {
+    const extrasSelected = Array.from(
+      selects.extras?.selectedOptions || [],
+    ).map((option) => option.value);
+    const isNewBus = Boolean(formData.get("isNewBus"));
+    const isRareWorking = Boolean(formData.get("isRareWorking"));
+    const extrasSet = new Set(extrasSelected);
+    if (isNewBus) extrasSet.add("New Bus");
+    if (isRareWorking) extrasSet.add("Rare Working");
+
+    const registrationDateInput = formData.get("registrationDate");
+    const todayISO = new Date().toISOString().slice(0, 10);
+    let registrationDate = (registrationDateInput || "").toString();
+    if (!existing && !registrationDate) {
+      registrationDate = todayISO;
+    }
+    if (!registrationDate && existing) {
+      registrationDate = existing.registrationDate || "";
+    }
+
+    const nowIso = new Date().toISOString();
+
+    return {
+      regKey,
+      registration,
+      fleetNumber: (formData.get("fleetNumber") || "").toString().trim(),
+      operator: formData.get("operator") || "",
+      status: formData.get("status") || "",
+      wrap: formData.get("wrap") || "",
+      vehicleType: formData.get("vehicleType") || "",
+      doors: formData.get("doors") || "",
+      engineType: formData.get("engineType") || "",
+      engine: formData.get("engine") || "",
+      chassis: formData.get("chassis") || "",
+      bodyType: formData.get("bodyType") || "",
+      registrationDate,
+      garage: formData.get("garage") || "",
+      extras: Array.from(extrasSet),
+      length: formData.get("length") || "",
+      isNewBus,
+      isRareWorking,
+      createdAt: existing?.createdAt || nowIso,
+      lastUpdated: nowIso,
+    };
+  }
+
+  function synchronizeOptionsWithBus(bus) {
+    DROPDOWN_FIELDS.forEach((field) => {
+      if (field === "extras") {
+        (bus.extras || []).forEach((tag) => ensureOption(field, tag));
+      } else {
+        ensureOption(field, bus[field]);
+      }
+    });
+  }
+
+  function renderPendingList(elements) {
+    const { pendingContainer, adminPanel } = elements;
+    if (!pendingContainer) return;
+
+    if (!isAdmin) {
+      pendingContainer.innerHTML =
+        '<p class="pending-empty">Enter the access code to review pending changes.</p>';
+      return;
+    }
+
+    if (!state.pendingChanges.length) {
+      pendingContainer.innerHTML =
+        '<p class="pending-empty">No updates waiting for approval.</p>';
+      return;
+    }
+
+    const cards = state.pendingChanges
+      .slice()
+      .sort(
+        (a, b) => new Date(b.submittedAt || 0) - new Date(a.submittedAt || 0),
+      )
+      .map((change) => pendingCard(change))
+      .join("");
+
+    pendingContainer.innerHTML = cards;
+  }
+
+  function pendingCard(change) {
+    const current = state.buses[change.regKey];
+    const diffRows = buildDiffRows(current, change.data || {});
+    const submitted = formatDateTime(change.submittedAt);
+
+    return `
+      <article class="pending-card">
+        <div class="pending-card__header">
+          <h4>${escapeHtml(change.registration)}</h4>
+          <span class="pending-card__meta">Submitted ${escapeHtml(submitted || "recently")}</span>
+        </div>
+        <ul class="pending-card__changes">
+          ${diffRows.join("")}
+        </ul>
+        <div class="pending-card__actions">
+          <button class="button-primary" data-action="approve" data-id="${escapeHtml(change.id)}">Approve</button>
+          <button class="button-tertiary" data-action="reject" data-id="${escapeHtml(change.id)}">Reject</button>
+        </div>
+      </article>
+    `;
+  }
+
+  function buildDiffRows(current, proposed) {
+    const rows = [];
+    const fields = [
+      "fleetNumber",
+      "operator",
+      "status",
+      "wrap",
+      "vehicleType",
+      "doors",
+      "engineType",
+      "engine",
+      "chassis",
+      "bodyType",
+      "registrationDate",
+      "garage",
+      "extras",
+      "length",
+      "isNewBus",
+      "isRareWorking",
+    ];
+
+    fields.forEach((field) => {
+      const proposedValue = proposed[field];
+      const currentValue = current ? current[field] : undefined;
+      if (valuesEqual(currentValue, proposedValue)) {
+        return;
+      }
+      rows.push(`
+        <li>
+          <span class="pending-card__label">${escapeHtml(FIELD_LABELS[field] || field)}</span>
+          <span class="pending-card__value">
+            <span>
+              <strong>${escapeHtml(formatFieldValue(proposedValue, field))}</strong>
+              <span class="arrow" aria-hidden="true">&larr; from</span>
+              <span>${escapeHtml(formatFieldValue(currentValue, field))}</span>
+            </span>
+          </span>
+        </li>
+      `);
+    });
+
+    if (!rows.length) {
+      rows.push(
+        '<li><span class="pending-card__label">No changes detected</span></li>',
+      );
+    }
+
+    return rows;
+  }
+
+  function formatFieldValue(value, field) {
+    if (Array.isArray(value)) {
+      return value.length ? value.join(", ") : "—";
+    }
+    if (typeof value === "boolean") {
+      return value ? "Yes" : "No";
+    }
+    if (
+      field === "registrationDate" ||
+      field === "lastUpdated" ||
+      field === "createdAt"
+    ) {
+      return formatDate(value);
+    }
+    return value ? value.toString() : "—";
+  }
+
+  function valuesEqual(a, b) {
+    if (Array.isArray(a) || Array.isArray(b)) {
+      const arrA = Array.isArray(a) ? [...a].sort() : [];
+      const arrB = Array.isArray(b) ? [...b].sort() : [];
+      return arrA.join("|") === arrB.join("|");
+    }
+    return (a ?? "") === (b ?? "");
+  }
+
+  function approvePending(elements, id) {
+    const index = state.pendingChanges.findIndex((change) => change.id === id);
+    if (index === -1) return;
+    const change = state.pendingChanges[index];
+    const regKey = change.regKey;
+    state.buses[regKey] = {
+      ...state.buses[regKey],
+      ...change.data,
+      regKey,
+      registration: change.registration,
+      lastUpdated: new Date().toISOString(),
+    };
+    synchronizeOptionsWithBus(state.buses[regKey]);
+    state.pendingChanges.splice(index, 1);
+    sortOptionLists();
+    saveState();
+    populateAllSelects(elements);
+    renderTable(elements);
+    renderHighlights(elements);
+    updateStats(elements);
+    updatePendingBadge(elements);
+    renderPendingList(elements);
+    showToast(
+      elements.toast,
+      `Update for ${change.registration} approved.`,
+      "success",
+    );
+  }
+
+  function rejectPending(elements, id) {
+    const index = state.pendingChanges.findIndex((change) => change.id === id);
+    if (index === -1) return;
+    const change = state.pendingChanges[index];
+    state.pendingChanges.splice(index, 1);
+    saveState();
+    updatePendingBadge(elements);
+    renderPendingList(elements);
+    showToast(
+      elements.toast,
+      `Update for ${change.registration} rejected.`,
+      "info",
+    );
+  }
+
+  function toggleAdmin(elements) {
+    const { adminToggle, adminPanel } = elements;
+    if (!adminToggle || !adminPanel) return;
+
+    if (!isAdmin) {
+      const code = window.prompt("Enter the admin access code to continue");
+      if (code !== ADMIN_CODE) {
+        showToast(elements.toast, "Incorrect admin code.", "error");
+        return;
+      }
+      isAdmin = true;
+      adminToggle.textContent = "Hide admin tools";
+      adminToggle.setAttribute("aria-expanded", "true");
+      adminPanel.hidden = false;
+      renderPendingList(elements);
+      return;
+    }
+
+    const expanded = adminToggle.getAttribute("aria-expanded") === "true";
+    adminToggle.setAttribute("aria-expanded", String(!expanded));
+    adminPanel.hidden = expanded;
+    adminToggle.textContent = expanded
+      ? "Access admin tools"
+      : "Hide admin tools";
+    if (!expanded) {
+      renderPendingList(elements);
+    }
+  }
+
+  function renderOptionList(elements, field) {
+    const { optionList } = elements;
+    if (!optionList) return;
+    const options = state.options[field] || [];
+    if (!options.length) {
+      optionList.innerHTML =
+        '<li class="option-empty">No options yet for this field.</li>';
+      return;
+    }
+    optionList.innerHTML = options
+      .map((value) => `<li>${escapeHtml(value)}</li>`)
+      .join("");
+  }
+
+  function addNewOption(elements) {
+    const { optionForm, optionCategory } = elements;
+    if (!optionForm || !optionCategory) return;
+    const formData = new FormData(optionForm);
+    const field = formData.get("category");
+    let value = (formData.get("value") || "").toString().trim();
+    if (!field || !value) {
+      showToast(
+        elements.toast,
+        "Choose a field and enter a value first.",
+        "error",
+      );
+      return;
+    }
+    value = capitalise(value);
+    if (!Array.isArray(state.options[field])) {
+      state.options[field] = [];
+    }
+    if (state.options[field].includes(value)) {
+      showToast(elements.toast, "That option already exists.", "info");
+      return;
+    }
+    state.options[field].push(value);
+    sortOptionLists();
+    saveState();
+    populateAllSelects(elements);
+    renderOptionList(elements, field);
+    optionForm.reset();
+    optionCategory.value = field;
+    showToast(
+      elements.toast,
+      `Added "${value}" to ${FIELD_LABELS[field] || field}.`,
+      "success",
+    );
+  }
+
+  function processIngestTextarea(elements) {
+    const { ingestInput } = elements;
+    if (!ingestInput) return;
+    const raw = ingestInput.value || "";
+    if (!raw.trim()) {
+      setIngestFeedback(
+        elements.ingestFeedback,
+        "Paste a TfL arrivals response first.",
+        "error",
+      );
+      return;
+    }
+    let parsed;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (error) {
+      setIngestFeedback(
+        elements.ingestFeedback,
+        "The TfL arrivals payload is not valid JSON.",
+        "error",
+      );
+      return;
+    }
+    handleArrivalRecords(elements, parsed, "manual");
+  }
+
+  function clearIngest(elements) {
+    const { ingestInput, ingestFeedback } = elements;
+    if (ingestInput) {
+      ingestInput.value = "";
+    }
+    setIngestFeedback(ingestFeedback, "", "");
+  }
+
+  function fetchArrivalsFromTfL(elements) {
+    const {
+      ingestIds,
+      ingestAppId,
+      ingestAppKey,
+      ingestFeedback,
+      ingestInput,
+    } = elements;
+    const idsNormalised = formatIdsForInput(ingestIds?.value || "");
+    if (!idsNormalised) {
+      setIngestFeedback(
+        ingestFeedback,
+        "Enter at least one registration to query the TfL API.",
+        "error",
+      );
+      return;
+    }
+
+    if (ingestIds) {
+      ingestIds.value = idsNormalised;
+    }
+
+    const appId = (ingestAppId?.value || "").trim();
+    const appKey = (ingestAppKey?.value || "").trim();
+    const url = new URL(
+      `https://api.tfl.gov.uk/Vehicle/${encodeURIComponent(idsNormalised)}/Arrivals`,
+    );
+    if (appId) {
+      url.searchParams.set("app_id", appId);
+    }
+    if (appKey) {
+      url.searchParams.set("app_key", appKey);
+    }
+
+    setIngestFeedback(ingestFeedback, "Contacting TfL…", "pending");
+
+    fetch(url.toString())
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error(`TfL responded with status ${response.status}`);
+        }
+        return response.json();
+      })
+      .then((data) => {
+        if (ingestInput) {
+          ingestInput.value = JSON.stringify(data, null, 2);
+        }
+        handleArrivalRecords(elements, data, "api");
+      })
+      .catch((error) => {
+        console.warn("Failed to fetch TfL arrivals", error);
+        setIngestFeedback(
+          ingestFeedback,
+          "Unable to fetch from TfL. Paste a JSON response instead.",
+          "error",
+        );
+      });
+  }
+
+  function handleArrivalRecords(elements, payload, source) {
+    const { ingestFeedback, optionCategory } = elements;
+    const records = extractArrivalRecords(payload);
+    if (!records.length) {
+      setIngestFeedback(
+        ingestFeedback,
+        "No vehicle records were found in the supplied data.",
+        "error",
+      );
+      return;
+    }
+
+    const summary = applyArrivals(records);
+    if (!summary.total) {
+      setIngestFeedback(
+        ingestFeedback,
+        "No registrations could be processed from the payload.",
+        "error",
+      );
+      return;
+    }
+
+    sortOptionLists();
+    saveState();
+    populateAllSelects(elements);
+    renderTable(elements);
+    renderHighlights(elements);
+    updateStats(elements);
+    updatePendingBadge(elements);
+    renderOptionList(elements, optionCategory?.value || "operator");
+
+    const parts = [
+      `Processed ${summary.total} arrival${summary.total === 1 ? "" : "s"}.`,
+    ];
+    if (summary.created) {
+      parts.push(
+        `${summary.created} new profile${summary.created === 1 ? "" : "s"} created automatically.`,
+      );
+    }
+    if (summary.rare) {
+      parts.push(
+        `${summary.rare} rare working${summary.rare === 1 ? "" : "s"} detected.`,
+      );
+    }
+
+    setIngestFeedback(ingestFeedback, parts.join(" "), "success");
+    showToast(
+      elements.toast,
+      source === "api"
+        ? "TfL arrivals processed successfully."
+        : "Vehicle arrivals imported successfully.",
+      "success",
+    );
+  }
+
+  function applyArrivals(records) {
+    const summary = { total: 0, created: 0, rare: 0 };
+    records.forEach((record) => {
+      const result = applyArrivalRecord(record);
+      if (!result) return;
+      summary.total += 1;
+      if (result.created) summary.created += 1;
+      if (result.rare) summary.rare += 1;
+    });
+    return summary;
+  }
+
+  function applyArrivalRecord(arrival) {
+    if (!arrival || typeof arrival !== "object") {
+      return null;
+    }
+    const vehicleId = (arrival.vehicleId || arrival.vrm || arrival.id || "")
+      .toString()
+      .trim();
+    const regKey = normaliseRegKey(vehicleId);
+    if (!regKey) {
+      return null;
+    }
+
+    const registration = formatRegistrationForDisplay(vehicleId, regKey);
+    const seenIso = parseArrivalTimestamp(arrival);
+    const routeKey = getRouteKey(arrival.lineId, arrival.lineName);
+    const routeLabel = formatRouteLabel(arrival.lineName, arrival.lineId);
+
+    const bus = state.buses[regKey];
+    if (!bus) {
+      const createdBus = createBusFromArrival({
+        regKey,
+        registration,
+        seenIso,
+        routeKey,
+        routeLabel,
+      });
+      state.buses[regKey] = createdBus;
+      synchronizeOptionsWithBus(createdBus);
+      return { created: true, rare: false };
+    }
+
+    const rare = updateBusFromArrival(bus, {
+      registration,
+      seenIso,
+      routeKey,
+      routeLabel,
+    });
+    synchronizeOptionsWithBus(bus);
+    return { created: false, rare };
+  }
+
+  function createBusFromArrival({
+    regKey,
+    registration,
+    seenIso,
+    routeKey,
+    routeLabel,
+  }) {
+    const observed = seenIso || new Date().toISOString();
+    const now = new Date().toISOString();
+    const registrationDate = observed.slice(0, 10);
+    const routeHistory = {};
+    if (routeKey) {
+      routeHistory[routeKey] = observed;
+    }
+    return {
+      regKey,
+      registration,
+      fleetNumber: "",
+      operator: "",
+      status: "Active",
+      wrap: "",
+      vehicleType: "",
+      doors: "",
+      engineType: "",
+      engine: "",
+      chassis: "",
+      bodyType: "",
+      registrationDate,
+      garage: "",
+      extras: ["New Bus"],
+      length: "",
+      isNewBus: true,
+      isRareWorking: false,
+      createdAt: observed,
+      lastUpdated: now,
+      lastSeenAt: observed,
+      lastSeenRoute: routeLabel || "",
+      routeHistory,
+      rareWorkings: [],
+    };
+  }
+
+  function updateBusFromArrival(
+    bus,
+    { registration, seenIso, routeKey, routeLabel },
+  ) {
+    const now = new Date().toISOString();
+    if (
+      registration &&
+      (!bus.registration || bus.registration === bus.regKey)
+    ) {
+      bus.registration = registration;
+    }
+    if (!bus.registrationDate && seenIso) {
+      bus.registrationDate = seenIso.slice(0, 10);
+    }
+    bus.lastUpdated = now;
+    if (seenIso) {
+      bus.lastSeenAt = seenIso;
+    }
+    if (routeLabel) {
+      bus.lastSeenRoute = routeLabel;
+    }
+    if (!bus.routeHistory) {
+      bus.routeHistory = {};
+    }
+
+    let recordedRare = false;
+    if (routeKey) {
+      const seenDate = normaliseDate(seenIso) || new Date();
+      const seenTimestamp = seenDate.toISOString();
+      const previous = bus.routeHistory[routeKey];
+      bus.routeHistory[routeKey] = seenTimestamp;
+      if (!previous) {
+        // First appearance on this route counts as a rare working.
+        recordedRare = recordRareWorking(
+          bus,
+          routeKey,
+          routeLabel,
+          seenTimestamp,
+        );
+      } else {
+        const previousDate = new Date(previous);
+        if (
+          Number.isFinite(previousDate.getTime()) &&
+          seenDate.getTime() - previousDate.getTime() >
+            RARE_WORKING_THRESHOLD_MS
+        ) {
+          recordedRare = recordRareWorking(
+            bus,
+            routeKey,
+            routeLabel,
+            seenTimestamp,
+          );
+        }
+      }
+    }
+
+    if (Array.isArray(bus.rareWorkings) && bus.rareWorkings.length) {
+      bus.isRareWorking = true;
+      if (!Array.isArray(bus.extras)) {
+        bus.extras = [];
+      }
+      if (!bus.extras.includes("Rare Working")) {
+        bus.extras.push("Rare Working");
+      }
+    }
+
+    return recordedRare;
+  }
+
+  function recordRareWorking(bus, routeKey, routeLabel, seenIso) {
+    if (!routeKey) return false;
+    if (!Array.isArray(bus.rareWorkings)) {
+      bus.rareWorkings = [];
+    }
+    const label = routeLabel || routeKey;
+    const existing = bus.rareWorkings.find(
+      (entry) => entry.routeKey === routeKey,
+    );
+    if (existing) {
+      existing.route = label;
+      existing.lastSeen = seenIso;
+    } else {
+      bus.rareWorkings.push({ routeKey, route: label, lastSeen: seenIso });
+    }
+    bus.isRareWorking = true;
+    if (!Array.isArray(bus.extras)) {
+      bus.extras = [];
+    }
+    if (!bus.extras.includes("Rare Working")) {
+      bus.extras.push("Rare Working");
+    }
+    return true;
+  }
+
+  function extractArrivalRecords(payload) {
+    if (!payload) return [];
+    if (Array.isArray(payload)) return payload;
+    if (Array.isArray(payload.arrivals)) return payload.arrivals;
+    if (Array.isArray(payload.result)) return payload.result;
+    if (Array.isArray(payload.records)) return payload.records;
+    if (typeof payload === "object") {
+      const arrayEntry = Object.values(payload).find((value) =>
+        Array.isArray(value),
+      );
+      if (Array.isArray(arrayEntry)) {
+        return arrayEntry;
+      }
+    }
+    return [];
+  }
+
+  function parseArrivalTimestamp(arrival) {
+    if (!arrival || typeof arrival !== "object") {
+      return new Date().toISOString();
+    }
+    const candidates = [
+      arrival.timestamp,
+      arrival.expectedArrival,
+      arrival.timeToLive,
+    ];
+    for (const value of candidates) {
+      const date = normaliseDate(value);
+      if (date) {
+        return date.toISOString();
+      }
+    }
+    return new Date().toISOString();
+  }
+
+  function normaliseDate(value) {
+    if (!value && value !== 0) {
+      return null;
+    }
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+      return null;
+    }
+    return date;
+  }
+
+  function formatRegistrationForDisplay(raw, regKey) {
+    const text = (raw || "").toString().trim();
+    if (!text) {
+      return formatRegistrationSpacing(regKey);
+    }
+    if (text.includes(" ")) {
+      return text.toUpperCase();
+    }
+    return formatRegistrationSpacing(text.toUpperCase());
+  }
+
+  function formatRegistrationSpacing(value) {
+    const text = (value || "").toString().trim().toUpperCase();
+    if (!text) return "";
+    if (text.length === 7) {
+      return `${text.slice(0, 4)} ${text.slice(4)}`;
+    }
+    if (text.length > 4) {
+      return `${text.slice(0, text.length - 3)} ${text.slice(-3)}`;
+    }
+    return text;
+  }
+
+  function getRouteKey(lineId, lineName) {
+    const id = (lineId || "").toString().trim();
+    if (id) {
+      return id.toUpperCase();
+    }
+    const name = (lineName || "").toString().trim();
+    return name ? name.toUpperCase() : "";
+  }
+
+  function formatRouteLabel(lineName, lineId) {
+    const raw = (lineName || lineId || "").toString().trim();
+    if (!raw) {
+      return "";
+    }
+    if (/^route\s+/i.test(raw)) {
+      const clean = raw.replace(/^route\s+/i, "").trim();
+      return `Route ${clean}`.trim();
+    }
+    return `Route ${raw}`.trim();
+  }
+
+  function formatIdsForInput(value) {
+    return (value || "")
+      .split(/[\s,]+/)
+      .map((part) => normaliseRegKey(part))
+      .filter(Boolean)
+      .join(",");
+  }
+
+  function setIngestFeedback(element, message, stateValue) {
+    if (!element) return;
+    element.textContent = message;
+    if (stateValue) {
+      element.dataset.state = stateValue;
+    } else {
+      delete element.dataset.state;
+    }
+  }
+
+  function clearForm(elements) {
+    const { fleetForm } = elements;
+    if (!fleetForm) return;
+    fleetForm.reset();
+  }
+
+  function prefillForm(elements, bus) {
+    const { registrationInput, selects } = elements;
+    const registration = registrationInput?.value || bus?.registration;
+    const regKey = normaliseRegKey(registration || "");
+    const record = bus || state.buses[regKey];
+    if (!record) {
+      clearFormKeepRegistration(elements);
+      return;
+    }
+
+    if (registrationInput) {
+      registrationInput.value = record.registration || registrationInput.value;
+    }
+
+    setValue(selects.fleetNumber, record.fleetNumber || "");
+    setSelectValue(selects.operator, record.operator);
+    setSelectValue(selects.status, record.status);
+    setSelectValue(selects.wrap, record.wrap);
+    setSelectValue(selects.vehicleType, record.vehicleType);
+    setSelectValue(selects.doors, record.doors);
+    setSelectValue(selects.engineType, record.engineType);
+    setSelectValue(selects.engine, record.engine);
+    setSelectValue(selects.chassis, record.chassis);
+    setSelectValue(selects.bodyType, record.bodyType);
+    setDateValue(selects.registrationDate, record.registrationDate);
+    setSelectValue(selects.garage, record.garage);
+    setMultiSelect(selects.extras, record.extras || []);
+    setSelectValue(selects.length, record.length);
+    if (selects.isNewBus) {
+      selects.isNewBus.checked = Boolean(record.isNewBus);
+    }
+    if (selects.isRareWorking) {
+      selects.isRareWorking.checked = Boolean(record.isRareWorking);
+    }
+  }
+
+  function clearFormKeepRegistration(elements) {
+    const { fleetForm, registrationInput } = elements;
+    if (!fleetForm) return;
+    const registration = registrationInput ? registrationInput.value : "";
+    fleetForm.reset();
+    if (registrationInput) {
+      registrationInput.value = registration.toUpperCase();
+    }
+  }
+
+  function setValue(input, value) {
+    if (!input) return;
+    input.value = value || "";
+  }
+
+  function setSelectValue(select, value) {
+    if (!select) return;
+    if (
+      value &&
+      !Array.from(select.options).some((option) => option.value === value)
+    ) {
+      const option = document.createElement("option");
+      option.value = value;
+      option.textContent = value;
+      select.appendChild(option);
+    }
+    select.value = value || "";
+  }
+
+  function setMultiSelect(select, values) {
+    if (!select) return;
+    const set = new Set(values);
+    Array.from(select.options).forEach((option) => {
+      option.selected = set.has(option.value);
+    });
+  }
+
+  function setDateValue(input, value) {
+    if (!input) return;
+    if (!value) {
+      input.value = "";
+      return;
+    }
+    const date = new Date(value);
+    if (!Number.isNaN(date.getTime())) {
+      input.value = date.toISOString().slice(0, 10);
+    } else {
+      input.value = value;
+    }
+  }
+
+  function setFormFeedback(element, message, stateValue) {
+    if (!element) return;
+    element.textContent = message;
+    if (stateValue) {
+      element.dataset.state = stateValue;
+    } else {
+      delete element.dataset.state;
+    }
+  }
+
+  function showToast(element, message, variant = "info") {
+    if (!element) return;
+    element.textContent = message;
+    element.dataset.visible = "true";
+    element.dataset.variant = variant;
+    clearTimeout(toastTimeout);
+    toastTimeout = setTimeout(() => {
+      element.dataset.visible = "false";
+    }, 3500);
+  }
+
+  function capitalise(value) {
+    return value
+      .split(" ")
+      .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+      .join(" ");
+  }
+
+  function escapeHtml(value) {
+    if (value === undefined || value === null) {
+      return "";
+    }
+    return value
+      .toString()
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#39;");
+  }
+
+  function formatDate(value) {
+    if (!value) return "—";
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+      return escapeHtml(value.toString());
+    }
+    return date.toLocaleDateString(undefined, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    });
+  }
+
+  function formatDateTime(value) {
+    if (!value) return "";
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+      return value.toString();
+    }
+    return date.toLocaleString(undefined, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  }
+})();


### PR DESCRIPTION
## Summary
- add an admin ingestion panel on the fleet page for fetching or pasting TfL Vehicle Arrivals payloads and guiding users through syncing data
- style the new ingestion workflow with dedicated admin panel layouts, feedback messaging, and responsive controls
- process arrivals client-side to create new registrations automatically, update route history, and flag rare workings with refreshed highlight displays

## Testing
- npx --yes prettier --check fleet.html fleet.css fleet.js

------
https://chatgpt.com/codex/tasks/task_e_68ca5df249a083228ff0479d4413d004