### PR TITLE
Add profile editor modal with backend integration

### DIFF
--- a/profile.css
+++ b/profile.css
@@ -351,6 +351,145 @@ body.dark-mode .profile-empty {
   border-color: rgba(250, 250, 250, 0.2);
 }
 
+.profile-editor[hidden] {
+  display: none !important;
+}
+
+.profile-editor {
+  position: fixed;
+  inset: 0;
+  z-index: 1200;
+  display: grid;
+  align-items: center;
+  justify-items: center;
+  padding: 1.5rem;
+  overflow-y: auto;
+}
+
+.profile-editor__backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  background: rgba(15, 23, 42, 0.55);
+  backdrop-filter: blur(6px);
+}
+
+.profile-editor__dialog {
+  position: relative;
+  z-index: 1;
+  width: min(520px, 100%);
+  background: var(--card-bg-light);
+  border-radius: 20px;
+  box-shadow: 0 25px 45px rgba(15, 23, 42, 0.2);
+  padding: 1.8rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.4rem;
+}
+
+body.dark-mode .profile-editor__dialog {
+  background: var(--card-bg-dark);
+  box-shadow: 0 30px 60px rgba(0, 0, 0, 0.45);
+}
+
+.profile-editor__header h2 {
+  margin: 0 0 0.4rem 0;
+  font-size: 1.65rem;
+}
+
+.profile-editor__header p {
+  margin: 0;
+  opacity: 0.8;
+}
+
+.profile-editor__body {
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+}
+
+.profile-editor__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.profile-editor__field label {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.profile-editor__field input[type='text'],
+.profile-editor__field input[type='file'] {
+  font: inherit;
+  border-radius: 12px;
+  border: 1px solid rgba(15, 23, 42, 0.15);
+  padding: 0.65rem 0.8rem;
+  background: rgba(255, 255, 255, 0.92);
+  transition: border-color var(--transition), box-shadow var(--transition);
+}
+
+body.dark-mode .profile-editor__field input[type='text'],
+body.dark-mode .profile-editor__field input[type='file'] {
+  background: rgba(15, 23, 42, 0.6);
+  border-color: rgba(255, 255, 255, 0.15);
+  color: inherit;
+}
+
+.profile-editor__field input:focus {
+  outline: none;
+  border-color: var(--accent-blue);
+  box-shadow: 0 0 0 3px rgba(41, 121, 255, 0.25);
+}
+
+.profile-editor__help {
+  margin: 0;
+  font-size: 0.82rem;
+  opacity: 0.75;
+}
+
+.profile-editor__error {
+  min-height: 1.3rem;
+  margin: 0;
+  font-size: 0.9rem;
+  color: #d22f2f;
+  font-weight: 600;
+}
+
+.profile-editor__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.profile-editor__actions .profile-hero__button {
+  min-width: 150px;
+}
+
+.profile-editor__dialog[aria-busy='true'] {
+  opacity: 0.7;
+  pointer-events: none;
+}
+
+body.modal-open {
+  overflow: hidden;
+}
+
+@media (max-width: 520px) {
+  .profile-editor {
+    padding: 1rem;
+  }
+
+  .profile-editor__dialog {
+    padding: 1.4rem;
+    gap: 1rem;
+  }
+
+  .profile-editor__header h2 {
+    font-size: 1.4rem;
+  }
+}
+
 @media (max-width: 780px) {
   .profile-hero {
     grid-template-columns: 1fr;

--- a/profile.html
+++ b/profile.html
@@ -50,11 +50,71 @@
           </div>
         </dl>
         <div class="profile-hero__actions">
+          <button type="button" class="profile-hero__button" id="editProfileBtn" data-disabled>Edit profile</button>
           <a href="settings.html" class="profile-hero__button" id="openSettings" data-disabled>Open settings</a>
           <button type="button" class="profile-hero__button profile-hero__button--ghost" id="signOutBtn" data-disabled>Sign out</button>
         </div>
       </div>
     </section>
+
+    <div
+      class="profile-editor"
+      id="profileEditor"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="profileEditorTitle"
+      hidden
+    >
+      <div class="profile-editor__backdrop" data-profile-editor-dismiss></div>
+      <form class="profile-editor__dialog" id="profileEditorForm" novalidate>
+        <header class="profile-editor__header">
+          <h2 id="profileEditorTitle">Edit your profile</h2>
+          <p>Update how you appear across RouteFlow London.</p>
+        </header>
+        <div class="profile-editor__body">
+          <div class="profile-editor__field">
+            <label for="profileEditorDisplayName">Display name</label>
+            <input
+              type="text"
+              id="profileEditorDisplayName"
+              name="displayName"
+              autocomplete="name"
+              maxlength="80"
+              placeholder="Your name"
+            />
+            <p class="profile-editor__help">Leave blank to use your email address instead.</p>
+          </div>
+          <div class="profile-editor__field">
+            <label for="profileEditorGender">Gender</label>
+            <input
+              type="text"
+              id="profileEditorGender"
+              name="gender"
+              maxlength="60"
+              placeholder="E.g. Woman, Man, Non-binary"
+            />
+            <p class="profile-editor__help">Optional. Saved securely via our Neon-backed profile service.</p>
+          </div>
+          <div class="profile-editor__field">
+            <label for="profileEditorAvatar">Avatar</label>
+            <input type="file" id="profileEditorAvatar" name="avatar" accept="image/*" />
+            <p class="profile-editor__help">Images up to 5&nbsp;MB. We'll resize them to fit the profile hero.</p>
+          </div>
+          <p class="profile-editor__error" id="profileEditorError" role="status" aria-live="polite"></p>
+        </div>
+        <footer class="profile-editor__actions">
+          <button type="submit" class="profile-hero__button" id="profileEditorSave">Save changes</button>
+          <button
+            type="button"
+            class="profile-hero__button profile-hero__button--ghost"
+            id="profileEditorCancel"
+            data-profile-editor-dismiss
+          >
+            Cancel
+          </button>
+        </footer>
+      </form>
+    </div>
 
     <section class="profile-grid">
       <article class="profile-card profile-card--stats" id="profileStatsCard">
@@ -117,6 +177,7 @@
 
   <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-auth-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-storage-compat.js"></script>
   <script>
     const firebaseConfig = {
       apiKey: "AIzaSyDuedLuagA4IXc9ZMG9wvoak-sRrhtFZfo",


### PR DESCRIPTION
## Summary
- add a profile editor modal with fields for display name, gender, and avatar upload alongside a new edit button in the hero
- style the modal experience and supporting controls for both light and dark modes
- preload profile details, validate edits, upload avatars via Firebase Storage, persist custom fields through the profile API, and refresh the hero after saves

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cb26868d88832294303fd5f9bace82