### PR TITLE
Proxy TfL API calls through backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,9 @@ A unified platform for tracking, planning, and exploring London transport routes
    cp .env.example .env
    ```
    At a minimum you must provide values for `DATABASE_URL` and `FIREBASE_API_KEY`.
-   Provide `TFL_APP_KEY` if you want the static pages (routes, disruptions, tracker)
-   to call TfL APIs without hitting anonymous rate limits.
+   Provide `TFL_APP_KEY` so that the backend can authenticate outgoing TfL requests
+   on behalf of the static pages (routes, disruptions, tracker) without hitting
+   anonymous rate limits.
 2. Navigate to `backend/`
 3. Install dependencies:
    ```sh
@@ -41,6 +42,14 @@ A unified platform for tracking, planning, and exploring London transport routes
    ```sh
    python api.py
    ```
+
+### TfL API proxy endpoints
+
+- The backend exposes a read-only proxy at `/api/tfl/<path>` that forwards
+  requests to the official TfL API and injects any configured credentials.
+- Set `TFL_APP_KEY` (and optionally `TFL_APP_ID` or `TFL_SUBSCRIPTION_KEY`) in
+  your deployment environment so that browser-based pages can call `/api/tfl/...`
+  without exposing secrets.
 
 ## Deployment
 

--- a/disruptions.js
+++ b/disruptions.js
@@ -1,30 +1,10 @@
 const REFRESH_INTERVAL = 120000;
 
-let warnedAboutMissingTflKey = false;
-
-const getTflAppKey = () => {
-  if (typeof window === 'undefined') return '';
-  const key = window.__ROUTEFLOW_CONFIG__?.tfl?.appKey;
-  if (typeof key === 'string' && key.trim()) {
-    return key.trim();
-  }
-  if (!warnedAboutMissingTflKey) {
-    console.warn('TfL app key is not configured; disruption data will use unauthenticated rate limits.');
-    warnedAboutMissingTflKey = true;
-  }
-  return '';
-};
-
-const withTflAppKey = (url) => {
-  const key = getTflAppKey();
-  if (!key) return url;
-  const separator = url.includes('?') ? '&' : '?';
-  return `${url}${separator}app_key=${encodeURIComponent(key)}`;
-};
+const TFL_API_BASE = '/api/tfl';
 
 const RAIL_ENDPOINT = () =>
