### PR TITLE
Overhaul homepage and dashboard with gamified design

### DIFF
--- a/dashboard.css
+++ b/dashboard.css
@@ -1,83 +1,592 @@
 .dashboard {
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 1.5rem;
-  max-width: 1200px;
-  margin: 2rem auto;
-  padding: 0 1rem;
-}
-@media(min-width:900px){
-  .dashboard { grid-template-columns: 1fr 1fr; }
-}
-.dashboard-column {
+  max-width: 1240px;
+  margin: clamp(3rem, 6vw, 4rem) auto clamp(4rem, 8vw, 5.5rem);
+  padding: 0 clamp(1rem, 4vw, 2.4rem);
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: clamp(2rem, 4vw, 3.2rem);
 }
-.card {
+
+.dashboard .card {
   background: var(--card-bg-light);
-  border-radius: var(--border-radius);
-  padding: 1.5rem;
-  box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+  border-radius: 26px;
+  padding: clamp(1.8rem, 3vw, 2.6rem);
+  border: 1px solid var(--glass-border);
+  box-shadow: var(--shadow-soft);
+  backdrop-filter: blur(18px);
 }
-body.dark-mode .card { background: var(--card-bg-dark); }
-.profile-card {
-  display: flex;
+
+body.dark-mode .dashboard .card {
+  background: var(--card-bg-dark);
+  border-color: var(--glass-border-dark);
+  box-shadow: var(--shadow-soft-dark);
+}
+
+.dashboard-hero {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
   align-items: center;
-  gap: 1rem;
+  gap: clamp(1.6rem, 3vw, 2.6rem);
+  background: linear-gradient(130deg, rgba(0, 54, 136, 0.18), rgba(29, 126, 240, 0.12));
+  position: relative;
+  overflow: hidden;
 }
-.profile-card img {
-  width: 70px;
-  height: 70px;
+
+.dashboard-hero::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top left, rgba(29, 126, 240, 0.22), transparent 55%),
+              radial-gradient(circle at bottom right, rgba(0, 54, 136, 0.26), transparent 60%);
+  z-index: 0;
+}
+
+.dashboard-hero > * {
+  position: relative;
+  z-index: 1;
+}
+
+.dashboard-hero__profile {
+  display: flex;
+  align-items: flex-start;
+  gap: clamp(1rem, 2vw, 1.6rem);
+}
+
+.dashboard-hero__profile img {
+  width: 82px;
+  height: 82px;
   border-radius: 50%;
   object-fit: cover;
+  box-shadow: 0 12px 28px rgba(9, 46, 121, 0.18);
 }
-.activity-list {
-  list-style: none;
-  padding: 0;
+
+.dashboard-hero__eyebrow {
   margin: 0;
-  max-height: 200px;
-  overflow-y: auto;
+  font-size: 0.78rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--accent-blue);
+  font-weight: 700;
 }
-.activity-list li {
-  padding: 0.5rem 0;
-  border-bottom: 1px solid #ddd;
+
+.dashboard-hero__hint {
+  margin: 0.4rem 0 0;
+  color: rgba(11, 23, 54, 0.72);
 }
-body.dark-mode .activity-list li { border-color: #444; }
-.favourites-grid {
+
+body.dark-mode .dashboard-hero__hint {
+  color: rgba(245, 248, 255, 0.75);
+}
+
+.dashboard-hero__xp {
+  margin-top: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.dashboard-hero__xp-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.dashboard-hero__level strong {
+  font-size: 1.4rem;
+  margin-left: 0.3rem;
+}
+
+.dashboard-hero__xp-balance {
+  color: var(--accent-blue);
+}
+
+.dashboard-hero__progress {
+  width: 100%;
+  height: 10px;
+  border-radius: 999px;
+  background: rgba(29, 126, 240, 0.12);
+  overflow: hidden;
+}
+
+.dashboard-hero__progress-bar {
+  width: var(--progress, 0%);
+  height: 100%;
+  background: linear-gradient(90deg, rgba(29, 126, 240, 0.8), rgba(0, 54, 136, 0.92));
+  border-radius: inherit;
+  transition: width 0.4s ease;
+}
+
+.dashboard-hero__progress-copy {
+  margin: 0;
+  font-size: 0.9rem;
+  color: rgba(11, 23, 54, 0.68);
+}
+
+body.dark-mode .dashboard-hero__progress {
+  background: rgba(29, 126, 240, 0.25);
+}
+
+body.dark-mode .dashboard-hero__progress-copy {
+  color: rgba(245, 248, 255, 0.72);
+}
+
+.dashboard-hero__actions {
+  display: flex;
+  flex-direction: column;
+  gap: 1.4rem;
+}
+
+.dashboard-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65rem;
+  padding: 0.75rem 1.4rem;
+  border-radius: 999px;
+  border: 1px solid rgba(29, 126, 240, 0.25);
+  background: rgba(255, 255, 255, 0.72);
+  color: var(--accent-blue);
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform var(--transition), box-shadow var(--transition), background var(--transition);
+}
+
+.dashboard-pill:hover,
+.dashboard-pill:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 34px rgba(29, 126, 240, 0.22);
+}
+
+.dashboard-pill.is-connected {
+  background: rgba(29, 126, 240, 0.15);
+  color: var(--accent-blue);
+  border-color: rgba(29, 126, 240, 0.35);
+}
+
+body.dark-mode .dashboard-pill {
+  background: rgba(29, 126, 240, 0.2);
+  color: #fff;
+}
+
+.dashboard-hero__stats {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(160px,1fr));
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 0.9rem;
+}
+
+.dashboard-hero__stats div {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 0.75rem 1rem;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.7);
+  border: 1px solid rgba(29, 126, 240, 0.1);
+  text-transform: uppercase;
+  font-size: 0.7rem;
+  letter-spacing: 0.12em;
+}
+
+.dashboard-hero__stats strong {
+  font-size: 1.2rem;
+  letter-spacing: normal;
+  text-transform: none;
+}
+
+body.dark-mode .dashboard-hero__stats div {
+  background: rgba(11, 24, 46, 0.82);
+  border-color: rgba(148, 172, 214, 0.2);
+}
+
+.dashboard-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: clamp(1.5rem, 3vw, 2.5rem);
+}
+
+.dashboard-card__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1.4rem;
+}
+
+.dashboard-card__eyebrow {
+  margin: 0;
+  font-size: 0.76rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--accent-blue);
+  font-weight: 700;
+}
+
+.dashboard-card__action {
+  border: 1px solid rgba(29, 126, 240, 0.25);
+  background: transparent;
+  color: var(--accent-blue);
+  border-radius: 999px;
+  padding: 0.45rem 1.2rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.dashboard-card__meta {
+  font-size: 0.9rem;
+  color: rgba(11, 23, 54, 0.6);
+}
+
+body.dark-mode .dashboard-card__meta {
+  color: rgba(245, 248, 255, 0.68);
+}
+
+.dashboard-task-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
   gap: 1rem;
 }
