### PR TITLE
Restore direct TfL API usage with exposed key

### DIFF
--- a/disruptions.js
+++ b/disruptions.js
@@ -1,10 +1,10 @@
+const APP_KEY = 'f17d0725d1654338ab02a361fe41abad';
 const REFRESH_INTERVAL = 120000;
 
-const TFL_API_BASE = '/api/tfl';
-
 const RAIL_ENDPOINT = () =>
-  `${TFL_API_BASE}/Line/Mode/tube,dlr,overground,elizabeth-line/Status?detail=true`;
-const BUS_ENDPOINT = () => `${TFL_API_BASE}/Line/Mode/bus/Status?detail=true`;
+  `https://api.tfl.gov.uk/Line/Mode/tube,dlr,overground,elizabeth-line/Status?detail=true&app_key=${APP_KEY}`;
+const BUS_ENDPOINT = () =>
+  `https://api.tfl.gov.uk/Line/Mode/bus/Status?detail=true&app_key=${APP_KEY}`;
 
 const elements = {
   railGrid: document.getElementById('railGrid'),

--- a/planning.js
+++ b/planning.js
@@ -1,6 +1,6 @@
 // Journey planning logic for Routeflow London
 
-const TFL_API_BASE = '/api/tfl';
+const APP_KEY = 'f17d0725d1654338ab02a361fe41abad';
 
 document.getElementById('journey-form').addEventListener('submit', async (e) => {
   e.preventDefault();
@@ -24,8 +24,9 @@ document.getElementById('journey-form').addEventListener('submit', async (e) => 
     const params = new URLSearchParams();
     if (mode.length) params.append('mode', mode.join(','));
     if (accessibility.length) params.append('accessibilityPreference', accessibility.join(','));
+    params.append('app_key', APP_KEY);
 
-    let url = `${TFL_API_BASE}/Journey/JourneyResults/${encodeURIComponent(from)}/to/${encodeURIComponent(to)}`;
+    let url = `https://api.tfl.gov.uk/Journey/JourneyResults/${encodeURIComponent(from)}/to/${encodeURIComponent(to)}`;
     if (params.toString()) url += `?${params.toString()}`;
 
     const res = await fetch(url);

--- a/routes.html
+++ b/routes.html
@@ -690,7 +690,19 @@ function signOut() {
   </div>
 
 <script>
-const BASE = '/api/tfl';
+const APP_KEY = 'f17d0725d1654338ab02a361fe41abad';
+const API_BASE = 'https://api.tfl.gov.uk';
+
+const buildUrl = (path, params = {}) => {
+  const url = new URL(path, API_BASE);
+  Object.entries(params).forEach(([key, value]) => {
+    if (value !== undefined && value !== null && value !== '') {
+      url.searchParams.append(key, value);
+    }
+  });
+  url.searchParams.set('app_key', APP_KEY);
+  return url.toString();
+};
 
 let allRoutes = [];
 let routeMeta = {};
@@ -702,7 +714,7 @@ let currentStopSequences = [];
 
 // Fetch all bus routes with start/destination data
 async function fetchRoutes() {
-  const res = await fetch(`${BASE}/Line/Mode/bus/Route`);
+  const res = await fetch(buildUrl('/Line/Mode/bus/Route'));
   const data = await res.json();
   allRoutes = data;
   routeMeta = {};
@@ -816,7 +828,7 @@ async function loadVehicleRegs(routeId) {
     const batch = stops.slice(index, index + maxConcurrent);
     await Promise.all(batch.map(async stop => {
       try {
-        const res = await fetch(`${BASE}/StopPoint/${stop.id}/Arrivals`);
+        const res = await fetch(buildUrl(`/StopPoint/${encodeURIComponent(stop.id)}/Arrivals`));
         const arrivals = await res.json();
         arrivals.filter(a => a.lineId.toLowerCase() === routeId.toLowerCase()).forEach(a => {
           if (a.vehicleId && !vehicleSet.has(a.vehicleId)) {
@@ -848,7 +860,7 @@ async function loadVehicleRegs(routeId) {
 // Load bus stops for route & direction
 async function loadStops(routeId, direction, branchId = 0) {
   try {
-    const res = await fetch(`${BASE}/Line/${routeId}/Route/Sequence/${direction}`);
+    const res = await fetch(buildUrl(`/Line/${encodeURIComponent(routeId)}/Route/Sequence/${direction}`));
     const data = await res.json();
     currentStopSequences = data.stopPointSequences || [];
     let stops = [];
@@ -875,7 +887,7 @@ async function loadStops(routeId, direction, branchId = 0) {
 async function showArrivals(ev, stopId, stopName, stopLetter) {
   ev.stopPropagation();
   try {
-    const res = await fetch(`${BASE}/StopPoint/${stopId}/Arrivals`);
+    const res = await fetch(buildUrl(`/StopPoint/${encodeURIComponent(stopId)}/Arrivals`));
     const data = await res.json();
     document.getElementById('arrivalTitle').innerHTML = stopName +
       (stopLetter ? `<span class="platform-bubble">${stopLetter}</span>` : '');
@@ -910,7 +922,7 @@ async function showBusStopsForReg(ev, vehicleId) {
   const tbody = document.getElementById('regList');
   tbody.innerHTML = `<tr><td colspan="3">Loading...</td></tr>`;
   try {
-    const res = await fetch(`${BASE}/Vehicle/${vehicleId}/Arrivals`);
+    const res = await fetch(buildUrl(`/Vehicle/${encodeURIComponent(vehicleId)}/Arrivals`));
     const data = await res.json();
     tbody.innerHTML = '';
     if (!data || data.length === 0) {

--- a/routes.js
+++ b/routes.js
@@ -1,12 +1,13 @@
 import { getRouteTagOverrideMap, normaliseRouteKey, STORAGE_KEYS } from './data-store.js';
 
-const TFL_API_BASE = '/api/tfl';
+const APP_KEY = 'f17d0725d1654338ab02a361fe41abad';
 
-const ROUTE_ENDPOINT = () => `${TFL_API_BASE}/Line/Mode/bus/Route`;
+const ROUTE_ENDPOINT = () =>
+  `https://api.tfl.gov.uk/Line/Mode/bus/Route?app_key=${APP_KEY}`;
 const ROUTE_STOPS_ENDPOINT = (routeId) =>
-  `${TFL_API_BASE}/Line/${encodeURIComponent(routeId)}/StopPoints`;
+  `https://api.tfl.gov.uk/Line/${encodeURIComponent(routeId)}/StopPoints?app_key=${APP_KEY}`;
 const ROUTE_VEHICLES_ENDPOINT = (routeId) =>
-  `${TFL_API_BASE}/Line/${encodeURIComponent(routeId)}/Arrivals`;
+  `https://api.tfl.gov.uk/Line/${encodeURIComponent(routeId)}/Arrivals?app_key=${APP_KEY}`;
 const LAST_ROUTE_KEY = 'routeflow.lastRoute';
 
 const fallbackRoutes = [

--- a/tracking.html
+++ b/tracking.html
@@ -372,7 +372,11 @@
   <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-auth-compat.js"></script>
   <script src="main.js"></script>
   <script>
-const TFL_API_BASE = '/api/tfl';
+const APP_KEY = 'f17d0725d1654338ab02a361fe41abad';
+const withAppKey = (url) => {
+  const separator = url.includes('?') ? '&' : '?';
+  return `${url}${separator}app_key=${APP_KEY}`;
+};
 const MODES = 'bus,tube,overground,dlr,tram,river-bus,national-rail,elizabeth-line';
 const LAST_STOP_KEY = 'routeflow.lastStop';
 const q = document.getElementById('q');
@@ -461,7 +465,7 @@ async function search(query) {
     return;
   }
 
-  const searchUrl = `${TFL_API_BASE}/StopPoint/Search/${encodeURIComponent(query)}?modes=${encodeURIComponent(MODES)}&maxResults=20`;
+  const searchUrl = withAppKey(`https://api.tfl.gov.uk/StopPoint/Search/${encodeURIComponent(query)}?modes=${encodeURIComponent(MODES)}&maxResults=20`);
 
   let searchData;
   try {
@@ -480,7 +484,9 @@ async function search(query) {
     return;
   }
 
-  const detailPromises = matches.map((m) => fetchJSON(`${TFL_API_BASE}/StopPoint/${m.id}`).catch(() => null));
+  const detailPromises = matches.map((m) =>
+    fetchJSON(withAppKey(`https://api.tfl.gov.uk/StopPoint/${encodeURIComponent(m.id)}`)).catch(() => null)
+  );
   const details = await Promise.all(detailPromises);
 
   const entries = [];
@@ -530,12 +536,14 @@ async function loadArrivals(stopId, stopName) {
   rows.innerHTML = `<div class="empty">Loading…</div>`;
 
   try {
-    let data = await fetchJSON(`${TFL_API_BASE}/StopPoint/${stopId}/Arrivals`);
+    let data = await fetchJSON(withAppKey(`https://api.tfl.gov.uk/StopPoint/${encodeURIComponent(stopId)}/Arrivals`));
 
     if (!Array.isArray(data) || data.length === 0) {
-      const info = await fetchJSON(`${TFL_API_BASE}/StopPoint/${stopId}`).catch(() => null);
+      const info = await fetchJSON(withAppKey(`https://api.tfl.gov.uk/StopPoint/${encodeURIComponent(stopId)}`)).catch(() => null);
       if (info && Array.isArray(info.children) && info.children.length) {
-        const childReqs = info.children.map((c) => fetchJSON(`${TFL_API_BASE}/StopPoint/${c.id}/Arrivals`).catch(() => []));
+        const childReqs = info.children.map((c) =>
+          fetchJSON(withAppKey(`https://api.tfl.gov.uk/StopPoint/${encodeURIComponent(c.id)}/Arrivals`)).catch(() => [])
+        );
         const childData = (await Promise.all(childReqs)).flat();
         data = childData;
       }


### PR DESCRIPTION
## Summary
- restore routes.js to call the public TfL endpoints directly with the shared app key
- update the tracking page scripts to reinstate the earlier TfL fetch logic and exposed key
- ensure disruptions, journey planning, and inline routes tools append the TfL app key when calling the API

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ccf8b78aa48322b00d5fcb8c5c1415