### PR TITLE
Restore legacy journey tools and fix TfL paging

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ A unified platform for tracking, planning, and exploring London transport routes
    Provide `TFL_APP_KEY` so that the backend can authenticate outgoing TfL requests
    on behalf of the static pages (routes, disruptions, tracker) without hitting
    anonymous rate limits.
+   Optionally provide `TFL_REGISTRATION_ENDPOINTS` (comma or newline separated)
+   to extend the automatic fleet sync to other TfL endpoints that expose vehicle
+   registrations.
 2. Navigate to `backend/`
 3. Install dependencies:
    ```sh

--- a/planning.html
+++ b/planning.html
@@ -3,120 +3,46 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Journey Planning | RouteFlow London</title>
+  <title>Journey Planning | Routeflow London</title>
   <link rel="icon" href="images/New_Routflow_London_Logo.png" type="image/png">
   <link href="https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible:wght@400;600&family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
   <link rel="stylesheet" href="style.css">
-  <link rel="stylesheet" href="planning.css">
   <script src="theme.js" defer></script>
 </head>
 <body>
   <div id="navbar-container"></div>
-
-  <main class="planning-shell">
-    <section class="planning-hero card">
-      <div class="planning-hero__content">
-        <p class="planning-hero__eyebrow">Multi-mode journey planner</p>
-        <h1>Design journeys across London with accessibility built in.</h1>
-        <p>Choose your start and destination points, filter by transport mode and accessibility preferences, then compare the best itineraries produced by TfL&#39;s journey planner.</p>
-      </div>
-      <dl class="planning-hero__meta">
-        <div>
-          <dt>Covered modes</dt>
-          <dd>Bus, Tube, DLR, tram, river, rail</dd>
-        </div>
-        <div>
-          <dt>Accessibility options</dt>
-          <dd>Stairs, escalators, lifts, step-free</dd>
-        </div>
-        <div>
-          <dt>Powered by</dt>
-          <dd>TfL Journey Planner API</dd>
-        </div>
-      </dl>
-    </section>
-
-    <section class="planning-layout">
-      <form id="journey-form" class="planning-form card">
-        <div class="planning-form__row">
-          <div class="planning-input">
-            <label for="from">From</label>
-            <input type="text" id="from" placeholder="Start location" required>
-          </div>
-          <div class="planning-input">
-            <label for="to">To</label>
-            <input type="text" id="to" placeholder="Destination" required>
-          </div>
-        </div>
-
-        <fieldset class="planning-fieldset">
-          <legend>Modes</legend>
-          <div class="planning-checkboxes">
-            <label><input type="checkbox" name="mode" value="bus" checked> Bus</label>
-            <label><input type="checkbox" name="mode" value="tube" checked> Tube</label>
-            <label><input type="checkbox" name="mode" value="dlr" checked> DLR</label>
-            <label><input type="checkbox" name="mode" value="overground" checked> Overground</label>
-            <label><input type="checkbox" name="mode" value="tram" checked> Tram</label>
-            <label><input type="checkbox" name="mode" value="river-bus" checked> River Bus</label>
-          </div>
-        </fieldset>
-
-        <fieldset class="planning-fieldset">
-          <legend>Accessibility</legend>
-          <div class="planning-checkboxes">
-            <label><input type="checkbox" name="accessibility" value="NoSolidStairs"> No solid stairs</label>
-            <label><input type="checkbox" name="accessibility" value="NoEscalators"> No escalators</label>
-            <label><input type="checkbox" name="accessibility" value="NoElevators"> No elevators</label>
-            <label><input type="checkbox" name="accessibility" value="StepFreeToVehicle"> Step-free to vehicle</label>
-            <label><input type="checkbox" name="accessibility" value="StepFreeToPlatform"> Step-free to platform</label>
-          </div>
-        </fieldset>
-
-        <button type="submit" class="planning-submit">Search journeys</button>
-      </form>
-
-      <aside class="planning-side">
-        <article class="planning-side__card card">
-          <h3>Make the most of your results</h3>
-          <ul>
-            <li>Compare interchange counts to find the most direct route.</li>
-            <li>Use accessibility filters to surface stations with lifts or ramps.</li>
-            <li>Switch to the tracking page to monitor live departures once you&#39;re on your way.</li>
-          </ul>
-        </article>
-      </aside>
-    </section>
-
-    <section class="planning-results card">
-      <header>
-        <h2>Journey options</h2>
-        <p>Results refresh instantly after each search.</p>
-      </header>
-      <div id="error" class="planning-error" role="alert"></div>
-      <div id="results" class="planning-results__list" aria-live="polite"></div>
-    </section>
+  <section class="page-banner">
+    <h1>Journey Planner</h1>
+    <p>Plan your trip across London using TfL data.</p>
+  </section>
+  <main class="planner">
+    <form id="journey-form" class="planner-form">
+      <input type="text" id="from" placeholder="From" required>
+      <input type="text" id="to" placeholder="To" required>
+      <fieldset class="filters">
+        <legend>Modes</legend>
+        <label><input type="checkbox" name="mode" value="bus" checked> Bus</label>
+        <label><input type="checkbox" name="mode" value="tube" checked> Tube</label>
+        <label><input type="checkbox" name="mode" value="dlr" checked> DLR</label>
+        <label><input type="checkbox" name="mode" value="overground" checked> Overground</label>
+        <label><input type="checkbox" name="mode" value="tram" checked> Tram</label>
+        <label><input type="checkbox" name="mode" value="river-bus" checked> River Bus</label>
+      </fieldset>
+      <fieldset class="filters">
+        <legend>Accessibility</legend>
+        <label><input type="checkbox" name="accessibility" value="NoSolidStairs"> No solid stairs</label>
+        <label><input type="checkbox" name="accessibility" value="NoEscalators"> No escalators</label>
+        <label><input type="checkbox" name="accessibility" value="NoElevators"> No elevators</label>
+        <label><input type="checkbox" name="accessibility" value="StepFreeToVehicle"> Step-free to vehicle</label>
+        <label><input type="checkbox" name="accessibility" value="StepFreeToPlatform"> Step-free to platform</label>
+      </fieldset>
+      <button type="submit">Search</button>
+    </form>
+    <div id="error" class="error"></div>
+    <div id="results"></div>
   </main>
-
-  <footer>
-    <div class="footer-links">
-      <a href="about.html">About</a> |
-      <a href="privacy.html">Privacy</a> |
-      <a href="terms.html">Terms</a> |
-      <a href="contact.html">Contact</a>
-    </div>
-    <div class="social-icons">
-      <a href="https://discord.gg/qVf3nN4Mgq"><i class="fa-brands fa-discord"></i></a>
-      <a href="https://www.tiktok.com/@the_bus_father"><i class="fab fa-tiktok"></i></a>
-      <a href="https://www.instagram.com/thebusfatherofficial/profilecard/?igsh=NXcybzV3cTA2azBo"><i class="fab fa-instagram"></i></a>
-    </div>
-    <small>Made for London. Built from scratch.</small>
-  </footer>
-
-  <script src="navbar-loader.js"></script>
-  <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-app-compat.js"></script>
-  <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-auth-compat.js"></script>
-  <script src="main.js"></script>
   <script src="planning.js"></script>
+  <script src="navbar-loader.js"></script>
 </body>
 </html>

--- a/routes.html
+++ b/routes.html
@@ -3,120 +3,951 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link rel="icon" href="images/New_Routflow_London_Logo.png" type="image/png" />
-  <title>Routes | RouteFlow London</title>
-  <link href="https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible:wght@400;600&family=Inter:wght@400;600;800&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="style.css" />
-  <link rel="stylesheet" href="network.css" />
+  <link rel="icon" href="images/New_Routflow_London_Logo.png" type="image/png">
+  <title>Routes | Routeflow London</title>
+  <link href="https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible:wght@400;600&family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="stylesheet" href="style.css">
   <script src="theme.js" defer></script>
 </head>
 <body>
-  <div id="navbar-container"></div>
-  <main class="network-shell">
-    <section class="network-hero">
-      <div>
-        <h1>London bus routes</h1>
-        <p>Discover every active Transport for London route, preview the stops it serves and step straight into the live tracker without losing context.</p>
-      </div>
-      <div class="network-hero__stats" id="routeStats">
-        <div class="network-stat">
-          <span>Total routes</span>
-          <strong id="routesTotal">0</strong>
+    <header class="navbar">
+  <div class="navbar__container">
+    <a href="index.html" class="navbar__logo" aria-label="RouteFlow London Home">
+      <img src="images/Routeflow London permanent logo.png" alt="RouteFlow London Logo" />
+      <strong>RouteFlow London</strong>
+    </a>
+    <nav class="navbar__links" id="navbarLinks">
+      <a href="index.html">Home</a>
+      <a href="dashboard.html">Dashboard</a>
+      <a href="tracking.html">Tracking</a>
+      <a href="planning.html">Planning</a>
+      <a href="routes.html">Routes</a>
+      <a href="withdrawn.html">Withdrawn</a>
+      <a href="disruptions.html">Disruptions</a>
+      <a href="fleet.html">Fleet</a>
+    </nav>
+    <div class="navbar__controls">
+      <button class="hamburger" id="hamburgerBtn" aria-label="Open mobile menu">
+        <i class="fa-solid fa-bars"></i>
+      </button>
+      <div class="account-menu" id="accountMenu">
+        <button aria-label="Account" id="profileIcon" type="button">
+          <i class="fa-regular fa-user"></i>
+        </button>
+        <div class="account-dropdown" id="dropdownContent">
+          <a href="profile.html">Profile</a>
+          <a href="settings.html">Settings</a>
+          <button onclick="openModal('login')" type="button">Login</button>
+          <button onclick="openModal('signup')" type="button">Sign Up</button>
+          <button onclick="signOut()" type="button">Sign out</button>
         </div>
-        <div class="network-stat">
-          <span>Night services</span>
-          <strong id="routesNight">0</strong>
-        </div>
-        <div class="network-stat">
-          <span>School services</span>
-          <strong id="routesSchool">0</strong>
-        </div>
       </div>
-    </section>
+    </div>
+  </div>
+  <!-- Mobile nav drawer -->
+  <nav class="mobile-drawer" id="mobileDrawer" aria-label="Mobile Navigation">
+    <button class="close-drawer" id="closeDrawerBtn" aria-label="Close menu">
+      <i class="fa-solid fa-times"></i>
+    </button>
+    <a href="index.html">Home</a>
+    <a href="dashboard.html">Dashboard</a>
+    <a href="tracking.html">Tracking</a>
+    <a href="planning.html">Planning</a>
+    <a href="routes.html">Routes</a>
+    <a href="withdrawn.html">Withdrawn</a>
+    <a href="disruptions.html">Disruptions</a>
+    <a href="fleet.html">Fleet</a>
+    <hr>
+    <a href="profile.html">Profile</a>
+    <a href="settings.html">Settings</a>
+    <button onclick="openModal('login')" type="button">Login</button>
+    <button onclick="openModal('signup')" type="button">Sign Up</button>
+    <button onclick="signOut()" type="button">Sign out</button>
+  </nav>
+  <div class="drawer-backdrop" id="drawerBackdrop"></div>
 
-    <section class="network-toolbar" aria-label="Route filters">
-      <div class="network-search">
-        <label for="routeSearch">Search routes</label>
-        <input type="search" id="routeSearch" placeholder="Search by route number or destination" autocomplete="off" />
+  <!-- Modal for login/signup/reset -->
+  <div id="authModal" class="modal" aria-modal="true" role="dialog">
+    <div class="modal-content">
+      <span class="close" id="closeModal" title="Close">&times;</span>
+      <!-- Login Form -->
+      <div id="loginFormContainer">
+        <h2>Login</h2>
+        <form id="loginForm" autocomplete="off">
+          <input type="email" id="loginEmail" placeholder="Email" required autocomplete="username">
+          <input type="password" id="loginPassword" placeholder="Password" required autocomplete="current-password">
+          <button type="submit">Login</button>
+          <button type="button" class="google-btn">Sign in with Google</button>
+          <p><a href="#" class="reset-password" id="showReset">Forgot Password?</a></p>
+          <div class="error-message" id="loginError" style="display:none;"></div>
+        </form>
+        <p>Don't have an account? <a href="#" id="showSignup">Sign up</a></p>
       </div>
-      <div class="network-filters" id="routeFilters" role="group" aria-label="Filter by service type">
-        <button type="button" class="network-chip" data-filter="Regular" data-active="true">Regular</button>
-        <button type="button" class="network-chip" data-filter="Night">Night</button>
-        <button type="button" class="network-chip" data-filter="School">School</button>
-        <button type="button" class="network-chip" data-filter="Special">Special</button>
+      <!-- Signup Form -->
+      <div id="signupFormContainer" style="display:none;">
+        <h2>Sign Up</h2>
+        <form id="signupForm" autocomplete="off">
+          <input type="email" id="signupEmail" placeholder="Email" required autocomplete="username">
+          <input type="password" id="signupPassword" placeholder="Password" required autocomplete="new-password">
+          <button type="submit">Sign Up</button>
+          <button type="button" class="google-btn">Sign Up with Google</button>
+          <div class="error-message" id="signupError" style="display:none;"></div>
+        </form>
+        <p>Already have an account? <a href="#" id="showLogin">Login</a></p>
       </div>
-    </section>
+      <!-- Reset Password Form -->
+      <div id="resetFormContainer" style="display:none;">
+        <h2>Reset Password</h2>
+        <form id="resetForm" autocomplete="off">
+          <input type="email" id="resetEmail" placeholder="Enter your email" required autocomplete="username">
+          <button type="submit">Send Reset Link</button>
+          <div class="error-message" id="resetError" style="display:none;"></div>
+        </form>
+        <p>Remembered? <a href="#" id="showLoginFromReset">Back to Login</a></p>
+      </div>
+    </div>
+  </div>
+</header>
+<section class="page-banner">
+  <h1>Routes</h1>
+  <p>Browse active London bus routes.</p>
+</section>
 
-    <section class="network-flow card" aria-label="How route previews work">
-      <div class="network-flow__header">
-        <h2 class="network-flow__title">Follow a route from overview to arrivals</h2>
-        <p class="network-flow__intro">Tap any card to open a stop and vehicle preview. Pick a stop and the tracker loads that exact board instantly.</p>
-      </div>
-      <ol class="network-flow__steps">
-        <li>Click a route card to open the overlay with its full stop list and live vehicle registrations.</li>
-        <li>Select a stop to jump into the tracking console with that board already focused.</li>
-        <li>Save the stop, add notes or check disruptions without repeating your search.</li>
-      </ol>
-      <div class="network-flow__actions">
-        <a class="network-flow__link" href="tracking.html">Open live tracker</a>
-        <a class="network-flow__link" href="disruptions.html">Check network disruptions</a>
-      </div>
-    </section>
+<style>
+.navbar {
+  background: #fff;
+  border-bottom: 1px solid #e5e5e5;
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+  font-family: 'Segoe UI', Arial, sans-serif;
+}
 
-    <section class="network-section">
-      <h2 class="network-section__title">Available routes</h2>
-      <div class="network-grid" id="routesGrid" aria-live="polite"></div>
-    </section>
-  </main>
+.navbar__container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0.7rem 2vw;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.2rem;
+}
 
-  <div id="routeOverlay" class="route-overlay" hidden>
-    <div class="route-overlay__backdrop" data-route-overlay-dismiss></div>
-    <section class="route-overlay__panel" role="dialog" aria-modal="true" aria-labelledby="routeOverlayTitle">
-      <header class="route-overlay__header">
-        <div>
-          <p class="route-overlay__eyebrow">Route preview</p>
-          <h2 id="routeOverlayTitle">Route details</h2>
-          <p id="routeOverlayMeta" class="route-overlay__meta"></p>
-        </div>
-        <button type="button" class="route-overlay__close" id="routeOverlayClose" aria-label="Close route preview">×</button>
-      </header>
-      <p id="routeOverlayStatus" class="route-overlay__status" role="status" aria-live="polite"></p>
-      <div class="route-overlay__body">
-        <section class="route-overlay__section" aria-labelledby="routeOverlayStopsTitle">
-          <h3 id="routeOverlayStopsTitle">Stops</h3>
-          <div id="routeOverlayStops" class="route-overlay__stops" role="list"></div>
-        </section>
-        <section class="route-overlay__section" aria-labelledby="routeOverlayVehiclesTitle">
-          <h3 id="routeOverlayVehiclesTitle">Active vehicles</h3>
-          <div id="routeOverlayVehicles" class="route-overlay__vehicles" role="list"></div>
-        </section>
+.navbar__logo {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  text-decoration: none;
+  color: #c62828;
+}
+.navbar__logo img {
+  height: 38px;
+}
+.navbar__logo strong {
+  font-size: 1.25rem;
+  font-weight: bold;
+  letter-spacing: 1px;
+}
+
+/* Desktop nav links */
+.navbar__links {
+  display: flex;
+  gap: 1rem;
+}
+.navbar__links a {
+  color: #333;
+  text-decoration: none;
+  padding: 0.45rem 0.9rem;
+  border-radius: 6px;
+  font-weight: 500;
+  font-size: 1.05rem;
+  transition: background .18s, color .18s;
+}
+.navbar__links a.active,
+.navbar__links a:hover {
+  background: #2979ff;
+  color: #fff;
+}
+
+.navbar__controls {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+/* Hamburger button */
+.hamburger {
+  background: none;
+  border: none;
+  font-size: 1.55rem;
+  color: #c62828;
+  cursor: pointer;
+  display: none;
+}
+.account-menu {
+  position: relative;
+}
+.account-menu button {
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  color: #333;
+  padding: 0.15rem 0.4rem;
+  border-radius: 50%;
+  cursor: pointer;
+  transition: background 0.17s;
+}
+.account-menu button:hover {
+  background: #f0f0f0;
+}
+.account-dropdown {
+  display: none;
+  flex-direction: column;
+  position: absolute;
+  right: 0;
+  top: 125%;
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 4px 18px #0002;
+  min-width: 150px;
+  z-index: 10;
+  padding: 0.5rem 0;
+}
+.account-dropdown a,
+.account-dropdown button {
+  background: none;
+  border: none;
+  color: #333;
+  padding: 0.7rem 1rem;
+  text-align: left;
+  text-decoration: none;
+  font-size: 1rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.16s;
+}
+.account-dropdown a:hover,
+.account-dropdown button:hover {
+  background: #2979ff;
+  color: #fff;
+}
+.account-menu.open .account-dropdown {
+  display: flex;
+}
+
+/* Mobile Nav Drawer */
+.mobile-drawer {
+  display: flex;
+  flex-direction: column;
+  position: fixed;
+  top: 0; left: 0;
+  width: 80vw;
+  max-width: 340px;
+  height: 100vh;
+  background: #fff;
+  box-shadow: 2px 0 32px #0005;
+  padding: 2rem 1.1rem 1.1rem 1.1rem;
+  z-index: 1200;
+  transform: translateX(-100%);
+  transition: transform 0.3s cubic-bezier(.7,.3,.3,1);
+  gap: 0.7rem;
+  overflow-y: auto;
+}
+.mobile-drawer.open {
+  transform: translateX(0);
+}
+.mobile-drawer a,
+.mobile-drawer button {
+  color: #333;
+  text-decoration: none;
+  padding: 0.75rem 0.7rem;
+  border-radius: 6px;
+  font-weight: 500;
+  background: none;
+  border: none;
+  text-align: left;
+  font-size: 1.08rem;
+  transition: background .18s;
+  cursor: pointer;
+}
+.mobile-drawer a:hover,
+.mobile-drawer button:hover {
+  background: #2979ff;
+  color: #fff;
+}
+.mobile-drawer hr {
+  margin: 1rem 0;
+  border: none;
+  border-top: 1px solid #eee;
+}
+.close-drawer {
+  align-self: flex-end;
+  margin-bottom: 1.2rem;
+  color: #c62828;
+  font-size: 1.3rem;
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+
+/* Drawer backdrop */
+.drawer-backdrop {
+  display: none;
+  position: fixed;
+  top: 0; left: 0;
+  width: 100vw; height: 100vh;
+  background: rgba(30,30,30,0.28);
+  z-index: 1100;
+  transition: opacity 0.2s;
+}
+.drawer-backdrop.open {
+  display: block;
+  opacity: 1;
+}
+
+/* Responsive */
+@media (max-width: 950px) {
+  .navbar__links {
+    display: none;
+  }
+  .hamburger {
+    display: block;
+  }
+}
+
+/* Hide mobile drawer on desktop */
+@media (min-width: 951px) {
+  .mobile-drawer, .drawer-backdrop { display: none !important; }
+}
+.modal {
+  display: none;
+  position: fixed;
+  z-index: 2000;
+  left: 0; top: 0;
+  width: 100vw; height: 100vh;
+  background: rgba(0,0,0,0.38);
+}
+.modal-content {
+  background: #fff;
+  margin: 7% auto;
+  border-radius: 14px;
+  width: 94%;
+  max-width: 375px;
+  padding: 2.2rem 1.7rem 1.2rem 1.7rem;
+  position: relative;
+  box-shadow: 0 8px 44px #2979ff22;
+  color: #2d3a4a;
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+}
+.close {
+  position: absolute;
+  right: 1.1rem;
+  top: 1.1rem;
+  font-size: 2rem;
+  color: #888;
+  background: none;
+  border: none;
+  cursor: pointer;
+  transition: color .18s;
+}
+.close:hover { color: #d32f2f; }
+/* Form elements */
+.modal-content input {
+  width: 100%;
+  margin: 0.5rem 0;
+  border-radius: 8px;
+  border: 1.5px solid #bbb;
+  padding: 0.8rem;
+  font-size: 1.07rem;
+  background: #fff;
+  color: #222;
+  transition: border .17s;
+}
+.modal-content input:focus {
+  outline: none;
+  border: 2px solid #2979ff;
+}
+.modal-content button[type="submit"], .google-btn {
+  width: 100%;
+  margin: 0.7rem 0 0.2rem 0;
+  background: #2979ff;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  padding: 0.8rem 0;
+  font-size: 1.08rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background .18s;
+}
+.modal-content button[type="submit"]:hover, .google-btn:hover {
+  background: #1565c0;
+}
+.google-btn {
+  background: #4285F4;
+  margin-bottom: 0.5rem;
+}
+.google-btn:hover {
+  background: #357ae8;
+}
+.error-message {
+  color: #d32f2f;
+  font-size: 0.98rem;
+  text-align: left;
+  margin-top: 0.4rem;
+}
+.reset-password {
+  color: #2979ff;
+  text-decoration: underline;
+  cursor: pointer;
+  font-size: 0.98rem;
+  transition: color .18s;
+}
+.reset-password:hover { color: #d32f2f; }
+</style>
+
+<script>
+/* Account dropdown */
+document.getElementById('profileIcon').addEventListener('click', function(e) {
+  e.stopPropagation();
+  const menu = document.getElementById('accountMenu');
+  menu.classList.toggle('open');
+});
+document.addEventListener('click', function(e) {
+  document.getElementById('accountMenu').classList.remove('open');
+});
+
+/* Mobile drawer open/close */
+const hamburger = document.getElementById('hamburgerBtn');
+const drawer = document.getElementById('mobileDrawer');
+const backdrop = document.getElementById('drawerBackdrop');
+const closeBtn = document.getElementById('closeDrawerBtn');
+function openDrawer() {
+  drawer.classList.add('open');
+  backdrop.classList.add('open');
+  document.body.style.overflow = 'hidden';
+}
+function closeDrawer() {
+  drawer.classList.remove('open');
+  backdrop.classList.remove('open');
+  document.body.style.overflow = '';
+}
+hamburger.addEventListener('click', function(e) {
+  e.stopPropagation(); openDrawer();
+});
+closeBtn.addEventListener('click', closeDrawer);
+backdrop.addEventListener('click', closeDrawer);
+
+/* Highlight active nav link */
+const setActiveLink = (selector) => {
+  const links = document.querySelectorAll(selector);
+  const path = window.location.pathname.split('/').pop();
+  links.forEach(link => {
+    if (link.getAttribute('href') === path) {
+      link.classList.add('active');
+    }
+  });
+};
+setActiveLink('.navbar__links a');
+setActiveLink('.mobile-drawer a');
+
+/* Modal logic */
+function clearFormMessages() {
+  document.getElementById('loginError').style.display = 'none';
+  document.getElementById('signupError').style.display = 'none';
+  document.getElementById('resetError').style.display = 'none';
+}
+function openModal(mode) {
+  document.getElementById('authModal').style.display = 'block';
+  document.getElementById('loginFormContainer').style.display = (mode==='login') ? '' : 'none';
+  document.getElementById('signupFormContainer').style.display = (mode==='signup') ? '' : 'none';
+  document.getElementById('resetFormContainer').style.display = 'none';
+  clearFormMessages();
+}
+function closeModal() {
+  document.getElementById('authModal').style.display = 'none';
+  clearFormMessages();
+}
+document.getElementById('closeModal').onclick = closeModal;
+window.onclick = function(event) {
+  if (event.target === document.getElementById('authModal')) closeModal();
+};
+document.addEventListener('keydown', function(event) {
+  if (event.key === "Escape") closeModal();
+});
+
+/* Switch between forms */
+document.getElementById('showSignup').onclick = function(e) {
+  e.preventDefault(); openModal('signup');
+};
+document.getElementById('showLogin').onclick = function(e) {
+  e.preventDefault(); openModal('login');
+};
+document.getElementById('showLoginFromReset').onclick = function(e) {
+  e.preventDefault(); openModal('login');
+};
+document.getElementById('showReset').onclick = function(e) {
+  e.preventDefault();
+  document.getElementById('loginFormContainer').style.display = 'none';
+  document.getElementById('signupFormContainer').style.display = 'none';
+  document.getElementById('resetFormContainer').style.display = '';
+  clearFormMessages();
+};
+
+/* Dummy handlers for forms (replace with your own backend/auth logic) */
+document.getElementById('loginForm').onsubmit = function(e) {
+  e.preventDefault();
+  // Replace with actual login logic
+  closeModal();
+  alert('Logged in (demo)');
+};
+document.getElementById('signupForm').onsubmit = function(e) {
+  e.preventDefault();
+  // Replace with actual signup logic
+  closeModal();
+  alert('Signed up (demo)');
+};
+document.getElementById('resetForm').onsubmit = function(e) {
+  e.preventDefault();
+  // Replace with actual reset logic
+  closeModal();
+  alert('Password reset link sent (demo)');
+};
+document.querySelectorAll('.google-btn').forEach(btn => {
+  btn.onclick = function(e) {
+    e.preventDefault();
+    closeModal();
+    alert('Google sign-in (demo)');
+  };
+});
+
+/* Dummy sign out */
+function signOut() {
+  closeModal();
+  alert('Signed out (demo)');
+}
+</script>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
       </div>
-      <footer class="route-overlay__footer">
-        <a class="route-overlay__tracker" id="routeOverlayTracker" href="tracking.html">Open tracker</a>
-      </footer>
-    </section>
+    </div>
   </div>
 
-  <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-app-compat.js"></script>
-  <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-auth-compat.js"></script>
-  <script src="config.js"></script>
-  <script>
-    (function initialiseFirebase() {
-      const firebaseConfig = window.__ROUTEFLOW_CONFIG__?.firebase;
-      if (!firebaseConfig?.apiKey) {
-        console.error('Firebase configuration is missing. Routes page authentication will be disabled.');
-        return;
-      }
-      if (typeof firebase === 'undefined') {
-        console.error('Firebase SDK not loaded. Routes page authentication will be disabled.');
-        return;
-      }
-      if (!firebase.apps.length) {
-        firebase.initializeApp(firebaseConfig);
-      }
-    })();
-  </script>
-  <script src="navbar-loader.js" defer></script>
-  <script type="module" src="routes.js"></script>
+  <!-- ROUTES SECTION -->
+
+ <style>
+    body { font-family: 'Segoe UI', sans-serif; background: #f6f7fa; margin: 0; padding: 1.5em; color: #222; }
+    h1 { text-align: center; margin: 1em 0 1.5em; }
+    .controls-row { display: flex; gap: 1em; align-items: center; justify-content: flex-start; margin-bottom: 1.4em; flex-wrap: wrap;}
+    .search-bar { flex: 1 1 180px; }
+    #routeSearch {
+      width: 100%; font-size: 1.03em; padding: 0.5em 1em; border-radius: 6px;
+      border: 1.5px solid #bbb; background: #fff; color: #222;
+    }
+    #routeGroupSelect {
+      padding: 0.5em 1em; border-radius: 6px; border: 1.5px solid #bbb; font-size: 1.03em; background: #fff; color: #222;
+      min-width: 140px;
+    }
+    table { width: 100%; border-collapse: collapse; background: #fff; box-shadow: 0 2px 12px #0001; margin-bottom: 2em; }
+    th, td { padding: 0.8em; text-align: center; border-bottom: 1px solid #eee; }
+    th { background: #2d3a4a; color: #fff; }
+    tr:hover { background: #eef6ff; cursor: pointer; }
+    .btn { padding: 0.45em 1em; background: #2d3a4a; color: #fff; border: none; border-radius: 4px; cursor: pointer; }
+    .btn:hover { background: #1a2536; }
+    .modal, .arrival-modal, .reg-modal {
+      position: fixed; top: 0; left: 0; width: 100vw; height: 100vh;
+      background: rgba(0,0,0,0.5); display: none; justify-content: center; align-items: center; z-index: 3000;
+    }
+    .modal-content, .arrival-content, .reg-content {
+      background: #fff; padding: 2em; border-radius: 8px; max-height: 92vh; width: 96vw; max-width: 600px; overflow-y: auto;
+      position: relative;
+    }
+    .close {
+      position: absolute; right: 1.3em; top: 1.1em;
+      font-size: 1.6em; color: #888; background: none; border: none; cursor: pointer;
+    }
+    .close:hover { color: #d32f2f; }
+    .direction-switch { margin: 1em 0; text-align: center; }
+    #vehicleTable { margin-bottom: 1.5em; border: 1px solid #eee; border-radius: 6px; overflow: hidden; font-size: 1em;}
+    #vehicleTable th, #vehicleTable td { border-bottom: 1px solid #f6f7fa; }
+    #vehicleTable th { background: #f6f7fa; color: #222; }
+    .platform-bubble {
+      display: inline-block;
+      background: #2d3a4a;
+      color: #fff;
+      border-radius: 1.3em;
+      font-size: 1em;
+      padding: 0.16em 0.8em;
+      margin-left: 0.5em;
+    }
+    .arrival-title { font-weight: bold; font-size: 1.2em; margin-bottom: 0.9em; }
+    .arrivals-table, .reg-table { width: 100%; border-collapse: collapse; margin: 1em 0; }
+    .arrivals-table th, .arrivals-table td, .reg-table th, .reg-table td { padding: 0.5em; border-bottom: 1px solid #eee; }
+    .arrivals-table th, .reg-table th { background: #f6f7fa; }
+    .empty-row { color: #888; font-style: italic; }
+    .reg-btn-link { color: #2979ff; cursor: pointer; border: none; background: none; text-decoration: underline; }
+    .reg-btn-link:hover { color: #2d3a4a; }
+    @media (max-width: 950px) {
+      .controls-row { flex-direction: column; align-items: stretch; gap: 0.6em;}
+      .search-bar, #routeGroupSelect { width: 100%; min-width: 0; }
+    }
+    @media (max-width: 650px) {
+      .modal-content, .arrival-content, .reg-content { padding: 0.7em; max-width: 99vw; }
+      th, td { font-size: 0.93em; padding: 0.4em; }
+      .platform-bubble { font-size: 0.93em; padding: 0.14em 0.7em; }
+    }
+  </style>
+</head>
+<body>
+  <h1>London Bus Route Explorer</h1>
+  <div class="controls-row">
+    <div class="search-bar">
+      <input type="text" id="routeSearch" placeholder="Search by route, start, or destination...">
+    </div>
+    <select id="routeGroupSelect">
+      <option value="all">Show All Routes</option>
+      <option value="1-99">1-99</option>
+      <option value="100-199">100-199</option>
+      <option value="200-299">200-299</option>
+      <option value="300-399">300-399</option>
+      <option value="400-499">400-499</option>
+      <option value="500-599">500-599</option>
+      <option value="600-699">600-699</option>
+      <option value="900-999">900-999</option>
+      <option value="A-M">A-M</option>
+      <option value="N">N Routes</option>
+      <option value="P-X">P-X</option>
+    </select>
+  </div>
+  <table id="routesTable">
+    <thead>
+      <tr><th>Route Number</th><th>Start</th><th>Destination</th></tr>
+    </thead>
+    <tbody></tbody>
+  </table>
+
+  <!-- Route Modal -->
+  <div class="modal" id="routeModal">
+    <div class="modal-content">
+      <button class="close" onclick="closeModal('routeModal')">&times;</button>
+      <h2 id="routeTitle"></h2>
+      <div><strong>Current Vehicles:</strong>
+        <table id="vehicleTable">
+          <thead>
+            <tr><th>#</th><th>Vehicle ID</th></tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+      </div>
+      <div class="direction-switch">
+        <button class="btn" onclick="toggleDirection()">Switch Direction</button>
+      </div>
+      <table id="stopsTable">
+        <thead><tr><th>Stop Name</th><th>Platform</th><th>Live Info</th></tr></thead>
+        <tbody></tbody>
+      </table>
+      <button id="routePageBtn" class="btn" style="margin-top: 1em">More Info</button>
+    </div>
+  </div>
+
+  <!-- Arrivals Modal -->
+  <div class="arrival-modal" id="arrivalModal">
+    <div class="arrival-content">
+      <button class="close" onclick="closeModal('arrivalModal')">&times;</button>
+      <div class="arrival-title" id="arrivalTitle"></div>
+      <table class="arrivals-table">
+        <thead>
+          <tr>
+            <th>Line</th>
+            <th>Destination</th>
+            <th>Due (min)</th>
+            <th>Reg</th>
+          </tr>
+        </thead>
+        <tbody id="arrivalList"></tbody>
+      </table>
+    </div>
+  </div>
+
+  <!-- Reg Modal -->
+  <div class="reg-modal" id="regModal">
+    <div class="reg-content">
+      <button class="close" onclick="closeModal('regModal')">&times;</button>
+      <div class="arrival-title" id="regTitle"></div>
+      <table class="reg-table">
+        <thead>
+          <tr>
+            <th>Stop Name</th>
+            <th>Platform</th>
+            <th>Due (min)</th>
+          </tr>
+        </thead>
+        <tbody id="regList"></tbody>
+      </table>
+    </div>
+  </div>
+
+<script>
+const BASE = '/api/tfl';
+
+let allRoutes = [];
+let routeMeta = {};
+let filteredRoutes = [];
+let currentRouteId = null;
+let currentDirection = 'inbound';
+let currentBranch = 0;
+let currentStopSequences = [];
+
+// Fetch all bus routes with start/destination data
+async function fetchRoutes() {
+  const res = await fetch(`${BASE}/Line/Mode/bus/Route`);
+  const data = await res.json();
+  allRoutes = data;
+  routeMeta = {};
+  data.forEach(item => {
+    if (item.routeSections && item.routeSections.length > 0) {
+      routeMeta[item.id] = {
+        start: item.routeSections[0].originationName,
+        end: item.routeSections[0].destinationName
+      };
+    }
+  });
+  filteredRoutes = [...allRoutes];
+  renderRoutesTable();
+}
+fetchRoutes();
+
+function filterByDropdown(val, routes) {
+  return routes.filter(r => {
+    const name = r.name;
+    if (/^[0-9]+$/.test(name)) {
+      const num = parseInt(name, 10);
+      if (val === '1-99') return num >= 1 && num <= 99;
+      if (val === '100-199') return num >= 100 && num <= 199;
+      if (val === '200-299') return num >= 200 && num <= 299;
+      if (val === '300-399') return num >= 300 && num <= 399;
+      if (val === '400-499') return num >= 400 && num <= 499;
+      if (val === '500-599') return num >= 500 && num <= 599;
+      if (val === '600-699') return num >= 600 && num <= 699;
+      if (val === '900-999') return num >= 900 && num <= 999;
+    } else if (/^[A-Ma-m]/.test(name)) return val === 'A-M';
+    else if (/^N/.test(name)) return val === 'N';
+    else if (/^[P-Xp-x]/.test(name)) return val === 'P-X';
+    return val === 'all';
+  });
+}
+
+function filterBySearch(term, routes) {
+  if (!term) return routes;
+  const lcTerm = term.toLowerCase();
+  return routes.filter(route => {
+    if (!routeMeta[route.id]) return false;
+    return (
+      route.name.toLowerCase().includes(lcTerm) ||
+      routeMeta[route.id].start.toLowerCase().includes(lcTerm) ||
+      routeMeta[route.id].end.toLowerCase().includes(lcTerm)
+    );
+  });
+}
+
+function renderRoutesTable() {
+  const tbody = document.querySelector('#routesTable tbody');
+  tbody.innerHTML = '';
+  const sorted = [...filteredRoutes].sort((a, b) => {
+    let an = parseInt(a.name), bn = parseInt(b.name);
+    if (!isNaN(an) && !isNaN(bn)) return an - bn;
+    return a.name.localeCompare(b.name);
+  });
+  for (const route of sorted) {
+    if (!routeMeta[route.id]) continue;
+    const tr = document.createElement('tr');
+    tr.innerHTML = `
+      <td>${route.name}</td>
+      <td>${routeMeta[route.id].start}</td>
+      <td>${routeMeta[route.id].end}</td>
+    `;
+    tr.addEventListener('click', () => openRouteModal(route.id));
+    tbody.appendChild(tr);
+  }
+}
+
+document.getElementById('routeGroupSelect').addEventListener('change', function() {
+  applyFilters();
+});
+document.getElementById('routeSearch').addEventListener('input', function() {
+  applyFilters();
+});
+
+function applyFilters() {
+  const groupVal = document.getElementById('routeGroupSelect').value;
+  const searchVal = document.getElementById('routeSearch').value.trim();
+  let filtered = filterByDropdown(groupVal, allRoutes);
+  filtered = filterBySearch(searchVal, filtered);
+  filteredRoutes = filtered;
+  renderRoutesTable();
+}
+
+// Modal logic
+async function openRouteModal(routeId) {
+  currentRouteId = routeId;
+  currentDirection = 'inbound';
+  currentBranch = 0;
+  document.getElementById('routeTitle').textContent =
+    `Route ${routeId} — ${routeMeta[routeId]?.start || ''} ↔ ${routeMeta[routeId]?.end || ''}`;
+  document.getElementById('routePageBtn').onclick = () => {
+    window.open(`/routes/${routeId}.html`, '_blank');
+  };
+  await loadStops(routeId, currentDirection, currentBranch); // stops must be loaded first
+  await loadVehicleRegs(routeId);
+  document.getElementById('routeModal').style.display = 'flex';
+}
+
+// Show all active vehicle regs in a table
+async function loadVehicleRegs(routeId) {
+  const stops = currentStopSequences[currentBranch]?.stopPoint || [];
+  const vehicleSet = new Set();
+  const regRowMap = {}; // vehicleId: true
+  // Limit concurrent requests for performance
+  const maxConcurrent = 10;
+  let index = 0;
+  async function processNextBatch() {
+    const batch = stops.slice(index, index + maxConcurrent);
+    await Promise.all(batch.map(async stop => {
+      try {
+        const res = await fetch(`${BASE}/StopPoint/${stop.id}/Arrivals`);
+        const arrivals = await res.json();
+        arrivals.filter(a => a.lineId.toLowerCase() === routeId.toLowerCase()).forEach(a => {
+          if (a.vehicleId && !vehicleSet.has(a.vehicleId)) {
+            vehicleSet.add(a.vehicleId);
+          }
+        });
+      } catch (e) {}
+    }));
+    index += maxConcurrent;
+    if (index < stops.length) {
+      await processNextBatch();
+    }
+  }
+  await processNextBatch();
+  const tbody = document.querySelector('#vehicleTable tbody');
+  tbody.innerHTML = '';
+  if (vehicleSet.size === 0) {
+    tbody.innerHTML = `<tr><td colspan="2" class="empty-row">No active buses currently tracked.</td></tr>`;
+    return;
+  }
+  let idx = 1;
+  for (const vehicleId of vehicleSet) {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${idx++}</td><td><button class="reg-btn-link" onclick="showBusStopsForReg(event, '${vehicleId}')">${vehicleId}</button></td>`;
+    tbody.appendChild(tr);
+  }
+}
+
+// Load bus stops for route & direction
+async function loadStops(routeId, direction, branchId = 0) {
+  try {
+    const res = await fetch(`${BASE}/Line/${routeId}/Route/Sequence/${direction}`);
+    const data = await res.json();
+    currentStopSequences = data.stopPointSequences || [];
+    let stops = [];
+    if (currentStopSequences.length > 0) {
+      stops = currentStopSequences[branchId].stopPoint;
+    }
+    const tbody = document.querySelector('#stopsTable tbody');
+    tbody.innerHTML = '';
+    stops.forEach(stop => {
+      const tr = document.createElement('tr');
+      tr.innerHTML = `
+        <td>${stop.name}</td>
+        <td>${stop.stopLetter ? `<span class="platform-bubble">${stop.stopLetter}</span>` : '-'}</td>
+        <td><button class='btn' onclick="showArrivals(event, '${stop.id}', '${stop.name}', '${stop.stopLetter || ''}')">Live</button></td>
+      `;
+      tbody.appendChild(tr);
+    });
+  } catch (e) {
+    document.querySelector('#stopsTable tbody').innerHTML = '<tr><td colspan="3">Error loading stops.</td></tr>';
+  }
+}
+
+// Show arrivals popup for a stop (as table, with stationName as title, platformName as bubble)
+async function showArrivals(ev, stopId, stopName, stopLetter) {
+  ev.stopPropagation();
+  try {
+    const res = await fetch(`${BASE}/StopPoint/${stopId}/Arrivals`);
+    const data = await res.json();
+    document.getElementById('arrivalTitle').innerHTML = stopName +
+      (stopLetter ? `<span class="platform-bubble">${stopLetter}</span>` : '');
+    const tbody = document.getElementById('arrivalList');
+    tbody.innerHTML = '';
+    if (!data || data.length === 0) {
+      tbody.innerHTML = `<tr><td colspan="4" class="empty-row">No arrivals at this time.</td></tr>`;
+    } else {
+      data.sort((a, b) => a.timeToStation - b.timeToStation)
+        .forEach(item => {
+          const tr = document.createElement('tr');
+          tr.innerHTML = `<td>${item.lineName}</td>
+            <td>${item.destinationName}</td>
+            <td>${Math.round(item.timeToStation/60)}</td>
+            <td><button class="reg-btn-link" onclick="showBusStopsForReg(event, '${item.vehicleId}')">${item.vehicleId}</button></td>`;
+          tbody.appendChild(tr);
+        });
+    }
+    document.getElementById('arrivalModal').style.display = 'flex';
+  } catch (e) {
+    document.getElementById('arrivalTitle').textContent = stopName;
+    document.getElementById('arrivalList').innerHTML = '<tr><td colspan="4" class="empty-row">Error fetching arrivals.</td></tr>';
+    document.getElementById('arrivalModal').style.display = 'flex';
+  }
+}
+window.showArrivals = showArrivals;
+
+// Show bus current and next stops for a reg
+async function showBusStopsForReg(ev, vehicleId) {
+  ev.stopPropagation();
+  document.getElementById('regTitle').textContent = `Bus: ${vehicleId}`;
+  const tbody = document.getElementById('regList');
+  tbody.innerHTML = `<tr><td colspan="3">Loading...</td></tr>`;
+  try {
+    const res = await fetch(`${BASE}/Vehicle/${vehicleId}/Arrivals`);
+    const data = await res.json();
+    tbody.innerHTML = '';
+    if (!data || data.length === 0) {
+      tbody.innerHTML = `<tr><td colspan="3" class="empty-row">No predictions available for this bus.</td></tr>`;
+    } else {
+      data.sort((a, b) => a.timeToStation - b.timeToStation)
+        .forEach(item => {
+          const tr = document.createElement('tr');
+          tr.innerHTML = `
+            <td>${item.stationName}</td>
+            <td>${item.platformName ? `<span class="platform-bubble">${item.platformName}</span>` : '-'}</td>
+            <td>${Math.round(item.timeToStation/60)}</td>
+          `;
+          tbody.appendChild(tr);
+        });
+    }
+    document.getElementById('regModal').style.display = 'flex';
+  } catch (e) {
+    tbody.innerHTML = '<tr><td colspan="3" class="empty-row">Error loading predictions for this bus.</td></tr>';
+    document.getElementById('regModal').style.display = 'flex';
+  }
+}
+window.showBusStopsForReg = showBusStopsForReg;
+
+// Switch route direction
+async function toggleDirection() {
+  currentDirection = (currentDirection === 'inbound') ? 'outbound' : 'inbound';
+  await loadStops(currentRouteId, currentDirection, currentBranch);
+  await loadVehicleRegs(currentRouteId);
+}
+window.toggleDirection = toggleDirection;
+
+// Close modal logic
+function closeModal(id) {
+  document.getElementById(id).style.display = 'none';
+}
+window.closeModal = closeModal;
+</script>
 </body>
 </html>