-.dashboard-empty {
-  grid-column: 1 / -1;
-  margin: 0;
-  padding: 0.75rem;
-  text-align: center;
-  font-size: 0.95rem;
-  opacity: 0.7;
+
+.dashboard-task {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1.1rem 1.3rem;
+  border-radius: 18px;
+  border: 1px solid rgba(29, 126, 240, 0.12);
+  background: rgba(255, 255, 255, 0.76);
 }
+
+.dashboard-task strong {
+  display: block;
+  font-size: 1rem;
+}
+
+.dashboard-task p {
+  margin: 0.35rem 0 0;
+  font-size: 0.9rem;
+  color: rgba(11, 23, 54, 0.68);
+}
+
+.dashboard-task__meta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.6rem;
+}
+
+.dashboard-task__xp {
+  font-weight: 600;
+  color: var(--accent-blue);
+}
+
+.dashboard-task__button {
+  border: none;
+  border-radius: 999px;
+  padding: 0.5rem 1.4rem;
+  font-weight: 600;
+  background: var(--accent-blue);
+  color: #fff;
+  cursor: pointer;
+}
+
+.dashboard-task.is-complete {
+  background: rgba(29, 126, 240, 0.12);
+  border-style: dashed;
+}
+
+.dashboard-task.is-complete .dashboard-task__button {
+  background: rgba(29, 126, 240, 0.2);
+  color: var(--accent-blue);
+  cursor: not-allowed;
+}
+
+body.dark-mode .dashboard-task {
+  background: rgba(11, 24, 46, 0.82);
+  border-color: rgba(148, 172, 214, 0.2);
+}
+
+body.dark-mode .dashboard-task p {
+  color: rgba(245, 248, 255, 0.72);
+}
+
+body.dark-mode .dashboard-task__button {
+  background: rgba(29, 126, 240, 0.7);
+}
+
+body.dark-mode .dashboard-task.is-complete {
+  background: rgba(29, 126, 240, 0.22);
+}
+
+body.dark-mode .dashboard-task.is-complete .dashboard-task__button {
+  background: rgba(29, 126, 240, 0.3);
+  color: rgba(245, 248, 255, 0.9);
+}
+
+.dashboard-badge-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.2rem;
+}
+
+.dashboard-badge {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 1.1rem;
+  border-radius: 20px;
+  padding: 1.1rem 1.3rem;
+  border: 1px solid rgba(29, 126, 240, 0.12);
+  background: rgba(255, 255, 255, 0.75);
+}
+
+.dashboard-badge__icon {
+  width: 52px;
+  height: 52px;
+  border-radius: 18px;
+  background: rgba(29, 126, 240, 0.14);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.4rem;
+  color: var(--accent-blue);
+}
+
+.dashboard-badge__content h3 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.dashboard-badge__content p {
+  margin: 0.3rem 0;
+  font-size: 0.9rem;
+  color: rgba(11, 23, 54, 0.7);
+}
+
+.dashboard-badge__progress {
+  width: 100%;
+  height: 8px;
+  border-radius: 999px;
+  background: rgba(29, 126, 240, 0.16);
+  overflow: hidden;
+  margin: 0.6rem 0;
+}
+
+.dashboard-badge__progress-bar {
+  width: var(--progress, 0%);
+  height: 100%;
+  background: linear-gradient(90deg, rgba(29, 126, 240, 0.8), rgba(0, 54, 136, 0.9));
+}
+
+.dashboard-badge__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  font-size: 0.85rem;
+}
+
+.dashboard-badge__xp {
+  font-weight: 600;
+  color: var(--accent-blue);
+}
+
+.dashboard-badge__claim {
+  border: none;
+  border-radius: 999px;
+  padding: 0.4rem 1.2rem;
+  background: var(--accent-blue);
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.dashboard-badge.is-earned {
+  border-style: solid;
+  border-color: rgba(29, 126, 240, 0.3);
+  background: rgba(29, 126, 240, 0.12);
+}
+
+body.dark-mode .dashboard-badge {
+  background: rgba(11, 24, 46, 0.84);
+  border-color: rgba(148, 172, 214, 0.2);
+}
+
+body.dark-mode .dashboard-badge__content p,
+body.dark-mode .dashboard-task__xp,
+body.dark-mode .dashboard-mini__xp {
+  color: rgba(148, 200, 255, 0.9);
+}
+
+body.dark-mode .dashboard-badge__icon {
+  background: rgba(29, 126, 240, 0.25);
+  color: #fff;
+}
+
+body.dark-mode .dashboard-badge.is-earned {
+  background: rgba(29, 126, 240, 0.26);
+  border-color: rgba(29, 126, 240, 0.4);
+}
+
+.dashboard-role-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1.1rem;
+}
+
+.dashboard-role {
+  border-radius: 18px;
+  padding: 1.1rem 1.3rem;
+  border: 1px solid rgba(29, 126, 240, 0.12);
+  background: rgba(255, 255, 255, 0.74);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.dashboard-role header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.dashboard-role__platform {
+  font-size: 0.72rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(11, 23, 54, 0.65);
+}
+
+.dashboard-role__status {
+  margin-top: auto;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.dashboard-role.is-active {
+  border-color: rgba(29, 126, 240, 0.3);
+  background: rgba(29, 126, 240, 0.1);
+}
+
+body.dark-mode .dashboard-role {
+  background: rgba(11, 24, 46, 0.84);
+  border-color: rgba(148, 172, 214, 0.2);
+}
+
+body.dark-mode .dashboard-role__platform {
+  color: rgba(245, 248, 255, 0.68);
+}
+
+body.dark-mode .dashboard-role.is-active {
+  background: rgba(29, 126, 240, 0.24);
+  border-color: rgba(29, 126, 240, 0.4);
+}
+
+.dashboard-mini-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.1rem;
+}
+
+.dashboard-mini {
+  border-radius: 18px;
+  border: 1px solid rgba(29, 126, 240, 0.12);
+  background: rgba(255, 255, 255, 0.74);
+  padding: 1.2rem 1.3rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+}
+
+body.dark-mode .dashboard-mini {
+  background: rgba(11, 24, 46, 0.84);
+  border-color: rgba(148, 172, 214, 0.2);
+}
+
+.dashboard-mini__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.dashboard-mini__xp {
+  font-weight: 600;
+  color: var(--accent-blue);
+}
+
+.dashboard-mini__button {
+  border: none;
+  border-radius: 999px;
+  background: var(--accent-blue);
+  color: #fff;
+  font-weight: 600;
+  padding: 0.45rem 1.3rem;
+  cursor: pointer;
+}
+
+.activity-list,
+.recents-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+  max-height: 250px;
+  overflow-y: auto;
+}
+
+.activity-list li,
+.recents-list li {
+  padding-bottom: 0.75rem;
+  border-bottom: 1px solid rgba(29, 126, 240, 0.1);
+}
+
+body.dark-mode .activity-list li,
+body.dark-mode .recents-list li {
+  border-color: rgba(148, 172, 214, 0.18);
+}
+
+.recents-list a {
+  color: inherit;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.favourites-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+}
+
 .favourite-item {
   display: flex;
   flex-direction: column;
   gap: 0.65rem;
-  background: var(--card-bg-light);
-  border-radius: 12px;
-  padding: 1rem;
-  border: 1px solid rgba(0, 0, 0, 0.05);
-  box-shadow: 0 1px 3px rgba(15, 23, 42, 0.08);
+  background: rgba(255, 255, 255, 0.78);
+  border-radius: 18px;
+  padding: 1rem 1.2rem;
+  border: 1px solid rgba(29, 126, 240, 0.12);
+  box-shadow: 0 12px 30px rgba(9, 46, 121, 0.08);
 }
+
 body.dark-mode .favourite-item {
-  background: var(--card-bg-dark);
-  border-color: rgba(255, 255, 255, 0.08);
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.35);
+  background: rgba(11, 24, 46, 0.82);
+  border-color: rgba(148, 172, 214, 0.2);
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.45);
 }
+
 .favourite-item__header {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 0.75rem;
 }
