### PR TITLE
Add loading placeholders to disruptions view

### DIFF
--- a/network.css
+++ b/network.css
@@ -221,6 +221,11 @@ body.dark-mode .network-search input {
   border-left: 4px solid transparent;
 }
 
+.network-card--loading {
+  gap: 0.85rem;
+  min-height: 120px;
+}
+
 body.dark-mode .network-card {
   background: var(--card-bg-dark);
   box-shadow: 0 14px 34px rgba(0, 0, 0, 0.45);
@@ -321,6 +326,71 @@ body.dark-mode .network-tag {
   flex-direction: column;
   gap: 0.35rem;
   font-size: 0.9rem;
+}
+
+.network-loading-block {
+  position: relative;
+  display: block;
+  height: 0.75rem;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.1);
+  overflow: hidden;
+}
+
+body.dark-mode .network-loading-block {
+  background: rgba(255, 255, 255, 0.16);
+}
+
+.network-loading-block::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  transform: translateX(-100%);
+  background: linear-gradient(
+    90deg,
+    rgba(255, 255, 255, 0),
+    rgba(255, 255, 255, 0.6),
+    rgba(255, 255, 255, 0)
+  );
+  animation: networkLoadingShimmer 1.4s ease-in-out infinite;
+}
+
+body.dark-mode .network-loading-block::after {
+  background: linear-gradient(
+    90deg,
+    rgba(15, 23, 42, 0),
+    rgba(15, 23, 42, 0.32),
+    rgba(15, 23, 42, 0)
+  );
+}
+
+.network-loading-block--title {
+  height: 1.1rem;
+  width: 60%;
+}
+
+.network-loading-block--status {
+  width: 80%;
+}
+
+.network-loading-block--meta {
+  width: 92%;
+}
+
+.network-loading-block--meta-small {
+  width: 48%;
+}
+
+@keyframes networkLoadingShimmer {
+  to {
+    transform: translateX(100%);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .network-loading-block::after {
+    animation: none;
+  }
 }
 
 .network-card__link {


### PR DESCRIPTION
## Summary
- add tracked loading state for disruptions data so the grid and stats show a skeleton while the API call completes
- introduce skeleton card styling that provides visual feedback in both light and dark mode

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68cad77b148c8322ac72fa5d72d68532