--- a/tracking.html
+++ b/tracking.html
@@ -4,86 +4,355 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Tracking | RouteFlow London</title>
-  <link rel="icon" href="images/New_Routflow_London_Logo.png" type="image/png">
-  <link href="https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible:wght@400;600&family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
-  <link rel="stylesheet" href="style.css">
-  <link rel="stylesheet" href="tracking.css">
+  <link rel="icon" href="images/New_Routflow_London_Logo.png" type="image/png" />
+  <link href="https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible:wght@400;600&family=Inter:wght@400;600;800&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&family=Montserrat:wght@600&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" />
+  <link rel="stylesheet" href="style.css" />
+  <link rel="stylesheet" href="navbar.css" />
   <script src="theme.js" defer></script>
+  <style>
+    :root {
+      --bg: #f7f8fb;
+      --card: #ffffff;
+      --ink: #1a1d21;
+      --muted: #6b7280;
+      --ring: #e5e7eb;
+      --accent: #c8102e;
+      --shadow: 0 8px 24px rgba(16, 24, 40, 0.06);
+      --bus: #d01c1f;
+      --tube: #003688;
+      --dlr: #00afad;
+      --overground: #ff6d00;
+      --elizabeth-line: #6633cc;
+      --tram: #00a650;
+      --river-bus: #0aa7b8;
+      --national-rail: #0b3b8c;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--ink);
+      font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji";
+      display: flex;
+      flex-direction: column;
+      min-height: 100vh;
+    }
+
+    header.tracking-brand {
+      width: 100%;
+      padding: 24px 16px;
+      background: #fff;
+      border-bottom: 1px solid var(--ring);
+    }
+
+    header.tracking-brand .brand {
+      max-width: 1100px;
+      margin: 0 auto;
+      display: flex;
+      align-items: center;
+      gap: 12px;
+    }
+
+    header.tracking-brand h1 {
+      font-size: 20px;
+      font-weight: 700;
+      letter-spacing: 0.2px;
+      margin: 0;
+      color: var(--accent);
+    }
+
+    header.tracking-brand small {
+      color: var(--muted);
+    }
+
+    .search-wrap {
+      width: 100%;
+      max-width: 900px;
+      margin: 18px auto 8px;
+      padding: 0 16px;
+    }
+
+    .search {
+      position: relative;
+      width: 100%;
+      background: var(--card);
+      border: 1px solid var(--ring);
+      border-radius: 14px;
+      box-shadow: var(--shadow);
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 10px 12px;
+    }
+
+    .search input {
+      flex: 1;
+      border: 0;
+      outline: 0;
+      font-size: 16px;
+      padding: 10px 12px;
+      background: transparent;
+    }
+
+    .search button {
+      border: 0;
+      background: var(--accent);
+      color: #fff;
+      font-weight: 600;
+      padding: 10px 14px;
+      border-radius: 10px;
+      cursor: pointer;
+    }
+
+    .search button:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+
+    .results {
+      position: absolute;
+      left: 0;
+      right: 0;
+      top: calc(100% + 8px);
+      background: var(--card);
+      border: 1px solid var(--ring);
+      border-radius: 12px;
+      box-shadow: var(--shadow);
+      overflow: auto;
+      max-height: 420px;
+      display: none;
+      z-index: 20;
+    }
+
+    .result {
+      padding: 12px 14px;
+      border-bottom: 1px solid var(--ring);
+      cursor: pointer;
+      display: flex;
+      gap: 10px;
+      align-items: center;
+    }
+
+    .result:last-child {
+      border-bottom: none;
+    }
+
+    .result:hover {
+      background: #f3f4f6;
+    }
+
+    .r-main {
+      flex: 1;
+    }
+
+    .r-title {
+      font-weight: 700;
+    }
+
+    .r-sub {
+      font-size: 12px;
+      color: var(--muted);
+      margin-top: 2px;
+    }
+
+    .container {
+      width: 100%;
+      max-width: 1100px;
+      padding: 12px 16px 48px;
+      margin: 0 auto;
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 16px;
+      flex: 1 0 auto;
+    }
+
+    .board {
+      background: var(--card);
+      border: 1px solid var(--ring);
+      border-radius: 14px;
+      box-shadow: var(--shadow);
+      overflow: hidden;
+    }
+
+    .board-head {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 14px 16px;
+      background: #fbfbfc;
+      border-bottom: 1px solid var(--ring);
+      gap: 12px;
+    }
+
+    .board-title {
+      font-weight: 800;
+      margin: 0;
+    }
+
+    .meta {
+      font-size: 12px;
+      color: var(--muted);
+    }
+
+    .actions {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      flex-wrap: wrap;
+      justify-content: flex-end;
+    }
+
+    .action-btn {
+      background: var(--accent);
+      color: #fff;
+      border: 0;
+      border-radius: 6px;
+      padding: 6px 8px;
+      font-size: 12px;
+      cursor: pointer;
+    }
+
+    .rows {
+      display: flex;
+      flex-direction: column;
+    }
+
+    .row {
+      display: grid;
+      grid-template-columns: 110px 1fr 110px;
+      gap: 12px;
+      padding: 12px 16px;
+      border-bottom: 1px solid var(--ring);
+      align-items: center;
+    }
+
+    .row:last-child {
+      border-bottom: none;
+    }
+
+    .badge {
+      justify-self: start;
+      color: #fff;
+      font-weight: 800;
+      letter-spacing: 0.2px;
+      padding: 8px 10px;
+      border-radius: 10px;
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      min-width: 90px;
+      justify-content: center;
+      text-transform: uppercase;
+    }
+
+    .dest {
+      display: flex;
+      flex-direction: column;
+    }
+
+    .dest b {
+      font-weight: 700;
+    }
+
+    .dest small {
+      color: var(--muted);
+    }
+
+    .eta {
+      justify-self: end;
+      font-weight: 800;
+    }
+
+    .empty {
+      padding: 18px;
+      color: var(--muted);
+      text-align: center;
+    }
+
+    footer.site-footer {
+      text-align: center;
+      padding: 24px 16px;
+      color: var(--muted);
+      font-size: 14px;
+    }
+
+    footer.site-footer .footer-links {
+      margin-bottom: 8px;
+    }
+
+    footer.site-footer a {
+      color: inherit;
+      text-decoration: none;
+    }
+
+    footer.site-footer .social-icons {
+      display: flex;
+      justify-content: center;
+      gap: 12px;
+      margin-bottom: 8px;
+      font-size: 20px;
+    }
+
+    @media (max-width: 720px) {
+      .row {
+        grid-template-columns: 1fr;
+        text-align: center;
+        gap: 8px;
+      }
+
+      .eta {
+        justify-self: center;
+      }
+
+      .actions {
+        justify-content: flex-start;
+      }
+    }
+  </style>
 </head>
 <body>
   <div id="navbar-container"></div>
 