-  withTflAppKey('https://api.tfl.gov.uk/Line/Mode/tube,dlr,overground,elizabeth-line/Status?detail=true');
-const BUS_ENDPOINT = () => withTflAppKey('https://api.tfl.gov.uk/Line/Mode/bus/Status?detail=true');
+  `${TFL_API_BASE}/Line/Mode/tube,dlr,overground,elizabeth-line/Status?detail=true`;
+const BUS_ENDPOINT = () => `${TFL_API_BASE}/Line/Mode/bus/Status?detail=true`;
 
 const elements = {
   railGrid: document.getElementById('railGrid'),

--- a/planning.js
+++ b/planning.js
@@ -1,5 +1,7 @@
 // Journey planning logic for Routeflow London
 
+const TFL_API_BASE = '/api/tfl';
+
 document.getElementById('journey-form').addEventListener('submit', async (e) => {
   e.preventDefault();
 
@@ -23,7 +25,7 @@ document.getElementById('journey-form').addEventListener('submit', async (e) => 
     if (mode.length) params.append('mode', mode.join(','));
     if (accessibility.length) params.append('accessibilityPreference', accessibility.join(','));
 
-    let url = `https://api.tfl.gov.uk/Journey/JourneyResults/${encodeURIComponent(from)}/to/${encodeURIComponent(to)}`;
+    let url = `${TFL_API_BASE}/Journey/JourneyResults/${encodeURIComponent(from)}/to/${encodeURIComponent(to)}`;
     if (params.toString()) url += `?${params.toString()}`;
 
     const res = await fetch(url);

--- a/routes.js
+++ b/routes.js
@@ -1,32 +1,12 @@
 import { getRouteTagOverrideMap, normaliseRouteKey, STORAGE_KEYS } from './data-store.js';
 
-let warnedAboutMissingTflKey = false;
+const TFL_API_BASE = '/api/tfl';
 
-const getTflAppKey = () => {
-  if (typeof window === 'undefined') return '';
-  const key = window.__ROUTEFLOW_CONFIG__?.tfl?.appKey;
-  if (typeof key === 'string' && key.trim()) {
-    return key.trim();
-  }
-  if (!warnedAboutMissingTflKey) {
-    console.warn('TfL app key is not configured; requests will use unauthenticated rate limits.');
-    warnedAboutMissingTflKey = true;
-  }
-  return '';
-};
-
-const withTflAppKey = (url) => {
-  const key = getTflAppKey();
-  if (!key) return url;
-  const separator = url.includes('?') ? '&' : '?';
-  return `${url}${separator}app_key=${encodeURIComponent(key)}`;
-};
-
-const ROUTE_ENDPOINT = () => withTflAppKey('https://api.tfl.gov.uk/Line/Mode/bus/Route');
+const ROUTE_ENDPOINT = () => `${TFL_API_BASE}/Line/Mode/bus/Route`;
 const ROUTE_STOPS_ENDPOINT = (routeId) =>
-  withTflAppKey(`https://api.tfl.gov.uk/Line/${encodeURIComponent(routeId)}/StopPoints`);
+  `${TFL_API_BASE}/Line/${encodeURIComponent(routeId)}/StopPoints`;
 const ROUTE_VEHICLES_ENDPOINT = (routeId) =>
-  withTflAppKey(`https://api.tfl.gov.uk/Line/${encodeURIComponent(routeId)}/Arrivals`);
+  `${TFL_API_BASE}/Line/${encodeURIComponent(routeId)}/Arrivals`;
 const LAST_ROUTE_KEY = 'routeflow.lastRoute';
 
 const fallbackRoutes = [

--- a/tracking.html
+++ b/tracking.html
@@ -104,26 +104,7 @@
   <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-auth-compat.js"></script>
   <script src="main.js"></script>
   <script>
-const tflKeyState = { warned: false };
-
-function getTflAppKey(){
-  const config = window.__ROUTEFLOW_CONFIG__ || {};
-  const tflConfig = config.tfl || {};
-  const key = typeof tflConfig.appKey === 'string' ? tflConfig.appKey.trim() : '';
-  if(!key && !tflKeyState.warned){
-    console.warn('TfL app key is not configured; tracker requests will use unauthenticated rate limits.');
-    tflKeyState.warned = true;
-  }
-  return key;
-}
-
-function withTflAppKey(url){
-  const key = getTflAppKey();
-  if(!key) return url;
-  const separator = url.includes('?') ? '&' : '?';
-  return `${url}${separator}app_key=${encodeURIComponent(key)}`;
-}
-
+const TFL_API_BASE = '/api/tfl';
 const MODES = "bus,tube,overground,dlr,tram,river-bus,national-rail,elizabeth-line";
 const LAST_STOP_KEY = 'routeflow.lastStop';
 const q = document.getElementById('q');
@@ -230,14 +211,14 @@ async function search(query){
     return;
   }
 
-  const searchUrl = withTflAppKey(`https://api.tfl.gov.uk/StopPoint/Search/${encodeURIComponent(query)}?modes=${encodeURIComponent(MODES)}&maxResults=20`);
+  const searchUrl = `${TFL_API_BASE}/StopPoint/Search/${encodeURIComponent(query)}?modes=${encodeURIComponent(MODES)}&maxResults=20`;
 
   let searchData;
   try{
     searchData = await fetchJSON(searchUrl);
   }catch(e){
     console.error(e);
-    results.innerHTML = `<div class="result"><div class="r-main"><div class="r-title">Search failed</div><div class="r-sub">Check network/API key</div></div></div>`;
+    results.innerHTML = `<div class="result"><div class="r-main"><div class="r-title">Search failed</div><div class="r-sub">Check your connection</div></div></div>`;
     results.style.display="block";
     return;
   }
@@ -250,7 +231,7 @@ async function search(query){
   }
 
   const detailPromises = matches.map(m =>
-    fetchJSON(withTflAppKey(`https://api.tfl.gov.uk/StopPoint/${encodeURIComponent(m.id)}`)).catch(()=>null)
+    fetchJSON(`${TFL_API_BASE}/StopPoint/${encodeURIComponent(m.id)}`).catch(()=>null)
   );
   const details = await Promise.all(detailPromises);
 
@@ -305,13 +286,13 @@ async function loadArrivals(stopId, stopName){
   rows.innerHTML = `<div class="empty">Loading…</div>`;
 
   try{
-    let data = await fetchJSON(withTflAppKey(`https://api.tfl.gov.uk/StopPoint/${encodeURIComponent(stopId)}/Arrivals`));
+    let data = await fetchJSON(`${TFL_API_BASE}/StopPoint/${encodeURIComponent(stopId)}/Arrivals`);
 
     if(!Array.isArray(data) || data.length===0){
-      const info = await fetchJSON(withTflAppKey(`https://api.tfl.gov.uk/StopPoint/${encodeURIComponent(stopId)}`)).catch(()=>null);
+      const info = await fetchJSON(`${TFL_API_BASE}/StopPoint/${encodeURIComponent(stopId)}`).catch(()=>null);
       if(info && Array.isArray(info.children) && info.children.length){
         const childReqs = info.children.map(c =>
-          fetchJSON(withTflAppKey(`https://api.tfl.gov.uk/StopPoint/${encodeURIComponent(c.id)}/Arrivals`)).catch(()=>[])
+          fetchJSON(`${TFL_API_BASE}/StopPoint/${encodeURIComponent(c.id)}/Arrivals`).catch(()=>[])
         );
         const childData = (await Promise.all(childReqs)).flat();
         data = childData;


### PR DESCRIPTION
## Summary
- add a credential-aware `/api/tfl` proxy in the Flask backend and stop injecting the TfL key into client config
- update routes, disruptions, journey planning and live tracking pages to call the backend proxy instead of hitting TfL directly
- document the new proxy behaviour and required environment variables for TfL credentials

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68cc82167d3083228d2f150411f8e866