+
 .favourite-item__eyebrow {
   font-size: 0.72rem;
   text-transform: uppercase;
@@ -85,23 +594,23 @@ body.dark-mode .favourite-item {
   color: var(--accent-blue);
   font-weight: 700;
 }
+
 body.dark-mode .favourite-item__eyebrow {
-  color: var(--accent-blue);
+  color: rgba(148, 200, 255, 0.9);
 }
+
 .favourite-item__title {
   margin: 0;
   font-size: 1.1rem;
   line-height: 1.3;
 }
+
 .favourite-item__meta {
   margin: 0;
   font-size: 0.92rem;
   opacity: 0.78;
 }
-.favourite-item__meta span {
-  display: inline-block;
-  margin-right: 0.35rem;
-}
+
 .favourite-item__remove {
   margin-left: auto;
   border-radius: 999px;
@@ -114,16 +623,19 @@ body.dark-mode .favourite-item__eyebrow {
   cursor: pointer;
   transition: background var(--transition), color var(--transition), border-color var(--transition);
 }
+
 .favourite-item__remove:hover,
 .favourite-item__remove:focus-visible {
   background: var(--accent-blue);
   color: #fff;
   border-color: var(--accent-blue);
 }
+
 body.dark-mode .favourite-item__remove {
   border-color: rgba(255, 255, 255, 0.35);
   color: var(--foreground-dark);
 }
+
 body.dark-mode .favourite-item__remove:hover,
 body.dark-mode .favourite-item__remove:focus-visible {
   color: #000;
@@ -131,41 +643,163 @@ body.dark-mode .favourite-item__remove:focus-visible {
   border-color: var(--foreground-dark);
 }
 
-.recents-list {
-  list-style: none;
-  padding: 0;
+.dashboard-empty {
+  grid-column: 1 / -1;
   margin: 0;
-  max-height: 200px;
-  overflow-y: auto;
+  padding: 1.2rem;
+  text-align: center;
+  font-size: 0.95rem;
+  opacity: 0.74;
 }
-.recents-list li {
-  padding: 0.5rem 0;
-  border-bottom: 1px solid #ddd;
+
+.dashboard-dialog::backdrop {
+  background: rgba(5, 10, 24, 0.55);
+  backdrop-filter: blur(4px);
 }
-body.dark-mode .recents-list li { border-color: #444; }
-.setting-item {
+
+.dashboard-dialog {
+  border: none;
+  padding: 0;
+  border-radius: 20px;
+  max-width: min(480px, 90vw);
+  width: 100%;
+}
+
+.dashboard-dialog__surface {
+  background: var(--card-bg-light);
+  padding: 1.8rem;
+  border-radius: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+}
+
+body.dark-mode .dashboard-dialog__surface {
+  background: var(--card-bg-dark);
+}
+
+.dashboard-dialog__header {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 1rem;
 }
 
+.dashboard-dialog__close {
+  border: none;
+  background: transparent;
+  color: inherit;
+  font-size: 1.2rem;
+  cursor: pointer;
+}
+
+.dashboard-dialog__lead {
+  margin: 0;
+  font-weight: 600;
+}
+
+.dashboard-dialog__options {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.dashboard-dialog__options button {
+  border: 1px solid rgba(29, 126, 240, 0.2);
+  border-radius: 12px;
+  padding: 0.75rem 1rem;
+  background: rgba(255, 255, 255, 0.85);
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.dashboard-dialog__cta {
+  border: none;
+  border-radius: 999px;
+  padding: 0.6rem 1.4rem;
+  background: var(--accent-blue);
+  color: #fff;
+  font-weight: 600;
+  align-self: flex-start;
+  cursor: pointer;
+  margin-top: 0.8rem;
+}
+
+.dashboard-dialog__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.dashboard-dialog__hint {
+  margin: 0.5rem 0 0;
+  font-size: 0.9rem;
+  color: rgba(11, 23, 54, 0.68);
+}
+
+.dashboard-dialog__footer {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.dashboard-dialog__button {
+  border: none;
+  border-radius: 999px;
+  padding: 0.6rem 1.5rem;
+  background: var(--accent-blue);
+  color: #fff;
+  font-weight: 600;
+}
+
+.dashboard-toast {
+  position: fixed;
+  bottom: 2rem;
+  right: 2rem;
+  background: rgba(0, 54, 136, 0.9);
+  color: #fff;
+  padding: 0.85rem 1.4rem;
+  border-radius: 999px;
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.25);
+  opacity: 0;
+  transform: translateY(10px);
+  transition: opacity 0.3s ease, transform 0.3s ease;
+  pointer-events: none;
+}
+
+.dashboard-toast.is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+/* Settings layout retains previous styling */
 .settings-page {
-  max-width: 600px;
-  margin: 2rem auto;
-  padding: 0 1rem;
+  max-width: 720px;
+  margin: clamp(3rem, 6vw, 4rem) auto;
+  padding: 0 clamp(1rem, 4vw, 2rem);
 }
 
 .settings-form {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 1.8rem;
 }
 
 .settings-card {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 1.1rem;
+  border-radius: 20px;
+  border: 1px solid rgba(29, 126, 240, 0.1);
+  padding: 1.6rem;
+  background: var(--card-bg-light);
+  box-shadow: var(--shadow-soft);
+}
+
+body.dark-mode .settings-card {
+  background: var(--card-bg-dark);
+  border-color: var(--glass-border-dark);
+  box-shadow: var(--shadow-soft-dark);
 }
 
 .settings-card h2 {
@@ -176,230 +810,59 @@ body.dark-mode .recents-list li { border-color: #444; }
 .settings-description {
   margin: 0;
   font-size: 0.95rem;
-  color: rgba(23, 23, 23, 0.72);
+  color: rgba(11, 23, 54, 0.7);
 }
 
 body.dark-mode .settings-description {
-  color: rgba(250, 250, 250, 0.72);
+  color: rgba(245, 248, 255, 0.75);
 }
 
 .settings-lead {
-  margin-top: 0.5rem;
-  margin-bottom: 2rem;
-  max-width: 60ch;
+  margin: 0 0 1.6rem;
+  color: rgba(11, 23, 54, 0.72);
 }
 
-.setting-row {
+.setting-row,
+.setting-item {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 1.5rem;
   padding: 0.75rem 0;
-  border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+  border-bottom: 1px solid rgba(29, 126, 240, 0.12);
 }
 
-body.dark-mode .setting-row {
-  border-color: rgba(255, 255, 255, 0.12);
-}
+@media (max-width: 960px) {
+  .dashboard-hero {
+    grid-template-columns: 1fr;
+  }
 
-.setting-row:last-child {
-  border-bottom: none;
-}
+  .dashboard-hero__profile {
+    align-items: center;
+  }
 
-.setting-row--stacked {
-  flex-direction: column;
-  align-items: stretch;
-}
+  .dashboard-hero__actions {
+    flex-direction: column;
+  }
 
-.setting-label {
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
-  font-weight: 600;
-}
-
-.setting-hint {
-  font-weight: 400;
-  font-size: 0.9rem;
-  opacity: 0.7;
-}
-
-.setting-control {
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-}
-
-.switch {
-  position: relative;
-  display: inline-flex;
-  align-items: center;
-  width: 52px;
-  height: 28px;
-  cursor: pointer;
-}
-
-.switch input {
-  position: absolute;
-  inset: 0;
-  width: 100%;
-  height: 100%;
-  opacity: 0;
-  margin: 0;
-  cursor: pointer;
-}
-
-.switch-slider {
-  position: absolute;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.25);
-  border-radius: 999px;
-  transition: background var(--transition), box-shadow var(--transition);
-}
-
-body.dark-mode .switch-slider {
-  background: rgba(255, 255, 255, 0.3);
-}
-
-.switch-slider::before {
-  content: '';
-  position: absolute;
-  left: 3px;
-  top: 3px;
-  width: 22px;
-  height: 22px;
-  border-radius: 50%;
-  background: #fff;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.25);
-  transition: transform var(--transition);
-}
-
-.switch input:checked + .switch-slider {
-  background: var(--accent-blue);
-}
-
-.switch input:checked + .switch-slider::before {
-  transform: translateX(24px);
-}
-
-.switch input:focus-visible + .switch-slider {
-  box-shadow: 0 0 0 3px rgba(41, 121, 255, 0.35);
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent-blue) 35%, transparent);
-}
-
-body.high-contrast .switch input:focus-visible + .switch-slider {
-  box-shadow: 0 0 0 3px var(--accent-blue);
-}
-
-.accent-palette {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-  gap: 0.75rem;
-}
-
-.accent-choice {
-  position: relative;
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  padding: 0.65rem 0.75rem;
-  border-radius: 0.9rem;
-  background: var(--card-bg-light);
-  border: 2px solid transparent;
-  cursor: pointer;
-  transition: border var(--transition), box-shadow var(--transition), transform var(--transition);
-}
-
-body.dark-mode .accent-choice {
-  background: var(--card-bg-dark);
-}
-
-.accent-choice input {
-  position: absolute;
-  inset: 0;
-  width: 100%;
-  height: 100%;
-  margin: 0;
-  opacity: 0;
-  cursor: pointer;
-}
-
-.accent-choice .accent-swatch {
-  width: 28px;
-  height: 28px;
-  border-radius: 50%;
-  background: linear-gradient(135deg, var(--accent-swatch), var(--accent-swatch-contrast));
-  border: 2px solid rgba(0, 0, 0, 0.2);
-}
-
-body.dark-mode .accent-choice .accent-swatch {
-  border-color: rgba(255, 255, 255, 0.25);
-}
-
-.accent-choice .accent-name {
-  font-weight: 600;
-}
-
-.accent-choice[data-selected="true"],
-.accent-choice:focus-within {
-  border-color: var(--accent-blue);
-  box-shadow: 0 0 0 3px rgba(41, 121, 255, 0.2);
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent-blue) 25%, transparent);
-}
-
-.accent-choice[data-selected="true"] {
-  transform: translateY(-1px);
-}
-
-.text-size-control {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-}
-
-.text-size-control input[type="range"] {
-  width: 100%;
-  accent-color: var(--accent-blue);
-}
-
-.text-scale-preview {
-  font-size: 0.9rem;
-  opacity: 0.75;
-}
-
-.settings-actions {
-  display: flex;
-  justify-content: flex-end;
-}
-
-.settings-actions button {
-  border-radius: 999px;
-  border: 1.5px solid var(--accent-blue);
-  background: transparent;
-  color: var(--accent-blue);
-  font-weight: 600;
-  padding: 0.65rem 1.2rem;
-  cursor: pointer;
-  transition: background var(--transition), color var(--transition), transform var(--transition);
-}
-
-.settings-actions button:hover {
-  background: var(--accent-blue);
-  color: #fff;
-  transform: translateY(-1px);
-}
-
-body.dark-mode .settings-actions button {
-  color: var(--accent-blue);
+  .dashboard-card__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
 }
 
 @media (max-width: 640px) {
-  .setting-row {
-    flex-direction: column;
-    align-items: stretch;
+  .dashboard {
+    padding: 0 1rem;
   }
 
-  .switch {
-    align-self: flex-start;
+  .dashboard-toast {
+    left: 50%;
+    right: auto;
+    transform: translate(-50%, 10px);
+  }
+
+  .dashboard-toast.is-visible {
+    transform: translate(-50%, 0);
   }
 }

--- a/dashboard.html
+++ b/dashboard.html
@@ -6,37 +6,149 @@
   <title>Dashboard | RouteFlow London</title>
   <link rel="icon" href="images/New_Routflow_London_Logo.png" type="image/png" />
   <link href="https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible:wght@400;600&family=Inter:wght@400;600;800&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" />
   <link rel="stylesheet" href="style.css" />
   <link rel="stylesheet" href="dashboard.css" />
   <script src="theme.js" defer></script>
 </head>
 <body>
   <div id="navbar-container"></div>
-  <main class="dashboard">
-    <div class="dashboard-column">
-      <section class="card profile-card">
+  <main class="dashboard" aria-labelledby="dashboard-title">
+    <section class="dashboard-hero card" data-animate="fade-up">
+      <div class="dashboard-hero__profile">
         <img src="user-icon.png" alt="User Avatar" id="profileAvatar" />
         <div>
-          <h2 id="welcomeTitle">Welcome</h2>
-          <p id="profileInfo"></p>
+          <p class="dashboard-hero__eyebrow">Welcome back to RouteFlow London</p>
+          <h1 id="dashboard-title">Welcome</h1>
+          <p id="profileInfo" class="dashboard-hero__hint"></p>
+          <div class="dashboard-hero__xp" role="group" aria-label="Experience progress">
+            <div class="dashboard-hero__xp-top">
+              <span class="dashboard-hero__level">Level <strong id="levelNumber">1</strong></span>
+              <span class="dashboard-hero__xp-balance"><strong id="xpValue">0</strong> XP</span>
+            </div>
+            <div class="dashboard-hero__progress" aria-hidden="true">
+              <div class="dashboard-hero__progress-bar" id="xpProgressBar"></div>
+            </div>
+            <p class="dashboard-hero__progress-copy"><span id="xpToNext">0</span> XP until the next level.</p>
+          </div>
         </div>
-      </section>
-      <section class="card" id="activityCard">
-        <h2>Recent Activity</h2>
+      </div>
+      <div class="dashboard-hero__actions">
+        <button class="dashboard-pill" id="discordConnectButton" type="button">
+          <i class="fa-brands fa-discord" aria-hidden="true"></i>
+          <span id="discordStatus">Connect Discord</span>
+        </button>
+        <div class="dashboard-hero__stats">
+          <div>
+            <span>Badges</span>
+            <strong id="badgeSummary">0</strong>
+          </div>
+          <div>
+            <span>Active role</span>
+            <strong id="activeRole">Explorer</strong>
+          </div>
+          <div>
+            <span>Streak</span>
+            <strong id="streakValue">0</strong>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="dashboard-grid">
+      <article class="card dashboard-card" id="tasksCard">
+        <header class="dashboard-card__header">
+          <div>
+            <p class="dashboard-card__eyebrow">Daily boosters</p>
+            <h2>Complete tasks to earn XP</h2>
+          </div>
+          <button type="button" class="dashboard-card__action" id="resetTasksButton">Reset tasks</button>
+        </header>
+        <ul class="dashboard-task-list" id="taskList"></ul>
+      </article>
+
+      <article class="card dashboard-card" id="badgesCard">
+        <header class="dashboard-card__header">
+          <div>
+            <p class="dashboard-card__eyebrow">Badge cabinet</p>
+            <h2>Showcase your London achievements</h2>
+          </div>
+          <span class="dashboard-card__meta" id="badgeCountLabel">0 badges</span>
+        </header>
+        <div class="dashboard-badge-grid" id="badgeGrid"></div>
+      </article>
+
+      <article class="card dashboard-card" id="rolesCard">
+        <header class="dashboard-card__header">
+          <div>
+            <p class="dashboard-card__eyebrow">Role sync</p>
+            <h2>One identity across web and Discord</h2>
+          </div>
+          <span class="dashboard-card__meta" id="roleSyncStatus">Not linked</span>
+        </header>
+        <div class="dashboard-role-grid" id="roleList"></div>
+      </article>
+
+      <article class="card dashboard-card" id="miniGamesCard">
+        <header class="dashboard-card__header">
+          <div>
+            <p class="dashboard-card__eyebrow">Mini games</p>
+            <h2>Play for streaks and bonus XP</h2>
+          </div>
+          <span class="dashboard-card__meta" id="miniGameSummary">0 games</span>
+        </header>
+        <div class="dashboard-mini-grid" id="miniGameList"></div>
+      </article>
+
+      <article class="card dashboard-card" id="activityCard">
+        <header class="dashboard-card__header">
+          <div>
+            <p class="dashboard-card__eyebrow">Timeline</p>
+            <h2>Recent activity</h2>
+          </div>
+        </header>
         <ul id="activityList" class="activity-list"></ul>
-      </section>
-    </div>
-    <div class="dashboard-column">
-      <section class="card">
-        <h2>Your Favourites</h2>
+      </article>
+
+      <article class="card dashboard-card">
+        <header class="dashboard-card__header">
+          <div>
+            <p class="dashboard-card__eyebrow">Saved stops</p>
+            <h2>Your favourites</h2>
+          </div>
+        </header>
         <div id="favouritesGrid" class="favourites-grid"></div>
-      </section>
-      <section class="card">
-        <h2>Recents</h2>
+      </article>
+
+      <article class="card dashboard-card">
+        <header class="dashboard-card__header">
+          <div>
+            <p class="dashboard-card__eyebrow">Quick access</p>
+            <h2>Recent pages</h2>
+          </div>
+        </header>
         <ul id="recentsList" class="recents-list"></ul>
-      </section>
-    </div>
+      </article>
+    </section>
   </main>
+
+  <dialog class="dashboard-dialog" id="miniGameDialog" aria-modal="true">
+    <form method="dialog" class="dashboard-dialog__surface">
+      <header class="dashboard-dialog__header">
+        <h2 id="miniGameTitle">Mini game</h2>
+        <button type="submit" class="dashboard-dialog__close" aria-label="Close mini game">
+          <i class="fa-solid fa-xmark" aria-hidden="true"></i>
+        </button>
+      </header>
+      <div class="dashboard-dialog__body" id="miniGameBody"></div>
+      <footer class="dashboard-dialog__footer">
+        <button type="submit" class="dashboard-dialog__button">Close</button>
+      </footer>
+    </form>
+  </dialog>
+
+  <div class="dashboard-toast" id="dashboardToast" role="status" aria-live="polite" hidden></div>
+
   <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-auth-compat.js"></script>
   <script src="config.js"></script>
@@ -62,8 +174,415 @@
     import {getRecents} from './recents.js';
     import {inferFavouriteType, resolveFavouriteTitle, buildFavouriteMeta} from './favourite-utils.js';
 
-    window.signOut = () => { firebase.auth().signOut(); };
-    window.openModal = () => {};
+    const STORAGE_PREFIX = 'routeflow:gamification';
+    const TOAST_DURATION = 4000;
+    const DEFAULT_GAMIFICATION = () => ({
+      xp: 1320,
+      streak: 3,
+      discordConnected: false,
+      lastMiniGame: null,
+      tasks: [
+        { id: 'task-tracking', title: 'Check live tracking', description: 'Open the live arrivals page and refresh a stop.', xp: 60, completed: false, badge: 'badge-tracker' },
+        { id: 'task-planning', title: 'Plan a journey', description: 'Plot a multi-mode route with accessibility filters.', xp: 80, completed: false, badge: 'badge-planner' },
+        { id: 'task-fleet', title: 'Review fleet changes', description: 'Visit the fleet dashboard to log a rare working.', xp: 70, completed: false, badge: 'badge-enthusiast' }
+      ],
+      badges: [
+        { id: 'badge-tracker', title: 'Pulse Watcher', description: 'Complete 5 live tracking sessions.', icon: 'fa-solid fa-wifi', progress: 2, goal: 5, xp: 150, earned: false },
+        { id: 'badge-planner', title: 'Journey Curator', description: 'Plan 10 multimodal trips.', icon: 'fa-solid fa-route', progress: 4, goal: 10, xp: 180, earned: false },
+        { id: 'badge-night', title: 'Night Bus Navigator', description: 'Log arrivals after 23:00 for 3 nights.', icon: 'fa-solid fa-moon', progress: 3, goal: 3, xp: 220, earned: true },
+        { id: 'badge-river', title: 'River Trailblazer', description: 'Track a Thames Clipper sailing.', icon: 'fa-solid fa-ship', progress: 0, goal: 1, xp: 120, earned: false }
+      ],
+      roles: [
+        { id: 'role-dashboard', platform: 'RouteFlow', title: 'Pathfinder', description: 'Unlocked at Level 5.', active: true },
+        { id: 'role-discord', platform: 'Discord', title: 'Community Pathfinder', description: 'Sync via the RouteFlow bot.', active: false }
+      ],
+      miniGames: [
+        { id: 'mini-trivia', title: 'TfL Trivia Rush', description: 'Answer 3 quick-fire questions.', xp: 160, type: 'trivia', played: false },
+        { id: 'mini-pairs', title: 'Line Match', description: 'Match routes to their colours in under 60s.', xp: 140, type: 'memory', played: false },
+        { id: 'mini-streak', title: 'Streak Builder', description: 'Log in on consecutive days.', xp: 120, type: 'streak', played: false }
+      ]
+    });
+
+    const LEVEL_THRESHOLDS = [0, 600, 1400, 2300, 3300, 4500, 6000, 7700, 9600, 11600, 13800];
+
+    let currentUid = 'guest';
+    let gamificationState = DEFAULT_GAMIFICATION();
+    let toastTimeout;
+
+    const toast = document.getElementById('dashboardToast');
+    const levelNumber = document.getElementById('levelNumber');
+    const xpValue = document.getElementById('xpValue');
+    const xpToNext = document.getElementById('xpToNext');
+    const xpProgressBar = document.getElementById('xpProgressBar');
+    const badgeSummary = document.getElementById('badgeSummary');
+    const badgeCountLabel = document.getElementById('badgeCountLabel');
+    const roleSyncStatus = document.getElementById('roleSyncStatus');
+    const miniGameSummary = document.getElementById('miniGameSummary');
+    const streakValue = document.getElementById('streakValue');
+    const activeRole = document.getElementById('activeRole');
+    const discordButton = document.getElementById('discordConnectButton');
+    const discordStatus = document.getElementById('discordStatus');
+
+    function storageKey(uid) {
+      return `${STORAGE_PREFIX}:${uid || 'guest'}`;
+    }
+
+    function safeParse(value) {
+      try {
+        return value ? JSON.parse(value) : null;
+      } catch (error) {
+        console.warn('RouteFlow dashboard: failed to parse stored gamification state', error);
+        return null;
+      }
+    }
+
+    function loadState(uid) {
+      try {
+        const stored = safeParse(localStorage.getItem(storageKey(uid)));
+        if (stored && typeof stored === 'object') {
+          const fallback = DEFAULT_GAMIFICATION();
+          return {
+            ...fallback,
+            ...stored,
+            tasks: (stored.tasks || fallback.tasks).map(task => ({ ...task })),
+            badges: (stored.badges || fallback.badges).map(badge => ({ ...badge })),
+            roles: (stored.roles || fallback.roles).map(role => ({ ...role })),
+            miniGames: (stored.miniGames || fallback.miniGames).map(game => ({ ...game }))
+          };
+        }
+      } catch (error) {
+        console.warn('RouteFlow dashboard: unable to load gamification state', error);
+      }
+      return DEFAULT_GAMIFICATION();
+    }
+
+    function saveState() {
+      try {
+        localStorage.setItem(storageKey(currentUid), JSON.stringify(gamificationState));
+      } catch (error) {
+        console.warn('RouteFlow dashboard: unable to save gamification state', error);
+      }
+    }
+
+    function showToast(message) {
+      if (!toast) return;
+      toast.textContent = message;
+      toast.hidden = false;
+      toast.classList.add('is-visible');
+      clearTimeout(toastTimeout);
+      toastTimeout = setTimeout(() => {
+        toast.classList.remove('is-visible');
+        toast.hidden = true;
+      }, TOAST_DURATION);
+    }
+
+    function calculateLevel(xp) {
+      let level = 1;
+      for (let i = 0; i < LEVEL_THRESHOLDS.length; i += 1) {
+        if (xp >= LEVEL_THRESHOLDS[i]) {
+          level = i + 1;
+        }
+      }
+      const prev = LEVEL_THRESHOLDS[level - 1] ?? 0;
+      const next = LEVEL_THRESHOLDS[level] ?? (prev + 1800);
+      const progress = Math.min(1, (xp - prev) / (next - prev));
+      return { level, prev, next, progress };
+    }
+
+    function formatNumber(value) {
+      return new Intl.NumberFormat('en-GB').format(value);
+    }
+
+    function updateLevelUI() {
+      const { xp, streak } = gamificationState;
+      const { level, prev, next, progress } = calculateLevel(xp);
+      levelNumber.textContent = level;
+      xpValue.textContent = formatNumber(xp);
+      const remaining = Math.max(0, next - xp);
+      xpToNext.textContent = formatNumber(remaining);
+      xpProgressBar.style.setProperty('--progress', `${Math.round(progress * 100)}%`);
+      streakValue.textContent = streak;
+      gamificationState.roles = gamificationState.roles.map(role => {
+        if (role.id === 'role-dashboard') {
+          return { ...role, active: level >= 5 };
+        }
+        if (role.id === 'role-discord') {
+          return { ...role, active: gamificationState.discordConnected };
+        }
+        return role;
+      });
+      const active = gamificationState.roles.find(role => role.active);
+      activeRole.textContent = active ? active.title : 'Explorer';
+    }
+
+    function renderTasks() {
+      const list = document.getElementById('taskList');
+      if (!list) return;
+      list.innerHTML = '';
+      gamificationState.tasks.forEach(task => {
+        const item = document.createElement('li');
+        item.className = `dashboard-task${task.completed ? ' is-complete' : ''}`;
+        item.innerHTML = `
+          <div class="dashboard-task__text">
+            <strong>${task.title}</strong>
+            <p>${task.description}</p>
+          </div>
+          <div class="dashboard-task__meta">
+            <span class="dashboard-task__xp">+${task.xp} XP</span>
+            <button type="button" class="dashboard-task__button" data-task="${task.id}" ${task.completed ? 'disabled' : ''}>
+              ${task.completed ? 'Completed' : 'Complete'}
+            </button>
+          </div>
+        `;
+        list.appendChild(item);
+      });
+    }
+
+    function renderBadges() {
+      const grid = document.getElementById('badgeGrid');
+      if (!grid) return;
+      grid.innerHTML = '';
+      let earnedCount = 0;
+      gamificationState.badges.forEach(badge => {
+        if (badge.earned) earnedCount += 1;
+        const progress = Math.min(1, badge.goal ? badge.progress / badge.goal : 1);
+        const card = document.createElement('article');
+        card.className = `dashboard-badge${badge.earned ? ' is-earned' : ''}`;
+        card.innerHTML = `
+          <div class="dashboard-badge__icon" aria-hidden="true"><i class="${badge.icon}"></i></div>
+          <div class="dashboard-badge__content">
+            <h3>${badge.title}</h3>
+            <p>${badge.description}</p>
+            <div class="dashboard-badge__progress" role="progressbar" aria-valuemin="0" aria-valuemax="${badge.goal}" aria-valuenow="${Math.min(badge.progress, badge.goal)}">
+              <div class="dashboard-badge__progress-bar" style="--progress:${Math.round(progress * 100)}%"></div>
+            </div>
+            <div class="dashboard-badge__footer">
+              <span>${badge.goal ? `${Math.min(badge.progress, badge.goal)} / ${badge.goal}` : 'Complete'}</span>
+              <span class="dashboard-badge__xp">${badge.xp} XP</span>
+              ${!badge.earned && progress >= 1 ? '<button type="button" class="dashboard-badge__claim" data-claim="' + badge.id + '">Claim</button>' : ''}
+            </div>
+          </div>
+        `;
+        grid.appendChild(card);
+      });
+      badgeSummary.textContent = earnedCount;
+      badgeCountLabel.textContent = `${earnedCount} badge${earnedCount === 1 ? '' : 's'} earned`;
+    }
+
+    function renderRoles() {
+      const container = document.getElementById('roleList');
+      if (!container) return;
+      container.innerHTML = '';
+      gamificationState.roles.forEach(role => {
+        const card = document.createElement('article');
+        card.className = `dashboard-role${role.active ? ' is-active' : ''}`;
+        card.innerHTML = `
+          <header>
+            <span class="dashboard-role__platform">${role.platform}</span>
+            <h3>${role.title}</h3>
+          </header>
+          <p>${role.description}</p>
+          <span class="dashboard-role__status">${role.active ? 'Active' : 'Locked'}</span>
+        `;
+        container.appendChild(card);
+      });
+      roleSyncStatus.textContent = gamificationState.discordConnected ? 'Synced' : 'Not linked';
+    }
+
+    function renderMiniGames() {
+      const container = document.getElementById('miniGameList');
+      if (!container) return;
+      container.innerHTML = '';
+      gamificationState.miniGames.forEach(game => {
+        const card = document.createElement('article');
+        card.className = 'dashboard-mini';
+        card.innerHTML = `
+          <h3>${game.title}</h3>
+          <p>${game.description}</p>
+          <div class="dashboard-mini__footer">
+            <span class="dashboard-mini__xp">${game.xp} XP</span>
+            <button type="button" data-mini-game="${game.id}" class="dashboard-mini__button">${game.played ? 'Replay' : 'Play'}</button>
+          </div>
+        `;
+        container.appendChild(card);
+      });
+      miniGameSummary.textContent = `${gamificationState.miniGames.length} mini games`;
+    }
+
+    function renderDiscordStatus() {
+      if (!discordButton || !discordStatus) return;
+      discordButton.classList.toggle('is-connected', gamificationState.discordConnected);
+      discordStatus.textContent = gamificationState.discordConnected ? 'Discord linked' : 'Connect Discord';
+    }
+
+    function renderAll() {
+      updateLevelUI();
+      renderTasks();
+      renderBadges();
+      renderRoles();
+      renderMiniGames();
+      renderDiscordStatus();
+    }
+
+    function addXp(amount, reason) {
+      gamificationState.xp += amount;
+      if (reason) {
+        showToast(`${reason} • +${amount} XP`);
+      }
+    }
+
+    function incrementBadgeProgress(badgeId) {
+      gamificationState.badges = gamificationState.badges.map(badge => {
+        if (badge.id === badgeId && !badge.earned) {
+          const progress = Math.min(badge.goal, (badge.progress ?? 0) + 1);
+          return { ...badge, progress };
+        }
+        return badge;
+      });
+    }
+
+    function completeTask(taskId) {
+      let awardedXp = 0;
+      let taskTitle = '';
+      let badgeRef = null;
+      gamificationState.tasks = gamificationState.tasks.map(task => {
+        if (task.id === taskId && !task.completed) {
+          awardedXp = task.xp;
+          taskTitle = task.title;
+          badgeRef = task.badge;
+          return { ...task, completed: true };
+        }
+        return task;
+      });
+      if (badgeRef) {
+        incrementBadgeProgress(badgeRef);
+      }
+      if (awardedXp) {
+        addXp(awardedXp, `${taskTitle} complete`);
+        logActivity(`Completed task: ${taskTitle}`);
+      }
+      saveState();
+      renderAll();
+    }
+
+    function claimBadge(badgeId) {
+      let badgeAward = 0;
+      let badgeTitle = '';
+      gamificationState.badges = gamificationState.badges.map(badge => {
+        if (badge.id === badgeId && !badge.earned && badge.progress >= badge.goal) {
+          badgeAward = badge.xp;
+          badgeTitle = badge.title;
+          return { ...badge, earned: true };
+        }
+        return badge;
+      });
+      if (badgeAward) {
+        addXp(badgeAward, `${badgeTitle} badge`);
+        logActivity(`Claimed badge: ${badgeTitle}`);
+      }
+      saveState();
+      renderAll();
+    }
+
+    function toggleDiscord() {
+      gamificationState.discordConnected = !gamificationState.discordConnected;
+      if (gamificationState.discordConnected) {
+        logActivity('Discord account linked');
+        showToast('Discord linked — roles syncing now.');
+      } else {
+        logActivity('Discord account disconnected');
+        showToast('Discord disconnected.');
+      }
+      saveState();
+      renderAll();
+    }
+
+    function openMiniGame(gameId) {
+      const game = gamificationState.miniGames.find(item => item.id === gameId);
+      if (!game) return;
+      const dialog = document.getElementById('miniGameDialog');
+      const title = document.getElementById('miniGameTitle');
+      const body = document.getElementById('miniGameBody');
+      if (!dialog || !title || !body) return;
+
+      title.textContent = game.title;
+      if (game.type === 'trivia') {
+        body.innerHTML = `
+          <p class="dashboard-dialog__lead">Which Underground line opened most recently?</p>
+          <div class="dashboard-dialog__options">
+            <button type="button" data-answer="wrong">Northern Line extension</button>
+            <button type="button" data-answer="correct">Elizabeth line</button>
+            <button type="button" data-answer="wrong">Jubilee Line</button>
+          </div>
+        `;
+      } else if (game.type === 'memory') {
+        body.innerHTML = `
+          <p class="dashboard-dialog__lead">Match the route to its colour:</p>
+          <ul class="dashboard-dialog__list">
+            <li><strong>Route 25</strong> — <span>Red</span></li>
+            <li><strong>Route 205</strong> — <span>Blue</span></li>
+            <li><strong>Route 15</strong> — <span>Heritage Green</span></li>
+          </ul>
+          <p class="dashboard-dialog__hint">Memorise and close the game when you're ready.</p>
+          <button type="button" class="dashboard-dialog__cta" data-complete="${game.id}">Claim XP</button>
+        `;
+      } else {
+        body.innerHTML = `
+          <p class="dashboard-dialog__lead">Keep your streak going! Check in daily to climb the leaderboard.</p>
+          <button type="button" class="dashboard-dialog__cta" data-complete="${game.id}">Log check-in</button>
+        `;
+      }
+
+      body.querySelectorAll('[data-answer]').forEach(button => {
+        button.addEventListener('click', (event) => {
+          const correct = event.currentTarget.dataset.answer === 'correct';
+          if (correct) {
+            addXp(game.xp, `${game.title} completed`);
+            gamificationState.miniGames = gamificationState.miniGames.map(item => item.id === gameId ? { ...item, played: true } : item);
+            saveState();
+            renderAll();
+            dialog.close();
+          } else {
+            showToast('Not quite! Try again.');
+          }
+        });
+      });
+
+      body.querySelectorAll('[data-complete]').forEach(button => {
+        button.addEventListener('click', () => {
+          addXp(game.xp, `${game.title} completed`);
+          gamificationState.miniGames = gamificationState.miniGames.map(item => item.id === gameId ? { ...item, played: true } : item);
+          saveState();
+          renderAll();
+          dialog.close();
+        });
+      });
+
+      if (typeof dialog.showModal === 'function') {
+        dialog.showModal();
+      }
+    }
+
+    function resetTasks() {
+      gamificationState.tasks = gamificationState.tasks.map(task => ({ ...task, completed: false }));
+      saveState();
+      renderAll();
+      showToast('Daily tasks reset. Ready when you are!');
+    }
+
+    function logActivity(message) {
+      if (!message) return;
+      const uid = currentUid || 'guest';
+      const key = `activity_${uid}`;
+      try {
+        const history = safeParse(localStorage.getItem(key)) || [];
+        history.unshift(message);
+        localStorage.setItem(key, JSON.stringify(history.slice(0, 10)));
+      } catch (error) {
+        console.warn('RouteFlow dashboard: unable to log activity', error);
+      }
+      loadActivity(uid);
+    }
 
     function createFavouriteCard(uid, favourite) {
       const card = document.createElement('article');
@@ -120,7 +639,7 @@
     async function loadFavourites(uid) {
       const grid = document.getElementById('favouritesGrid');
       grid.innerHTML = '';
-      if (!uid) {
+      if (!uid || uid === 'guest') {
         const emptyState = document.createElement('p');
         emptyState.className = 'dashboard-empty';
         emptyState.textContent = 'Sign in to manage favourites.';
@@ -169,7 +688,7 @@
     function loadActivity(uid) {
       const list = document.getElementById('activityList');
       list.innerHTML = '';
-      const acts = JSON.parse(localStorage.getItem(`activity_${uid}`) || '[]');
+      const acts = safeParse(localStorage.getItem(`activity_${uid}`)) || [];
       if (acts.length === 0) {
         list.innerHTML = '<li>No recent activity.</li>';
         return;
@@ -181,29 +700,59 @@
       });
     }
 
+    document.addEventListener('click', (event) => {
+      const taskButton = event.target.closest('[data-task]');
+      if (taskButton) {
+        completeTask(taskButton.dataset.task);
+        return;
+      }
+
+      const badgeButton = event.target.closest('[data-claim]');
+      if (badgeButton) {
+        claimBadge(badgeButton.dataset.claim);
+        return;
+      }
+
+      const miniButton = event.target.closest('[data-mini-game]');
+      if (miniButton) {
+        openMiniGame(miniButton.dataset.miniGame);
+      }
+    });
+
+    if (discordButton) {
+      discordButton.addEventListener('click', toggleDiscord);
+    }
+
+    const resetTasksButton = document.getElementById('resetTasksButton');
+    if (resetTasksButton) {
+      resetTasksButton.addEventListener('click', resetTasks);
+    }
+
     firebase.auth().onAuthStateChanged(async user => {
-      const title = document.getElementById('welcomeTitle');
+      const title = document.getElementById('dashboard-title');
       const info = document.getElementById('profileInfo');
       const avatar = document.getElementById('profileAvatar');
       if (user) {
+        currentUid = user.uid;
+        gamificationState = loadState(currentUid);
         title.textContent = `Welcome, ${user.email}`;
         avatar.src = user.photoURL || 'user-icon.png';
-        info.textContent = '';
-        try {
-          await loadFavourites(user.uid);
-        } catch (error) {
-          console.error('Failed to render favourites on dashboard after sign-in.', error);
-        }
+        info.textContent = 'Your rewards sync automatically across devices and Discord.';
+        await loadFavourites(user.uid);
         loadActivity(user.uid);
         loadRecents(user.uid);
       } else {
+        currentUid = 'guest';
+        gamificationState = loadState(currentUid);
         title.textContent = 'Welcome';
         avatar.src = 'user-icon.png';
-        info.textContent = 'Please sign in to see your data.';
-        document.getElementById('favouritesGrid').innerHTML = '<p>Sign in to manage favourites.</p>';
-        document.getElementById('activityList').innerHTML = '<li>Sign in to see activity.</li>';
+        info.textContent = 'Sign in to save favourites and track your rewards everywhere.';
+        const favouritesGrid = document.getElementById('favouritesGrid');
+        favouritesGrid.innerHTML = '<p class="dashboard-empty">Sign in to manage favourites.</p>';
+        loadActivity('guest');
         loadRecents('guest');
       }
+      renderAll();
     });
   </script>
 </body>

--- a/index.html
+++ b/index.html
@@ -13,94 +13,160 @@
 <body>
   <div id="navbar-container"></div>
 
-  <main class="landing">
-    <section class="landing-hero card">
+  <main class="landing" aria-labelledby="landing-title">
+    <section class="landing-hero card" data-animate="fade-up">
       <div class="landing-hero__content">
-        <p class="landing-hero__eyebrow">Your companion to London transport</p>
-        <h1>Everything you need to move around London with confidence.</h1>
+        <p class="landing-hero__eyebrow">The official London transport companion</p>
+        <h1 id="landing-title">Plan, track and play your way around the capital.</h1>
         <p class="landing-hero__lead">
-          RouteFlow London blends real-time data with enthusiast insights so you can plan smarter journeys, watch departures update in
-          real time, and keep favourite routes close without juggling a dozen tabs.
+          RouteFlow London pairs real-time data with a playful dashboard so you can
+          check arrivals, map complex journeys and unlock rewards without digging through a maze of menus.
         </p>
-        <div class="landing-hero__actions">
-          <a class="landing-hero__button landing-hero__button--primary" href="tracking.html">
+        <div class="landing-hero__actions" role="group">
+          <a class="landing-hero__button landing-hero__button--primary" href="dashboard.html">
+            <i class="fa-solid fa-compass"></i>
+            Open dashboard
+          </a>
+          <a class="landing-hero__button" href="tracking.html">
             <i class="fa-solid fa-wifi"></i>
             Live tracking
           </a>
-          <a class="landing-hero__button" href="planning.html">
-            <i class="fa-solid fa-route"></i>
-            Journey planner
-          </a>
         </div>
-        <dl class="landing-hero__metrics" aria-label="Platform snapshot">
+        <dl class="landing-hero__metrics" aria-label="RouteFlow snapshot">
           <div>
-            <dt>Stops monitored</dt>
-            <dd>20k+</dd>
+            <dt>Network feeds</dt>
+            <dd>Live across TfL</dd>
           </div>
           <div>
-            <dt>Journey combinations</dt>
-            <dd>Millions</dd>
+            <dt>Gamified members</dt>
+            <dd>14k+</dd>
           </div>
           <div>
-            <dt>Community insights</dt>
-            <dd>Daily</dd>
+            <dt>Mini games</dt>
+            <dd>Fresh every week</dd>
           </div>
         </dl>
       </div>
-      <div class="landing-hero__preview">
+      <div class="landing-hero__preview" aria-hidden="true">
         <div class="landing-preview">
-          <h2>Live now</h2>
-          <p>See departures update in real time and save the stops that matter most.</p>
+          <header class="landing-preview__header">
+            <span class="landing-preview__label">Dashboard sneak peek</span>
+            <span class="landing-preview__level">Level 5 &bull; 3,250 XP</span>
+          </header>
           <ul class="landing-preview__list">
             <li>
-              <span class="landing-preview__label">Arrivals</span>
-              <strong>Refreshes every 25s</strong>
+              <strong>Badges unlocked</strong>
+              <span>Night Bus Navigator</span>
             </li>
             <li>
-              <span class="landing-preview__label">Notes</span>
-              <strong>Pin rare workings</strong>
+              <strong>Active role</strong>
+              <span>Community Pathfinder</span>
             </li>
             <li>
-              <span class="landing-preview__label">Favourites</span>
-              <strong>Sync across devices</strong>
+              <strong>Mini game streak</strong>
+              <span>4 days</span>
             </li>
           </ul>
-          <a class="landing-preview__cta" href="tracking.html">Open live arrivals</a>
+          <a class="landing-preview__cta" href="dashboard.html">See the full dashboard</a>
         </div>
       </div>
     </section>
 
-    <section class="landing-panels" aria-label="Highlights">
-      <article class="landing-panel">
+    <section class="landing-panels" aria-label="Key highlights">
+      <article class="landing-panel" data-animate="fade-up">
         <div class="landing-panel__icon" aria-hidden="true">
-          <i class="fa-solid fa-tower-broadcast"></i>
+          <i class="fa-solid fa-satellite-dish"></i>
         </div>
         <div class="landing-panel__content">
-          <h2>Real-time arrivals</h2>
-          <p>Departures refresh automatically with tidy colour-coded lines for every mode across the network.</p>
+          <h2>Live, accurate arrivals</h2>
+          <p>Watch bus, tube and river updates roll in within seconds and pin the stops that matter.</p>
         </div>
       </article>
-      <article class="landing-panel">
+      <article class="landing-panel" data-animate="fade-up" data-animate-delay="100">
         <div class="landing-panel__icon" aria-hidden="true">
           <i class="fa-solid fa-route"></i>
         </div>
         <div class="landing-panel__content">
-          <h2>Multi-mode planning</h2>
-          <p>Compare step-free options, river links and buses side by side to pick the itinerary that fits.</p>
+          <h2>Smarter journey planning</h2>
+          <p>Compare accessible routes, view rare workings and save itineraries straight to your dashboard.</p>
         </div>
       </article>
-      <article class="landing-panel">
+      <article class="landing-panel" data-animate="fade-up" data-animate-delay="200">
         <div class="landing-panel__icon" aria-hidden="true">
-          <i class="fa-solid fa-book-open"></i>
+          <i class="fa-solid fa-chart-line"></i>
         </div>
         <div class="landing-panel__content">
-          <h2>Enthusiast archive</h2>
-          <p>Discover fleet changes, rare workings and withdrawn routes curated by the community.</p>
+          <h2>Insights for enthusiasts</h2>
+          <p>Dive into fleets, withdrawn lines and community notes maintained by London transport fans.</p>
         </div>
       </article>
     </section>
 
-    <section class="landing-tools card">
+    <section class="landing-gamify card" aria-label="Gamified community features">
+      <header class="landing-gamify__header">
+        <p class="landing-gamify__eyebrow">Playful transport community</p>
+        <h2>Earn, sync and compete with RouteFlow Gamification.</h2>
+        <p>Badge up with tasks, sync your Discord role automatically and tackle mini games inspired by the network.</p>
+      </header>
+      <div class="landing-gamify__grid">
+        <article class="landing-gamify__item">
+          <span class="landing-gamify__icon" aria-hidden="true"><i class="fa-solid fa-award"></i></span>
+          <h3>Collect limited badges</h3>
+          <p>Complete daily and weekly tasks to unlock themed badges ranging from Night Bus Navigator to River Trailblazer.</p>
+        </article>
+        <article class="landing-gamify__item">
+          <span class="landing-gamify__icon" aria-hidden="true"><i class="fa-solid fa-user-shield"></i></span>
+          <h3>Unified roles</h3>
+          <p>Your achievements set your title across the dashboard and our Discord server in a single tap.</p>
+        </article>
+        <article class="landing-gamify__item">
+          <span class="landing-gamify__icon" aria-hidden="true"><i class="fa-solid fa-gamepad"></i></span>
+          <h3>Mini games with purpose</h3>
+          <p>Take on quick-fire trivia, route matching and daily streak challenges to earn bonus XP.</p>
+        </article>
+        <article class="landing-gamify__item">
+          <span class="landing-gamify__icon" aria-hidden="true"><i class="fa-brands fa-discord"></i></span>
+          <h3>Discord bot integration</h3>
+          <p>Link your Discord account to receive live notifications, leaderboard updates and exclusive events.</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="landing-devices" aria-label="Cross-platform support">
+      <div class="landing-devices__card card" data-animate="fade-up">
+        <h2>Built for every screen.</h2>
+        <p>RouteFlow adapts seamlessly across Android, iOS 16+ and desktop browsers. Controls remain consistent while content reflows so you can check live departures or badges on the go.</p>
+        <ul class="landing-devices__list">
+          <li><i class="fa-brands fa-android" aria-hidden="true"></i> Android phones &amp; tablets</li>
+          <li><i class="fa-brands fa-apple" aria-hidden="true"></i> iPhone &amp; iPad (iOS 16+)</li>
+          <li><i class="fa-brands fa-chrome" aria-hidden="true"></i> Chrome, Edge and Safari</li>
+        </ul>
+      </div>
+      <div class="landing-devices__mock card" aria-hidden="true" data-animate="fade-up" data-animate-delay="120">
+        <div class="landing-devices__screen">
+          <span>Responsive preview</span>
+          <div class="landing-devices__dots">
+            <span></span><span></span><span></span>
+          </div>
+          <div class="landing-devices__grid">
+            <div>
+              <strong>Live arrivals</strong>
+              <p>Swipe friendly cards with colour-coded modes.</p>
+            </div>
+            <div>
+              <strong>Badge tracker</strong>
+              <p>Tap to see what unlocks next.</p>
+            </div>
+            <div>
+              <strong>Discord sync</strong>
+              <p>Roles and notifications stay aligned.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="landing-tools card" aria-label="Core tools">
       <header class="landing-tools__header">
         <p class="landing-tools__eyebrow">Essential tools</p>
         <h2>Made for commuters and enthusiasts alike</h2>
@@ -141,12 +207,12 @@
       </footer>
     </section>
 
-    <section class="landing-updates card">
+    <section class="landing-updates card" aria-label="Newsletter">
       <div class="landing-updates__content">
         <h2>Stay in the loop</h2>
         <p>Subscribe for feature announcements, enthusiast meet-ups and rare vehicle alerts.</p>
       </div>
-      <form id="newsletter-form" class="landing-updates__form">
+      <form id="newsletter-form" class="landing-updates__form" novalidate>
         <label for="email" class="sr-only">Email address</label>
         <input type="email" id="email" placeholder="Enter your email" required />
         <button type="submit">Subscribe</button>
@@ -158,22 +224,35 @@
   <footer>
     <div class="footer-links">
       <a href="about.html">About</a>
+      <a href="contact.html">Contact</a>
       <a href="privacy.html">Privacy</a>
       <a href="terms.html">Terms</a>
-      <a href="contact.html">Contact</a>
+      <a href="settings.html">Settings</a>
     </div>
-    <div class="social-icons">
-      <a href="https://discord.gg/qVf3nN4Mgq"><i class="fa-brands fa-discord"></i></a>
-      <a href="https://www.tiktok.com/@the_bus_father"><i class="fab fa-tiktok"></i></a>
-      <a href="https://www.instagram.com/thebusfatherofficial/profilecard/?igsh=NXcybzV3cTA2azBo"><i class="fab fa-instagram"></i></a>
-    </div>
-    <small>Made for London. Built from scratch.</small>
+    <p class="footer-copy">&copy; <span id="copyright-year"></span> RouteFlow London. All rights reserved.</p>
   </footer>
 
   <script src="navbar-loader.js"></script>
-  <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-app-compat.js"></script>
-  <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-auth-compat.js"></script>
-  <script src="main.js"></script>
-  <script type="module" src="blog.js"></script>
+  <script src="blog.js" type="module"></script>
+  <script>
+    const form = document.getElementById('newsletter-form');
+    const responseMessage = document.getElementById('response-message');
+
+    form.addEventListener('submit', (event) => {
+      event.preventDefault();
+      const emailInput = document.getElementById('email');
+      const email = emailInput.value.trim();
+
+      if (!email) {
+        responseMessage.textContent = 'Please enter your email address.';
+        return;
+      }
+
+      responseMessage.textContent = 'Thanks for subscribing! We\'ll keep you posted.';
+      emailInput.value = '';
+    });
+
+    document.getElementById('copyright-year').textContent = new Date().getFullYear();
+  </script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -4,22 +4,26 @@
   Variables & Root
 -------------------------------*/
 :root {
-  --primary: #d32f2f;
-  --primary-dark: #b71c1c;
-  --accent-blue: #2979ff;
-  --accent-blue-dark: #1565c0;
-  --background-light: #fff;
-  --foreground-light: #171717;
-  --background-dark: #121212;
-  --foreground-dark: #fafafa;
-  --card-bg-light: #f6f8fa;
-  --card-bg-dark: #232323;
-  --border-radius: 14px;
-  --transition: 0.2s cubic-bezier(.46,.03,.52,.96);
+  --primary: #003688;
+  --primary-dark: #002b66;
+  --accent-blue: #1d7ef0;
+  --accent-blue-dark: #0f5cb9;
+  --background-light: #edf3ff;
+  --foreground-light: #0b1736;
+  --background-dark: #050a18;
+  --foreground-dark: #f5f8ff;
+  --card-bg-light: rgba(255, 255, 255, 0.9);
+  --card-bg-dark: rgba(12, 18, 34, 0.82);
+  --glass-border: rgba(13, 63, 133, 0.08);
+  --glass-border-dark: rgba(148, 172, 214, 0.2);
+  --border-radius: 18px;
+  --shadow-soft: 0 22px 60px rgba(9, 46, 121, 0.16);
+  --shadow-soft-dark: 0 32px 70px rgba(0, 0, 0, 0.65);
+  --transition: 0.25s cubic-bezier(.46,.03,.52,.96);
 }
 
 body {
-  background: var(--background-light);
+  background: linear-gradient(160deg, #e7f0ff 0%, #f4f7ff 45%, #ffffff 100%);
   color: var(--foreground-light);
   font-family: 'Inter', 'Segoe UI', Arial, sans-serif;
   margin: 0;
@@ -28,7 +32,7 @@ body {
   transition: background 0.25s, color 0.25s;
 }
 body.dark-mode {
-  background: var(--background-dark);
+  background: radial-gradient(circle at top, #0d142d 0%, #050915 55%, #02040a 100%);
   color: var(--foreground-dark);
 }
 
@@ -1518,31 +1522,33 @@ body.dark-mode .admin-form__group--stacked textarea {
 }
 
 main.landing {
-  max-width: 1180px;
-  margin: 0 auto 5rem;
-  padding: clamp(3rem, 6vw, 5rem) 1.5rem 4.5rem;
+  max-width: 1240px;
+  margin: 0 auto clamp(4rem, 8vw, 6rem);
+  padding: clamp(3.2rem, 7vw, 6rem) clamp(1.2rem, 4vw, 2.4rem);
   display: flex;
   flex-direction: column;
-  gap: clamp(2.5rem, 6vw, 3.75rem);
+  gap: clamp(2.6rem, 6vw, 4.2rem);
 }
 
 main.landing .card {
+  position: relative;
   background: var(--card-bg-light);
-  border-radius: 22px;
-  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.14);
+  border-radius: 26px;
   padding: clamp(2rem, 4vw, 3.4rem);
-  border: 1px solid rgba(15, 23, 42, 0.06);
+  border: 1px solid var(--glass-border);
+  box-shadow: var(--shadow-soft);
+  backdrop-filter: blur(18px);
 }
 
 body.dark-mode main.landing .card {
   background: var(--card-bg-dark);
-  box-shadow: 0 26px 52px rgba(0, 0, 0, 0.6);
-  border: 1px solid rgba(148, 163, 184, 0.24);
+  border-color: var(--glass-border-dark);
+  box-shadow: var(--shadow-soft-dark);
 }
 
 main.landing .card p {
   margin: 0;
-  color: rgba(15, 23, 42, 0.78);
+  color: rgba(11, 23, 54, 0.78);
 }
 
 main.landing .card p + p {
@@ -1550,28 +1556,42 @@ main.landing .card p + p {
 }
 
 body.dark-mode main.landing .card p {
-  color: rgba(226, 232, 240, 0.85);
+  color: rgba(245, 248, 255, 0.84);
 }
 
 .landing-hero {
   position: relative;
   display: grid;
-  grid-template-columns: minmax(0, 1.08fr) minmax(0, 0.92fr);
-  gap: clamp(1.8rem, 3.5vw, 3.4rem);
+  grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.95fr);
+  gap: clamp(1.8rem, 3.5vw, 3.6rem);
   align-items: center;
-  background: linear-gradient(135deg, rgba(41, 121, 255, 0.18), rgba(211, 47, 47, 0.14));
-  padding: clamp(2.6rem, 6vw, 4rem);
-  border-radius: 28px;
-  box-shadow: 0 32px 60px rgba(15, 23, 42, 0.16);
+  background: linear-gradient(135deg, rgba(0, 54, 136, 0.16), rgba(29, 126, 240, 0.12));
+  padding: clamp(2.6rem, 6vw, 4.2rem);
+  border-radius: 32px;
+  box-shadow: var(--shadow-soft);
   overflow: hidden;
   isolation: isolate;
-  border: 1px solid rgba(15, 23, 42, 0.06);
+  border: 1px solid var(--glass-border);
+}
+
+.landing-hero::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top left, rgba(29, 126, 240, 0.18) 0%, transparent 60%),
+              radial-gradient(circle at bottom right, rgba(0, 54, 136, 0.22) 0%, transparent 55%);
+  z-index: -1;
 }
 
 body.dark-mode .landing-hero {
-  background: linear-gradient(135deg, rgba(41, 121, 255, 0.25), rgba(211, 47, 47, 0.32));
-  box-shadow: 0 40px 72px rgba(0, 0, 0, 0.65);
-  border: 1px solid rgba(148, 163, 184, 0.24);
+  background: linear-gradient(135deg, rgba(0, 54, 136, 0.45), rgba(29, 126, 240, 0.28));
+  box-shadow: var(--shadow-soft-dark);
+  border-color: var(--glass-border-dark);
+}
+
+body.dark-mode .landing-hero::after {
+  background: radial-gradient(circle at top left, rgba(29, 126, 240, 0.32) 0%, transparent 60%),
+              radial-gradient(circle at bottom right, rgba(0, 27, 68, 0.55) 0%, transparent 55%);
 }
 
 .landing-hero__content {
@@ -1620,7 +1640,7 @@ body.dark-mode .landing-hero__lead {
   gap: 0.5rem;
   padding: 0.7rem 1.8rem;
   border-radius: 999px;
-  border: 1px solid rgba(41, 121, 255, 0.3);
+  border: 1px solid rgba(29, 126, 240, 0.28);
   font-weight: 600;
   text-decoration: none;
   color: var(--accent-blue);
@@ -1636,13 +1656,13 @@ body.dark-mode .landing-hero__lead {
   background: var(--accent-blue);
   color: #fff;
   border-color: transparent;
-  box-shadow: 0 6px 16px rgba(41, 121, 255, 0.28);
+  box-shadow: 0 12px 30px rgba(29, 126, 240, 0.32);
 }
 
 .landing-hero__button:hover,
 .landing-hero__button:focus-visible {
-  transform: translateY(-1px);
-  box-shadow: 0 8px 20px rgba(41, 121, 255, 0.2);
+  transform: translateY(-2px);
+  box-shadow: 0 14px 34px rgba(29, 126, 240, 0.3);
 }
 
 .landing-hero__metrics {
@@ -1696,20 +1716,41 @@ body.dark-mode .landing-hero__metrics dd {
 }
 
 .landing-preview {
-  background: rgba(255, 255, 255, 0.95);
-  border-radius: 20px;
-  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.16);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.92), rgba(229, 239, 255, 0.85));
+  border-radius: 22px;
+  box-shadow: 0 22px 50px rgba(9, 46, 121, 0.18);
   padding: clamp(1.8rem, 3.5vw, 2.6rem);
   display: flex;
   flex-direction: column;
   gap: 1.3rem;
-  border: 1px solid rgba(15, 23, 42, 0.05);
+  border: 1px solid rgba(29, 126, 240, 0.14);
 }
 
 body.dark-mode .landing-preview {
-  background: rgba(17, 24, 39, 0.86);
-  box-shadow: 0 26px 52px rgba(0, 0, 0, 0.6);
-  border: 1px solid rgba(148, 163, 184, 0.24);
+  background: linear-gradient(135deg, rgba(6, 15, 35, 0.8), rgba(11, 33, 66, 0.92));
+  box-shadow: 0 32px 70px rgba(0, 0, 0, 0.65);
+  border: 1px solid rgba(148, 172, 214, 0.28);
+}
+
+.landing-preview__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 0.9rem;
+  color: rgba(11, 23, 54, 0.72);
+}
+
+body.dark-mode .landing-preview__header {
+  color: rgba(245, 248, 255, 0.75);
+}
+
+.landing-preview__level {
+  font-weight: 700;
+  color: var(--accent-blue);
+}
+
+body.dark-mode .landing-preview__level {
+  color: rgba(98, 191, 255, 0.92);
 }
 
 .landing-preview__list {
@@ -1723,14 +1764,14 @@ body.dark-mode .landing-preview {
 .landing-preview__list li {
   padding: 0.75rem 1rem;
   border-radius: 14px;
-  background: rgba(41, 121, 255, 0.08);
+  background: rgba(29, 126, 240, 0.12);
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
 }
 
 body.dark-mode .landing-preview__list li {
-  background: rgba(41, 121, 255, 0.18);
+  background: rgba(29, 126, 240, 0.22);
 }
 
 .landing-preview__label {
@@ -1752,12 +1793,12 @@ body.dark-mode .landing-preview__label {
   align-self: flex-start;
   padding: 0.65rem 1.45rem;
   border-radius: 999px;
-  border: 1px solid rgba(41, 121, 255, 0.3);
+  border: 1px solid rgba(29, 126, 240, 0.3);
   text-decoration: none;
   font-weight: 600;
   color: var(--accent-blue);
   transition: background var(--transition), color var(--transition), box-shadow var(--transition), transform var(--transition);
-  box-shadow: 0 10px 24px rgba(41, 121, 255, 0.2);
+  box-shadow: 0 12px 26px rgba(29, 126, 240, 0.24);
 }
 
 .landing-preview__cta:hover,
@@ -1765,7 +1806,7 @@ body.dark-mode .landing-preview__label {
   background: var(--accent-blue);
   color: #fff;
   transform: translateY(-2px);
-  box-shadow: 0 16px 32px rgba(41, 121, 255, 0.28);
+  box-shadow: 0 18px 36px rgba(29, 126, 240, 0.32);
 }
 
 .landing-panels {
@@ -1775,14 +1816,14 @@ body.dark-mode .landing-preview__label {
 }
 
 .landing-panel {
-  background: rgba(255, 255, 255, 0.92);
-  border-radius: 20px;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.92), rgba(230, 240, 255, 0.88));
+  border-radius: 22px;
   padding: 2rem;
-  box-shadow: 0 18px 38px rgba(15, 23, 42, 0.12);
+  box-shadow: 0 18px 40px rgba(9, 46, 121, 0.12);
   display: flex;
   align-items: flex-start;
   gap: 1.2rem;
-  border: 1px solid rgba(15, 23, 42, 0.06);
+  border: 1px solid rgba(29, 126, 240, 0.1);
 }
 
 .landing-panel__icon {
@@ -1792,7 +1833,7 @@ body.dark-mode .landing-preview__label {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  background: rgba(41, 121, 255, 0.12);
+  background: rgba(29, 126, 240, 0.14);
   color: var(--accent-blue);
   font-size: 1.45rem;
   flex-shrink: 0;
@@ -1810,14 +1851,209 @@ body.dark-mode .landing-preview__label {
 }
 
 body.dark-mode .landing-panel {
-  background: rgba(17, 24, 39, 0.86);
-  box-shadow: 0 25px 45px rgba(0, 0, 0, 0.55);
-  border: 1px solid rgba(148, 163, 184, 0.22);
+  background: linear-gradient(135deg, rgba(6, 15, 35, 0.82), rgba(11, 27, 52, 0.9));
+  box-shadow: 0 25px 55px rgba(0, 0, 0, 0.6);
+  border: 1px solid rgba(148, 172, 214, 0.22);
 }
 
 body.dark-mode .landing-panel__icon {
-  background: rgba(41, 121, 255, 0.22);
+  background: rgba(29, 126, 240, 0.25);
   color: #fff;
+}
+
+.landing-gamify {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.8rem, 3vw, 2.6rem);
+}
+
+.landing-gamify__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  max-width: 62ch;
+}
+
+.landing-gamify__eyebrow {
+  margin: 0;
+  font-size: 0.78rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--accent-blue);
+  font-weight: 700;
+}
+
+.landing-gamify__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+  gap: clamp(1.2rem, 3vw, 2rem);
+}
+
+.landing-gamify__item {
+  border-radius: 18px;
+  padding: 1.8rem;
+  background: rgba(255, 255, 255, 0.86);
+  border: 1px solid rgba(29, 126, 240, 0.1);
+  box-shadow: 0 16px 36px rgba(9, 46, 121, 0.12);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+body.dark-mode .landing-gamify__item {
+  background: rgba(11, 24, 46, 0.82);
+  border-color: rgba(148, 172, 214, 0.2);
+  box-shadow: 0 20px 48px rgba(0, 0, 0, 0.55);
+}
+
+.landing-gamify__icon {
+  width: 46px;
+  height: 46px;
+  border-radius: 14px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(29, 126, 240, 0.16);
+  color: var(--accent-blue);
+  font-size: 1.35rem;
+}
+
+body.dark-mode .landing-gamify__icon {
+  background: rgba(29, 126, 240, 0.24);
+  color: #fff;
+}
+
+.landing-devices {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: clamp(1.6rem, 4vw, 2.5rem);
+  align-items: stretch;
+}
+
+.landing-devices__card {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.landing-devices__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+  font-weight: 600;
+}
+
+.landing-devices__list li {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.98rem;
+}
+
+.landing-devices__list i {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: rgba(29, 126, 240, 0.12);
+  color: var(--accent-blue);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+body.dark-mode .landing-devices__list i {
+  background: rgba(29, 126, 240, 0.22);
+  color: #fff;
+}
+
+.landing-devices__mock {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(1.6rem, 3vw, 2.4rem);
+  background: linear-gradient(140deg, rgba(29, 126, 240, 0.08), rgba(0, 54, 136, 0.14));
+  border-radius: 24px;
+  border: 1px solid rgba(29, 126, 240, 0.12);
+  box-shadow: 0 20px 46px rgba(9, 46, 121, 0.14);
+}
+
+body.dark-mode .landing-devices__mock {
+  background: linear-gradient(140deg, rgba(6, 15, 35, 0.75), rgba(11, 27, 52, 0.88));
+  border-color: rgba(148, 172, 214, 0.22);
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.6);
+}
+
+.landing-devices__screen {
+  width: 100%;
+  border-radius: 22px;
+  padding: 1.6rem;
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid rgba(29, 126, 240, 0.12);
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+}
+
+body.dark-mode .landing-devices__screen {
+  background: rgba(11, 24, 46, 0.84);
+  border-color: rgba(148, 172, 214, 0.22);
+}
+
+.landing-devices__screen > span {
+  font-weight: 700;
+  color: rgba(11, 23, 54, 0.82);
+}
+
+body.dark-mode .landing-devices__screen > span {
+  color: rgba(245, 248, 255, 0.85);
+}
+
+.landing-devices__dots {
+  display: flex;
+  gap: 0.4rem;
+}
+
+.landing-devices__dots span {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: rgba(29, 126, 240, 0.35);
+}
+
+body.dark-mode .landing-devices__dots span {
+  background: rgba(29, 126, 240, 0.48);
+}
+
+.landing-devices__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.9rem;
+}
+
+.landing-devices__grid div {
+  padding: 0.9rem 1rem;
+  border-radius: 14px;
+  background: rgba(29, 126, 240, 0.1);
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+body.dark-mode .landing-devices__grid div {
+  background: rgba(29, 126, 240, 0.22);
+}
+
+.landing-devices__grid strong {
+  font-size: 0.98rem;
+}
+
+.landing-devices__grid p {
+  margin: 0;
+  font-size: 0.88rem;
 }
 
 body.dark-mode .landing-panel__content p {
@@ -1853,25 +2089,25 @@ body.dark-mode .landing-panel__content p {
 }
 
 .landing-tool {
-  border-radius: 20px;
+  border-radius: 22px;
   padding: 2.1rem;
-  background: rgba(255, 255, 255, 0.9);
-  box-shadow: 0 14px 34px rgba(15, 23, 42, 0.1);
+  background: rgba(255, 255, 255, 0.88);
+  box-shadow: 0 16px 38px rgba(9, 46, 121, 0.12);
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  border: 1px solid rgba(15, 23, 42, 0.05);
+  border: 1px solid rgba(29, 126, 240, 0.08);
   transition: transform var(--transition), box-shadow var(--transition);
 }
 
 .landing-tool--accent {
-  background: linear-gradient(135deg, rgba(41, 121, 255, 0.16), rgba(211, 47, 47, 0.18));
+  background: linear-gradient(135deg, rgba(29, 126, 240, 0.16), rgba(0, 54, 136, 0.18));
 }
 
 body.dark-mode .landing-tool {
-  background: rgba(17, 24, 39, 0.86);
-  box-shadow: 0 22px 46px rgba(0, 0, 0, 0.55);
-  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(11, 24, 46, 0.84);
+  box-shadow: 0 22px 52px rgba(0, 0, 0, 0.6);
+  border: 1px solid rgba(148, 172, 214, 0.2);
 }
 
 .landing-tool__icon {
@@ -1881,20 +2117,20 @@ body.dark-mode .landing-tool {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  background: rgba(41, 121, 255, 0.1);
+  background: rgba(29, 126, 240, 0.12);
   color: var(--accent-blue);
   font-size: 1.4rem;
 }
 
 body.dark-mode .landing-tool__icon {
-  background: rgba(41, 121, 255, 0.22);
+  background: rgba(29, 126, 240, 0.24);
   color: #fff;
 }
 
 .landing-tool:hover,
 .landing-tool:focus-within {
   transform: translateY(-6px);
-  box-shadow: 0 24px 50px rgba(15, 23, 42, 0.18);
+  box-shadow: 0 26px 56px rgba(9, 46, 121, 0.18);
 }
 
 .landing-tool__link {
@@ -2039,14 +2275,14 @@ body.dark-mode .landing-updates__form input {
   background: var(--primary);
   color: #fff;
   cursor: pointer;
-  transition: background var(--transition);
-  box-shadow: 0 12px 28px rgba(211, 47, 47, 0.3);
+  transition: background var(--transition), box-shadow var(--transition);
+  box-shadow: 0 12px 28px rgba(0, 54, 136, 0.28);
 }
 
 .landing-updates__form button:hover,
 .landing-updates__form button:focus-visible {
   background: var(--primary-dark);
-  box-shadow: 0 16px 34px rgba(211, 47, 47, 0.35);
+  box-shadow: 0 16px 36px rgba(0, 54, 136, 0.32);
 }
 
 .landing-updates__response {


### PR DESCRIPTION
## Summary
- rebuild the landing page with a sleeker hero, gamification highlights, and cross-platform messaging
- create a gamified dashboard experience featuring daily tasks, badges, Discord role sync, mini games, and refreshed favourites/activity layouts
- refresh shared styling tokens to support the new responsive, glassmorphism-inspired aesthetic across cards

## Testing
- Not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68ccf4c5cc208322ae73bdd24d8f7ba3