-  <main class="tracking-shell">
-    <section class="tracking-hero card">
-      <div class="tracking-hero__content">
-        <p class="tracking-hero__eyebrow">Live arrival board</p>
-        <h1>Track buses, tubes, trams and river services in real time.</h1>
-        <p>Search for any stop or station across the TfL network to see departures update automatically. Save favourites, jot down notes and keep your personal watch list close at hand.</p>
+  <header class="tracking-brand">
+    <div class="brand">
+      <h1>RouteFlow London</h1>
+      <small>Live arrivals for buses, tubes, trams & boats</small>
+    </div>
+    <div class="search-wrap">
+      <div class="search" id="searchBox">
+        <input id="q" type="text" placeholder="Search a station name or paste a Stop ID…" autocomplete="off" />
+        <button id="goBtn" type="button" disabled>Search</button>
+        <div class="results" id="results"></div>
       </div>
-      <ul class="tracking-hero__highlights">
-        <li>
-          <span>Live refresh</span>
-          <strong>Every 25 seconds</strong>
-        </li>
-        <li>
-          <span>Modes covered</span>
-          <strong>Bus, Tube, DLR, tram, river, rail</strong>
-        </li>
-        <li>
-          <span>Productivity</span>
-          <strong>Notes &amp; favourites built-in</strong>
-        </li>
-      </ul>
-    </section>
+    </div>
+  </header>
 
-    <section class="tracking-layout">
-      <section class="tracking-board card" aria-live="polite">
-        <header class="tracking-board__header">
-          <div>
-            <h2 id="boardTitle">No stop selected</h2>
-            <p id="boardMeta">Type a station or stop name to get started.</p>
-          </div>
-          <div class="tracking-board__actions">
-            <button class="tracking-chip" id="favBtn" type="button">☆ Favourite</button>
-            <button class="tracking-chip" id="noteBtn" type="button">📝 Add note</button>
-            <span class="tracking-board__timestamp" id="updated"></span>
-          </div>
-        </header>
-
-        <div class="tracking-search">
-          <label class="sr-only" for="q">Search for a stop or station</label>
-          <div class="tracking-search__field" id="searchBox">
-            <input id="q" type="text" placeholder="Search a station name or paste a Stop ID…" autocomplete="off" />
-            <button id="goBtn" type="button" disabled>Search</button>
-            <div class="tracking-search__results" id="results"></div>
-          </div>
+  <main class="container">
+    <section class="board" id="board" aria-live="polite">
+      <div class="board-head">
+        <div>
+          <h2 class="board-title" id="boardTitle">No stop selected</h2>
+          <div class="meta" id="boardMeta">Type a station name and choose a stop from the list.</div>
         </div>
-
-        <div class="tracking-board__rows" id="rows">
-          <div class="empty">Nothing to show yet.</div>
+        <div class="actions">
+          <button class="action-btn" id="favBtn" type="button">☆ Favourite</button>
+          <button class="action-btn" id="noteBtn" type="button">📝 Add note</button>
+          <div class="meta" id="updated"></div>
         </div>
-      </section>
-
-      <aside class="tracking-side">
-        <article class="tracking-side__card card">
-          <h3>Tips for faster searches</h3>
-          <ul>
-            <li>Paste a StopPoint ID (e.g. 490008660N) to jump straight to arrivals.</li>
-            <li>Use the favourites button to pin key stops to your profile dashboard.</li>
-            <li>Add notes for rare allocations, disruptions or personal reminders.</li>
-          </ul>
-        </article>
-        <article class="tracking-side__card card">
-          <h3>Need planning tools?</h3>
-          <p>Switch to the journey planner to compare multi-mode routes with accessibility filters.</p>
-          <a class="tracking-side__link" href="planning.html">Open journey planner</a>
-        </article>
-      </aside>
+      </div>
+      <div class="rows" id="rows">
+        <div class="empty">Nothing to show yet.</div>
+      </div>
     </section>
   </main>
 
-  <footer>
+  <footer class="site-footer">
     <div class="footer-links">
       <a href="about.html">About</a> |
       <a href="privacy.html">Privacy</a> |
@@ -91,21 +360,20 @@
       <a href="contact.html">Contact</a>
     </div>
     <div class="social-icons">
-      <a href="https://discord.gg/qVf3nN4Mgq"><i class="fa-brands fa-discord"></i></a>
-      <a href="https://www.tiktok.com/@the_bus_father"><i class="fab fa-tiktok"></i></a>
-      <a href="https://www.instagram.com/thebusfatherofficial/profilecard/?igsh=NXcybzV3cTA2azBo"><i class="fab fa-instagram"></i></a>
+      <a href="https://discord.gg/qVf3nN4Mgq" aria-label="Discord"><i class="fa-brands fa-discord"></i></a>
+      <a href="https://www.tiktok.com/@the_bus_father" aria-label="TikTok"><i class="fab fa-tiktok"></i></a>
+      <a href="https://www.instagram.com/thebusfatherofficial/profilecard/?igsh=NXcybzV3cTA2azBo" aria-label="Instagram"><i class="fab fa-instagram"></i></a>
     </div>
     <small>Made for London. Built from scratch.</small>
   </footer>
 
   <script src="config.js"></script>
-  <script src="navbar-loader.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-auth-compat.js"></script>
   <script src="main.js"></script>
   <script>
 const TFL_API_BASE = '/api/tfl';
-const MODES = "bus,tube,overground,dlr,tram,river-bus,national-rail,elizabeth-line";
+const MODES = 'bus,tube,overground,dlr,tram,river-bus,national-rail,elizabeth-line';
 const LAST_STOP_KEY = 'routeflow.lastStop';
 const q = document.getElementById('q');
 const goBtn = document.getElementById('goBtn');
@@ -118,339 +386,280 @@ const updated = document.getElementById('updated');
 let refreshTimer = null;
 let currentStop = null;
 let refreshSeconds = 25;
-let distanceUnit = "metric";
+let distanceUnit = 'metric';
 
-function storeLastStop(stop){
-  if(typeof window === 'undefined' || !('localStorage' in window)) return;
-  if(!stop || !stop.id) return;
-  try{
+function storeLastStop(stop) {
+  if (typeof window === 'undefined' || !('localStorage' in window)) return;
+  if (!stop || !stop.id) return;
+  try {
     window.localStorage.setItem(LAST_STOP_KEY, JSON.stringify({
       id: stop.id,
       name: stop.name || '',
       timestamp: Date.now()
     }));
-  }catch(e){
-    // ignore storage issues
-  }
+  } catch (e) {}
 }
 
-function updateTrackingUrl(stop){
-  if(typeof window === 'undefined' || !window.history?.replaceState) return;
-  try{
-    const url = new URL(window.location.href);
-    if(stop && stop.id){
-      url.searchParams.set('stopId', stop.id);
-      if(stop.name){
-        url.searchParams.set('stopName', stop.name);
-      }else{
-        url.searchParams.delete('stopName');
-      }
-    }else{
-      url.searchParams.delete('stopId');
-      url.searchParams.delete('stopName');
-    }
-    window.history.replaceState({}, '', url);
-  }catch(e){
-    // ignore URL update issues
-  }
-}
-
-function loadSettings(){
-  try{
+function loadSettings() {
+  try {
     const s = JSON.parse(localStorage.getItem('rfSettings')) || {};
     refreshSeconds = Number(s.refreshSeconds) || 25;
-    distanceUnit = s.distanceUnit || "metric";
-  }catch(e){
+    distanceUnit = s.distanceUnit || 'metric';
+  } catch (e) {
     refreshSeconds = 25;
-    distanceUnit = "metric";
+    distanceUnit = 'metric';
   }
 }
 loadSettings();
 
-/* ---------- helpers ---------- */
-const sleep = ms => new Promise(r=>setTimeout(r,ms));
-function debounce(fn, ms=300){
-  let t; return (...args)=>{ clearTimeout(t); t=setTimeout(()=>fn(...args),ms); };
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+function debounce(fn, ms = 300) {
+  let t;
+  return (...args) => {
+    clearTimeout(t);
+    t = setTimeout(() => fn(...args), ms);
+  };
 }
-function minsOrDue(seconds){
-  const m = Math.round(seconds/60);
-  return m <= 0 ? "Due" : `${m} min`;
+function minsOrDue(seconds) {
+  const m = Math.round(seconds / 60);
+  return m <= 0 ? 'Due' : `${m} min`;
 }
-function formatDistance(m){
-  return distanceUnit === "imperial" ? `${(m/1609.344).toFixed(2)} mi` : `${Math.round(m)} m`;
+function formatDistance(m) {
+  return distanceUnit === 'imperial' ? `${(m / 1609.344).toFixed(2)} mi` : `${Math.round(m)} m`;
 }
-function modeClass(mode){
+function modeClass(mode) {
   return `mode-${mode}`;
 }
-function modeIcon(mode){
-  switch(mode){
-    case "bus": return "🚍";
-    case "tube": return "🚇";
-    case "dlr": return "🚈";
-    case "overground": return "🟠";
-    case "elizabeth-line": return "🟣";
-    case "tram": return "🚊";
-    case "river-bus": return "⛴️";
-    case "national-rail": return "🚆";
-    default: return "🚌";
+function modeIcon(mode) {
+  switch (mode) {
+    case 'bus': return '🚍';
+    case 'tube': return '🚇';
+    case 'dlr': return '🚈';
+    case 'overground': return '🟠';
+    case 'elizabeth-line': return '🟣';
+    case 'tram': return '🚊';
+    case 'river-bus': return '⛴️';
+    case 'national-rail': return '🚆';
+    default: return '🚌';
   }
 }
-async function fetchJSON(url){
+async function fetchJSON(url) {
   const res = await fetch(url);
-  if(!res.ok) throw new Error(`HTTP ${res.status}`);
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
   return res.json();
 }
 
-/* ---------- search ---------- */
-async function search(query){
-  if(!query) { results.style.display="none"; return; }
+async function search(query) {
+  if (!query) {
+    results.style.display = 'none';
+    return;
+  }
 
-  if(/^\d{8,}[A-Z]?$/i.test(query.trim())){
-    results.style.display="none";
-    selectStop(query.trim(), "Selected stop");
+  if (/^\d{8,}[A-Z]?$/i.test(query.trim())) {
+    results.style.display = 'none';
+    selectStop(query.trim(), 'Selected stop');
     return;
   }
 
   const searchUrl = `${TFL_API_BASE}/StopPoint/Search/${encodeURIComponent(query)}?modes=${encodeURIComponent(MODES)}&maxResults=20`;
 
   let searchData;
-  try{
+  try {
     searchData = await fetchJSON(searchUrl);
-  }catch(e){
+  } catch (e) {
     console.error(e);
-    results.innerHTML = `<div class="result"><div class="r-main"><div class="r-title">Search failed</div><div class="r-sub">Check your connection</div></div></div>`;
-    results.style.display="block";
+    results.innerHTML = `<div class="result"><div class="r-main"><div class="r-title">Search failed</div><div class="r-sub">Check your connection and try again</div></div></div>`;
+    results.style.display = 'block';
     return;
   }
 
-  const matches = (searchData && searchData.matches) ? searchData.matches.slice(0,20) : [];
-  if(matches.length === 0){
+  const matches = (searchData && searchData.matches) ? searchData.matches.slice(0, 20) : [];
+  if (matches.length === 0) {
     results.innerHTML = `<div class="result"><div class="r-main"><div class="r-title">No results</div><div class="r-sub">Try another station name</div></div></div>`;
-    results.style.display="block";
+    results.style.display = 'block';
     return;
   }
 
-  const detailPromises = matches.map(m =>
-    fetchJSON(`${TFL_API_BASE}/StopPoint/${encodeURIComponent(m.id)}`).catch(()=>null)
-  );
+  const detailPromises = matches.map((m) => fetchJSON(`${TFL_API_BASE}/StopPoint/${m.id}`).catch(() => null));
   const details = await Promise.all(detailPromises);
 
   const entries = [];
-  details.forEach(sp => {
-    if(!sp) return;
-    if(Array.isArray(sp.children) && sp.children.length){
-      sp.children.forEach(child=>{
-        entries.push(child);
-      });
-    }else{
+  details.forEach((sp) => {
+    if (!sp) return;
+    if (Array.isArray(sp.children) && sp.children.length) {
+      sp.children.forEach((child) => entries.push(child));
+    } else {
       entries.push(sp);
     }
   });
 
-  results.innerHTML = entries.map(sp=>{
-    const stopName = sp.commonName || sp.name || "";
-    const stopLetter = sp.stopLetter || (sp.additionalProperties||[]).find(p=>p.key==="StopLetter")?.value || "";
-    const towards = (sp.additionalProperties||[]).find(p=>p.key==="Towards")?.value || "";
-    const mode = (sp.modes && sp.modes[0]) ? sp.modes[0] : "bus";
+  results.innerHTML = entries.map((sp) => {
+    const stopName = sp.commonName || sp.name || '';
+    const stopLetter = sp.stopLetter || (sp.additionalProperties || []).find((p) => p.key === 'StopLetter')?.value || '';
+    const towards = (sp.additionalProperties || []).find((p) => p.key === 'Towards')?.value || '';
+    const mode = (sp.modes && sp.modes[0]) ? sp.modes[0] : 'bus';
     const icon = modeIcon(mode);
-    const platformText = stopLetter ? `Platform: ${stopLetter}` : `Platform: –`;
-    const towardsText = towards ? `Towards: ${towards}` : `Towards: –`;
+    const platformText = stopLetter ? `Platform: ${stopLetter}` : 'Platform: –';
+    const towardsText = towards ? `Towards: ${towards}` : 'Towards: –';
 
     return `
       <div class="result" data-id="${sp.id}" data-name="${stopName}">
-        <div class="chip ${modeClass(mode)}" style="color:#fff;border-color:transparent;background:inherit;display:none"></div>
         <div class="r-main">
           <div class="r-title">${icon} ${stopName}</div>
-          <div class="r-sub">${platformText} &nbsp;•&nbsp; ${towardsText}</div>
+          <div class="r-sub">${platformText} · ${towardsText}</div>
         </div>
       </div>
     `;
-  }).join("");
+  }).join('');
 
-  Array.from(results.querySelectorAll('.result')).forEach(el=>{
-    el.addEventListener('click', ()=>{
+  Array.from(results.querySelectorAll('.result')).forEach((el) => {
+    el.addEventListener('click', () => {
       const id = el.getAttribute('data-id');
       const name = el.getAttribute('data-name');
-      results.style.display="none";
+      results.style.display = 'none';
       selectStop(id, name);
     });
   });
 
-  results.style.display="block";
+  results.style.display = 'block';
 }
 
-/* ---------- arrivals ---------- */
-async function loadArrivals(stopId, stopName){
-  boardTitle.textContent = stopName || "Live Arrivals";
-  boardMeta.textContent = "Fetching live data…";
+async function loadArrivals(stopId, stopName) {
+  boardTitle.textContent = stopName || 'Live Arrivals';
+  boardMeta.textContent = 'Fetching live data…';
   rows.innerHTML = `<div class="empty">Loading…</div>`;
 
-  try{
-    let data = await fetchJSON(`${TFL_API_BASE}/StopPoint/${encodeURIComponent(stopId)}/Arrivals`);
+  try {
+    let data = await fetchJSON(`${TFL_API_BASE}/StopPoint/${stopId}/Arrivals`);
 
-    if(!Array.isArray(data) || data.length===0){
-      const info = await fetchJSON(`${TFL_API_BASE}/StopPoint/${encodeURIComponent(stopId)}`).catch(()=>null);
-      if(info && Array.isArray(info.children) && info.children.length){
-        const childReqs = info.children.map(c =>
-          fetchJSON(`${TFL_API_BASE}/StopPoint/${encodeURIComponent(c.id)}/Arrivals`).catch(()=>[])
-        );
+    if (!Array.isArray(data) || data.length === 0) {
+      const info = await fetchJSON(`${TFL_API_BASE}/StopPoint/${stopId}`).catch(() => null);
+      if (info && Array.isArray(info.children) && info.children.length) {
+        const childReqs = info.children.map((c) => fetchJSON(`${TFL_API_BASE}/StopPoint/${c.id}/Arrivals`).catch(() => []));
         const childData = (await Promise.all(childReqs)).flat();
         data = childData;
       }
     }
 
-    if(!Array.isArray(data) || data.length===0){
+    if (!Array.isArray(data) || data.length === 0) {
       rows.innerHTML = `<div class="empty">No live arrivals right now.</div>`;
       updated.textContent = new Date().toLocaleTimeString();
-      boardMeta.textContent = "";
+      boardMeta.textContent = '';
       return;
     }
 
-    data.sort((a,b)=> a.timeToStation - b.timeToStation);
+    data.sort((a, b) => a.timeToStation - b.timeToStation);
 
-    rows.innerHTML = data.map(a=>{
-      const mode = (a.modeName || "bus");
+    rows.innerHTML = data.map((a) => {
+      const mode = (a.modeName || 'bus');
       const badgeClass = modeClass(mode);
       const icon = modeIcon(mode);
       const eta = minsOrDue(a.timeToStation);
-      const line = a.lineName || a.lineId || "";
+      const line = a.lineName || a.lineId || '';
 
       const details = [];
-      if(a.vehicleId) details.push(`Reg: ${a.vehicleId}`);
-      if(typeof a.distance === 'number') details.push(formatDistance(a.distance));
+      if (a.vehicleId) details.push(`Reg: ${a.vehicleId}`);
+      if (typeof a.distance === 'number') details.push(formatDistance(a.distance));
       const detailStr = details.join(' • ');
 
       return `
         <div class="row">
-          <div class="badge ${badgeClass}" style="background:var(--${mode.replace(/ /g,'') || 'bus'})">
+          <div class="badge ${badgeClass}" style="background: var(--${mode}, var(--accent))">
             ${icon} ${line}
           </div>
           <div class="dest">
-            <b>${a.destinationName || a.towards || "—"}</b>
+            <b>${a.destinationName || a.towards || '—'}</b>
             <small>${detailStr}</small>
           </div>
           <div class="eta">${eta}</div>
         </div>
       `;
-    }).join("");
+    }).join('');
 
     updated.textContent = `Updated ${new Date().toLocaleTimeString()}`;
-    boardMeta.textContent = "";
-  }catch(e){
+    boardMeta.textContent = '';
+    storeLastStop({ id: stopId, name: stopName });
+  } catch (e) {
     console.error(e);
     rows.innerHTML = `<div class="empty">Error loading arrivals.</div>`;
-    boardMeta.textContent = "Please try again.";
+    boardMeta.textContent = 'Please try again.';
   }
 }
 
-function startRefreshTimer(){
-  if(refreshTimer) clearInterval(refreshTimer);
-  refreshTimer = setInterval(()=> {
-    if(currentStop) loadArrivals(currentStop.id, currentStop.name);
+function startRefreshTimer() {
+  if (refreshTimer) clearInterval(refreshTimer);
+  refreshTimer = setInterval(() => {
+    if (currentStop) loadArrivals(currentStop.id, currentStop.name);
   }, refreshSeconds * 1000);
 }
 
-function selectStop(id, name){
+function selectStop(id, name) {
   loadSettings();
   currentStop = { id, name };
   q.value = name;
-  results.style.display = "none";
-  updateTrackingUrl(currentStop);
-  storeLastStop(currentStop);
+  results.style.display = 'none';
   loadArrivals(id, name);
   startRefreshTimer();
 }
 
-q.addEventListener('input', debounce((event)=>{
-  const value = event.target.value.trim();
-  goBtn.disabled = !value;
-  search(value);
-}, 250));
+const runSearch = debounce(() => search(q.value.trim()), 250);
 
-q.addEventListener('keydown', (event) => {
-  if (event.key === 'Enter') {
-    event.preventDefault();
-    const value = q.value.trim();
-    if (value) {
-      search(value);
+q.addEventListener('input', () => {
+  goBtn.disabled = q.value.trim().length < 2;
+  runSearch();
+});
+q.addEventListener('focus', () => {
+  if (results.innerHTML.trim()) results.style.display = 'block';
+});
+document.addEventListener('click', (e) => {
+  if (!document.getElementById('searchBox').contains(e.target)) {
+    results.style.display = 'none';
+  }
+});
+q.addEventListener('keydown', (e) => {
+  if (e.key === 'Enter') {
+    e.preventDefault();
+    if (results.style.display !== 'block') runSearch();
+  }
+});
+goBtn.addEventListener('click', () => runSearch());
+
+(function restoreLastStop() {
+  try {
+    const saved = JSON.parse(localStorage.getItem(LAST_STOP_KEY));
+    if (saved && saved.id && Date.now() - saved.timestamp < 12 * 60 * 60 * 1000) {
+      selectStop(saved.id, saved.name);
     }
-  }
-});
-
-goBtn.addEventListener('click', ()=>{
-  const value = q.value.trim();
-  if(!value) return;
-  search(value);
-});
-
-document.addEventListener('click', (event)=>{
-  if(!event.target.closest('#searchBox')){
-    results.style.display = "none";
-  }
-});
-
-const params = new URLSearchParams(window.location.search);
-const initialStopId = params.get('stopId');
-const initialStopName = params.get('stopName');
-if(initialStopId){
-  selectStop(initialStopId, initialStopName || 'Selected stop');
-}
-
-window.addEventListener('beforeunload', () => {
-  if(refreshTimer) clearInterval(refreshTimer);
-});
+  } catch (e) {}
+})();
   </script>
   <script type="module">
-    import { addFavourite } from './favourites.js';
-    import { addNote } from './notes.js';
+import { addFavourite } from './favourites.js';
+import { addNote } from './notes.js';
 
-    const favBtn = document.getElementById('favBtn');
-    const noteBtn = document.getElementById('noteBtn');
+const favBtn = document.getElementById('favBtn');
+const noteBtn = document.getElementById('noteBtn');
 
-    favBtn?.addEventListener('click', async () => {
-      const user = firebase.auth()?.currentUser;
-      if (!user || !currentStop) {
-        alert('Select a stop and sign in first.');
-        return;
-      }
-      try {
-        favBtn.disabled = true;
-        await addFavourite(user.uid, currentStop);
-        favBtn.textContent = '★ Favourited';
-      } catch (error) {
-        console.error('Failed to save stop as favourite from tracker view.', error);
-        alert('We could not save this favourite. Please try again.');
-      } finally {
-        favBtn.disabled = false;
-      }
-    });
+favBtn.addEventListener('click', () => {
+  const user = firebase.auth().currentUser;
+  if (!user || !currentStop) {
+    alert('Select a stop and sign in first');
+    return;
+  }
+  addFavourite(user.uid, currentStop);
+  favBtn.textContent = '★ Favourited';
+});
 
-    noteBtn?.addEventListener('click', async () => {
-      const user = firebase.auth()?.currentUser;
-      if (!user || !currentStop) {
-        alert('Select a stop and sign in first.');
-        return;
-      }
-      const text = prompt('Enter a note for this stop:');
-      if (!text) {
-        return;
-      }
-      const trimmedText = text.trim();
-      if (!trimmedText) {
-        alert('Your note cannot be empty.');
-        return;
-      }
-      const stopName = (currentStop.name || currentStop.title || currentStop.id || 'Saved stop').toString().trim() || 'Saved stop';
-      try {
-        noteBtn.disabled = true;
-        await addNote(user.uid, { id: currentStop.id, name: stopName, text: trimmedText });
-      } catch (error) {
-        console.error('Failed to add note from tracker view.', error);
-        alert('We could not save this note. Please try again.');
-      } finally {
-        noteBtn.disabled = false;
-      }
-    });
+noteBtn.addEventListener('click', () => {
+  const user = firebase.auth().currentUser;
+  if (!user || !currentStop) {
+    alert('Select a stop and sign in first');
+    return;
+  }
+  const text = prompt('Enter a note for this stop:');
+  if (text) addNote(user.uid, { id: currentStop.id, name: currentStop.name, text });
+});
   </script>
+  <script src="navbar-loader.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- make pagination follow the originating request when walking TfL next links so every discovery endpoint is supported
- restore the simplified journey planner form so it mirrors the last known working layout while still using the backend proxy
- bring back the previous tracking console and route distribution tooling, updated to call the backend instead of embedding TfL API keys

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68cc869d0db08322af1e34ed8a335c83