### PR TITLE
Implement auth gating and Info hub redesign

### DIFF
--- a/admin.js
+++ b/admin.js
@@ -707,18 +707,18 @@ function createTagOverridePanel() {
 function createBlogPanel() {
   const panel = document.createElement('section');
   panel.className = 'admin-panel';
-  panel.setAttribute('aria-labelledby', 'blogPanelHeading');
+  panel.setAttribute('aria-labelledby', 'infoPanelHeading');
 
   const header = document.createElement('div');
   header.className = 'admin-panel__header';
 
   const heading = document.createElement('h2');
-  heading.id = 'blogPanelHeading';
-  heading.textContent = 'Blog updates';
+  heading.id = 'infoPanelHeading';
+  heading.textContent = 'Info hub updates';
 
   const description = document.createElement('p');
   description.className = 'admin-panel__description';
-  description.textContent = 'Publish announcements and news that appear on the homepage and blog page.';
+  description.textContent = 'Publish briefs and news that appear on the homepage and Info hub.';
 
   header.append(heading, description);
   panel.append(header);
@@ -787,11 +787,11 @@ function createBlogPanel() {
 
   form.append(grid);
 
-  const summaryField = createTextarea('blog-summary', 'Summary', 'A short teaser that appears on the homepage.');
+  const summaryField = createTextarea('blog-summary', 'Summary', 'A short teaser that appears on the homepage and Info hub.');
   inputs.summary = summaryField.textarea;
   form.append(summaryField.group);
 
-  const contentField = createTextarea('blog-content', 'Full content', 'Add paragraphs separated by a blank line.');
+  const contentField = createTextarea('blog-content', 'Full content', 'Add paragraphs separated by a blank line for the Info hub.');
   inputs.content = contentField.textarea;
   inputs.content.rows = 6;
   form.append(contentField.group);
@@ -804,7 +804,7 @@ function createBlogPanel() {
   featuredInput.id = 'blog-featured';
   inputs.featured = featuredInput;
   const featuredText = document.createElement('span');
-  featuredText.textContent = 'Mark as featured';
+  featuredText.textContent = 'Mark as featured brief';
   featuredLabel.append(featuredInput, featuredText);
   featuredGroup.append(featuredLabel);
   form.append(featuredGroup);
@@ -815,7 +815,7 @@ function createBlogPanel() {
   const submit = document.createElement('button');
   submit.type = 'submit';
   submit.className = 'button admin-button';
-  submit.textContent = 'Publish post';
+  submit.textContent = 'Publish brief';
 
   const cancel = document.createElement('button');
   cancel.type = 'button';
@@ -850,7 +850,7 @@ function createBlogPanel() {
   const resetForm = () => {
     form.reset();
     adminState.blogEditId = null;
-    submit.textContent = 'Publish post';
+    submit.textContent = 'Publish brief';
     cancel.hidden = true;
   };
 
@@ -876,7 +876,7 @@ function createBlogPanel() {
     if (!posts.length) {
       const empty = document.createElement('p');
       empty.className = 'admin-empty';
-      empty.textContent = 'No posts published yet. Add your first update above.';
+      empty.textContent = 'No briefs published yet. Add your first update above.';
       listWrapper.append(empty);
       return;
     }
@@ -1002,7 +1002,7 @@ function createBlogPanel() {
       const current = adminState.blogPosts.find((item) => item.id === adminState.blogEditId);
       if (!current) {
         resetForm();
-        updateFeedback(feedback, 'The post you were editing is no longer available.', 'info');
+        updateFeedback(feedback, 'The brief you were editing is no longer available.', 'info');
       }
     }
   };

--- a/auth-guard.js
+++ b/auth-guard.js
@@ -1,0 +1,133 @@
+(function () {
+  'use strict';
+
+  const DEFAULT_LOCK_MESSAGE = 'Sign in to unlock this area.';
+  const DEFAULT_ERROR_MESSAGE = 'Authentication is unavailable right now. Please try again later.';
+
+  function getLoginButton(overlay) {
+    return overlay ? overlay.querySelector('[data-auth-gate-login]') : null;
+  }
+
+  function updateMessage(overlay, meta, options) {
+    if (!overlay) return;
+    const target = overlay.querySelector('[data-auth-gate-message]');
+    if (!target) return;
+    if (meta?.message) {
+      target.textContent = meta.message;
+      return;
+    }
+    if (meta?.reason === 'auth-missing') {
+      target.textContent = options.errorMessage || DEFAULT_ERROR_MESSAGE;
+      return;
+    }
+    target.textContent = options.lockedMessage || DEFAULT_LOCK_MESSAGE;
+  }
+
+  function showOverlay(overlay, shouldShow) {
+    if (!overlay) return;
+    if (shouldShow) {
+      overlay.removeAttribute('hidden');
+      overlay.setAttribute('aria-hidden', 'false');
+    } else {
+      overlay.setAttribute('hidden', '');
+      overlay.setAttribute('aria-hidden', 'true');
+    }
+  }
+
+  function toggleLockedState(root, sections, locked) {
+    if (root) {
+      if (locked) {
+        root.setAttribute('data-auth-locked', 'true');
+      } else {
+        root.removeAttribute('data-auth-locked');
+      }
+    }
+    if (Array.isArray(sections)) {
+      sections.forEach((section) => {
+        if (!section) return;
+        if (locked) {
+          section.setAttribute('data-locked', 'true');
+        } else {
+          section.removeAttribute('data-locked');
+        }
+      });
+    }
+  }
+
+  function ensureLoginHandler(overlay) {
+    if (!overlay) return;
+    overlay.addEventListener('click', (event) => {
+      const trigger = event.target.closest('[data-auth-gate-login]');
+      if (!trigger) return;
+      event.preventDefault();
+      if (typeof window.openModal === 'function') {
+        window.openModal('login');
+      } else {
+        window.location.href = 'index.html#login';
+      }
+    });
+  }
+
+  function createAuthGate(options = {}) {
+    const root = options.root || document.body;
+    const overlay = options.overlay || null;
+    const lockedSections = Array.from(options.lockedSections || []);
+    const onLock = typeof options.onLock === 'function' ? options.onLock : null;
+    const onUnlock = typeof options.onUnlock === 'function' ? options.onUnlock : null;
+
+    ensureLoginHandler(overlay);
+
+    let lastState = null;
+
+    const api = {
+      lock(meta = {}) {
+        if (lastState === true && !meta.force) {
+          updateMessage(overlay, meta, options);
+          return;
+        }
+        lastState = true;
+        toggleLockedState(root, lockedSections, true);
+        updateMessage(overlay, meta, options);
+        showOverlay(overlay, true);
+        const loginButton = getLoginButton(overlay);
+        if (loginButton) {
+          setTimeout(() => {
+            if (typeof loginButton.focus === 'function') {
+              loginButton.focus();
+            }
+          }, 16);
+        }
+        if (onLock) {
+          try {
+            onLock(meta);
+          } catch (error) {
+            console.warn('Auth gate onLock handler failed', error);
+          }
+        }
+      },
+      unlock(meta = {}) {
+        if (lastState === false && !meta.force) {
+          return;
+        }
+        lastState = false;
+        toggleLockedState(root, lockedSections, false);
+        showOverlay(overlay, false);
+        if (onUnlock) {
+          try {
+            onUnlock(meta.user || meta);
+          } catch (error) {
+            console.warn('Auth gate onUnlock handler failed', error);
+          }
+        }
+      }
+    };
+
+    api.lock({ initial: true });
+
+    return api;
+  }
+
+  window.RouteflowAuthGate = Object.freeze({
+    create: createAuthGate
+  });
+})();

--- a/components/navbar.html
+++ b/components/navbar.html
@@ -15,7 +15,7 @@
         <li><a class="navbar__link" data-nav-link href="dashboard.html">Dashboard</a></li>
         <li><a class="navbar__link" data-nav-link href="tracking.html">Tracking</a></li>
         <li><a class="navbar__link" data-nav-link href="planning.html">Planning</a></li>
-        <li><a class="navbar__link" data-nav-link href="blog.html">Blog</a></li>
+        <li><a class="navbar__link" data-nav-link href="info.html">Info</a></li>
         <li><a class="navbar__link" data-nav-link href="routes.html">Routes</a></li>
         <li><a class="navbar__link" data-nav-link href="withdrawn.html">Withdrawn</a></li>
         <li><a class="navbar__link" data-nav-link href="disruptions.html">Disruptions</a></li>
@@ -71,7 +71,7 @@
         <li><a class="navbar__drawer-link" data-nav-link href="dashboard.html">Dashboard</a></li>
         <li><a class="navbar__drawer-link" data-nav-link href="tracking.html">Tracking</a></li>
         <li><a class="navbar__drawer-link" data-nav-link href="planning.html">Planning</a></li>
-        <li><a class="navbar__drawer-link" data-nav-link href="blog.html">Blog</a></li>
+        <li><a class="navbar__drawer-link" data-nav-link href="info.html">Info</a></li>
         <li><a class="navbar__drawer-link" data-nav-link href="routes.html">Routes</a></li>
         <li><a class="navbar__drawer-link" data-nav-link href="withdrawn.html">Withdrawn</a></li>
         <li><a class="navbar__drawer-link" data-nav-link href="disruptions.html">Disruptions</a></li>

--- a/dashboard.css
+++ b/dashboard.css
@@ -172,8 +172,8 @@ body.dark-mode .dashboard-pill {
 
 .dashboard-hero__stats {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-  gap: 0.9rem;
+  grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+  gap: clamp(0.8rem, 2vw, 1.2rem);
 }
 
 .dashboard-hero__stats div {
@@ -202,7 +202,7 @@ body.dark-mode .dashboard-hero__stats div {
 
 .dashboard-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
   gap: clamp(1.5rem, 3vw, 2.5rem);
 }
 
@@ -356,6 +356,20 @@ body.dark-mode .dashboard-task.is-complete .dashboard-task__button {
   color: var(--accent-blue);
 }
 
+.dashboard-badge__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.6rem;
+}
+
+.dashboard-badge__tier {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--accent-blue);
+}
+
 .dashboard-badge__content h3 {
   margin: 0;
   font-size: 1.05rem;
@@ -418,8 +432,13 @@ body.dark-mode .dashboard-badge {
 
 body.dark-mode .dashboard-badge__content p,
 body.dark-mode .dashboard-task__xp,
-body.dark-mode .dashboard-mini__xp {
+body.dark-mode .dashboard-mini__xp,
+body.dark-mode .dashboard-mini__hint {
   color: rgba(148, 200, 255, 0.9);
+}
+
+body.dark-mode .dashboard-badge__tier {
+  color: rgba(148, 172, 214, 0.8);
 }
 
 body.dark-mode .dashboard-badge__icon {
@@ -492,6 +511,142 @@ body.dark-mode .dashboard-role.is-active {
   gap: 1.1rem;
 }
 
+.dashboard-challenge-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: clamp(1rem, 2vw, 1.6rem);
+}
+
+.dashboard-challenge-list,
+.dashboard-mission-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.9rem;
+}
+
+.dashboard-challenge,
+.dashboard-mission {
+  border: 1px solid rgba(29, 126, 240, 0.16);
+  border-radius: 18px;
+  padding: 1rem 1.1rem;
+  background: rgba(255, 255, 255, 0.78);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65);
+  display: grid;
+  gap: 0.4rem;
+}
+
+.dashboard-challenge[data-status='complete'] {
+  border-color: rgba(29, 126, 240, 0.32);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.72), 0 12px 24px rgba(29, 126, 240, 0.16);
+}
+
+.dashboard-challenge[data-status='missed'] {
+  border-color: rgba(255, 99, 132, 0.35);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+body.dark-mode .dashboard-challenge,
+body.dark-mode .dashboard-mission {
+  background: rgba(8, 18, 38, 0.74);
+  border-color: rgba(84, 125, 210, 0.28);
+  box-shadow: inset 0 1px 0 rgba(148, 172, 214, 0.15);
+}
+
+body.dark-mode .dashboard-challenge[data-status='missed'] {
+  border-color: rgba(248, 113, 113, 0.45);
+}
+
+.dashboard-challenge__meta,
+.dashboard-mission__meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  font-size: 0.85rem;
+  color: rgba(11, 23, 54, 0.66);
+}
+
+body.dark-mode .dashboard-challenge__meta,
+body.dark-mode .dashboard-mission__meta {
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.dashboard-challenge__progress {
+  position: relative;
+  width: 100%;
+  height: 8px;
+  border-radius: 999px;
+  background: rgba(29, 126, 240, 0.16);
+  overflow: hidden;
+}
+
+.dashboard-challenge__progress-bar {
+  position: absolute;
+  inset: 0;
+  width: var(--progress, 0%);
+  background: linear-gradient(120deg, rgba(29, 126, 240, 0.85), rgba(0, 54, 136, 0.95));
+  border-radius: inherit;
+  transition: width 0.4s ease;
+}
+
+.dashboard-mission__title {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.dashboard-mission__title span {
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--accent-blue);
+}
+
+.dashboard-mission__xp {
+  font-weight: 600;
+  color: var(--accent-blue);
+}
+
+.dashboard-mission__copy {
+  margin: 0;
+  color: rgba(11, 23, 54, 0.7);
+}
+
+body.dark-mode .dashboard-mission__copy {
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.dashboard-mission[data-status='complete'] {
+  opacity: 0.6;
+}
+
+.dashboard-mission[data-status='complete'] .dashboard-task__button {
+  display: none;
+}
+
+.dashboard-challenge__penalty {
+  margin: 0;
+  font-size: 0.8rem;
+  color: #b45309;
+}
+
+body.dark-mode .dashboard-challenge__penalty {
+  color: #f6ad55;
+}
+
+.dashboard-mini__hint {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(11, 23, 54, 0.62);
+}
+
+body.dark-mode .dashboard-mini__hint {
+  color: rgba(226, 232, 240, 0.7);
+}
+
 .dashboard-mini {
   border-radius: 18px;
   border: 1px solid rgba(29, 126, 240, 0.12);
@@ -526,6 +681,11 @@ body.dark-mode .dashboard-mini {
   font-weight: 600;
   padding: 0.45rem 1.3rem;
   cursor: pointer;
+}
+
+.dashboard-mini__button[disabled] {
+  opacity: 0.55;
+  cursor: not-allowed;
 }
 
 .activity-list,

--- a/dashboard.html
+++ b/dashboard.html
@@ -13,12 +13,32 @@
 </head>
 <body>
   <div id="navbar-container"></div>
+  <section
+    class="auth-gate"
+    id="dashboardAuthGate"
+    role="alertdialog"
+    aria-modal="true"
+    aria-labelledby="dashboardGateTitle"
+    aria-live="assertive"
+    hidden
+  >
+    <div class="auth-gate__panel">
+      <p class="auth-gate__eyebrow">Progress locked</p>
+      <h2 class="auth-gate__title" id="dashboardGateTitle">Log in to activate the RouteFlow dashboard</h2>
+      <p class="auth-gate__message" data-auth-gate-message>Sign in to unlock this area.</p>
+      <button type="button" class="auth-gate__cta" data-auth-gate-login>
+        <i class="fa-solid fa-lock-open" aria-hidden="true"></i>
+        <span>Sign in to continue</span>
+      </button>
+      <p class="auth-gate__hint">Routes, disruptions and the Info hub remain public for everyone.</p>
+    </div>
+  </section>
   <main class="dashboard" aria-labelledby="dashboard-title">
-    <section class="dashboard-hero card" data-animate="fade-up">
+    <section class="dashboard-hero card" data-animate="fade-up" data-locked-section data-lock-label="Sign in">
       <div class="dashboard-hero__profile">
         <img src="user-icon.png" alt="User Avatar" id="profileAvatar" />
         <div>
-          <p class="dashboard-hero__eyebrow">Welcome back to RouteFlow London</p>
+          <p class="dashboard-hero__eyebrow">RouteFlow progression</p>
           <h1 id="dashboard-title">Welcome</h1>
           <p id="profileInfo" class="dashboard-hero__hint"></p>
           <div class="dashboard-hero__xp" role="group" aria-label="Experience progress">
@@ -30,6 +50,7 @@
               <div class="dashboard-hero__progress-bar" id="xpProgressBar"></div>
             </div>
             <p class="dashboard-hero__progress-copy"><span id="xpToNext">0</span> XP until the next level.</p>
+            <p class="dashboard-hero__progress-copy" id="dailyCapCopy"><span id="dailyCapText">Daily cap: 0 XP remaining</span></p>
           </div>
         </div>
       </div>
@@ -51,12 +72,16 @@
             <span>Streak</span>
             <strong id="streakValue">0</strong>
           </div>
+          <div>
+            <span>Combo chain</span>
+            <strong id="comboValue">0</strong>
+          </div>
         </div>
       </div>
     </section>
 
     <section class="dashboard-grid">
-      <article class="card dashboard-card" id="tasksCard">
+      <article class="card dashboard-card" id="tasksCard" data-locked-section data-lock-label="Sign in">
         <header class="dashboard-card__header">
           <div>
             <p class="dashboard-card__eyebrow">Daily boosters</p>
@@ -67,7 +92,7 @@
         <ul class="dashboard-task-list" id="taskList"></ul>
       </article>
 
-      <article class="card dashboard-card" id="badgesCard">
+      <article class="card dashboard-card" id="badgesCard" data-locked-section data-lock-label="Sign in">
         <header class="dashboard-card__header">
           <div>
             <p class="dashboard-card__eyebrow">Badge cabinet</p>
@@ -78,7 +103,7 @@
         <div class="dashboard-badge-grid" id="badgeGrid"></div>
       </article>
 
-      <article class="card dashboard-card" id="rolesCard">
+      <article class="card dashboard-card" id="rolesCard" data-locked-section data-lock-label="Sign in">
         <header class="dashboard-card__header">
           <div>
             <p class="dashboard-card__eyebrow">Role sync</p>
@@ -89,7 +114,7 @@
         <div class="dashboard-role-grid" id="roleList"></div>
       </article>
 
-      <article class="card dashboard-card" id="miniGamesCard">
+      <article class="card dashboard-card" id="miniGamesCard" data-locked-section data-lock-label="Sign in">
         <header class="dashboard-card__header">
           <div>
             <p class="dashboard-card__eyebrow">Mini games</p>
@@ -100,7 +125,38 @@
         <div class="dashboard-mini-grid" id="miniGameList"></div>
       </article>
 
-      <article class="card dashboard-card" id="activityCard">
+      <article class="card dashboard-card" id="challengesCard" data-locked-section data-lock-label="Sign in">
+        <header class="dashboard-card__header">
+          <div>
+            <p class="dashboard-card__eyebrow">Challenges</p>
+            <h2>Weekly goals and combo chains</h2>
+          </div>
+          <span class="dashboard-card__meta" id="challengeSummary">Track your streaks</span>
+        </header>
+        <div class="dashboard-challenge-grid">
+          <section aria-labelledby="weeklyChallengesTitle">
+            <h3 id="weeklyChallengesTitle">Weekly challenges</h3>
+            <ul class="dashboard-challenge-list" id="weeklyChallengeList"></ul>
+          </section>
+          <section aria-labelledby="comboChallengesTitle">
+            <h3 id="comboChallengesTitle">Combo milestones</h3>
+            <ul class="dashboard-challenge-list" id="comboChallengeList"></ul>
+          </section>
+        </div>
+      </article>
+
+      <article class="card dashboard-card" id="missionsCard" data-locked-section data-lock-label="Sign in">
+        <header class="dashboard-card__header">
+          <div>
+            <p class="dashboard-card__eyebrow">Missions</p>
+            <h2>Meaningful contributions earn more XP</h2>
+          </div>
+          <span class="dashboard-card__meta" id="missionSummary">0 missions</span>
+        </header>
+        <ul class="dashboard-mission-list" id="missionList"></ul>
+      </article>
+
+      <article class="card dashboard-card" id="activityCard" data-locked-section data-lock-label="Sign in">
         <header class="dashboard-card__header">
           <div>
             <p class="dashboard-card__eyebrow">Timeline</p>
@@ -110,7 +166,7 @@
         <ul id="activityList" class="activity-list"></ul>
       </article>
 
-      <article class="card dashboard-card">
+      <article class="card dashboard-card" data-locked-section data-lock-label="Sign in">
         <header class="dashboard-card__header">
           <div>
             <p class="dashboard-card__eyebrow">Saved stops</p>
@@ -120,7 +176,7 @@
         <div id="favouritesGrid" class="favourites-grid"></div>
       </article>
 
-      <article class="card dashboard-card">
+      <article class="card dashboard-card" data-locked-section data-lock-label="Sign in">
         <header class="dashboard-card__header">
           <div>
             <p class="dashboard-card__eyebrow">Quick access</p>
@@ -169,45 +225,268 @@
     })();
   </script>
   <script src="navbar-loader.js"></script>
+  <script src="auth-guard.js"></script>
   <script type="module">
-    import {getFavourites, removeFavourite} from './favourites.js';
-    import {getRecents} from './recents.js';
-    import {inferFavouriteType, resolveFavouriteTitle, buildFavouriteMeta} from './favourite-utils.js';
+    import { getFavourites, removeFavourite } from './favourites.js';
+    import { getRecents } from './recents.js';
+    import { inferFavouriteType, resolveFavouriteTitle, buildFavouriteMeta } from './favourite-utils.js';
 
     const STORAGE_PREFIX = 'routeflow:gamification';
     const TOAST_DURATION = 4000;
+    const LEVEL_CONFIG = { base: 420, growth: 1.48, maxLevel: 40 };
+
     const DEFAULT_GAMIFICATION = () => ({
-      xp: 1320,
-      streak: 3,
+      xp: 1820,
+      streak: 1,
+      dailyCap: 750,
+      dailyXp: 0,
+      lastDailyReset: null,
+      lastLoginDate: null,
       discordConnected: false,
-      lastMiniGame: null,
+      combo: { current: 0, best: 0 },
       tasks: [
-        { id: 'task-tracking', title: 'Check live tracking', description: 'Open the live arrivals page and refresh a stop.', xp: 60, completed: false, badge: 'badge-tracker' },
-        { id: 'task-planning', title: 'Plan a journey', description: 'Plot a multi-mode route with accessibility filters.', xp: 80, completed: false, badge: 'badge-planner' },
-        { id: 'task-fleet', title: 'Review fleet changes', description: 'Visit the fleet dashboard to log a rare working.', xp: 70, completed: false, badge: 'badge-enthusiast' }
+        {
+          id: 'task-tracking',
+          title: 'Verify live tracking',
+          description: 'Refresh arrivals for a priority stop and log a reliability note.',
+          xp: 90,
+          completed: false,
+          badge: 'badge-tracker',
+          trigger: 'task-core'
+        },
+        {
+          id: 'task-planning',
+          title: 'Plan a multi-mode journey',
+          description: 'Use accessibility filters to craft a trip with at least two modes.',
+          xp: 120,
+          completed: false,
+          badge: 'badge-planner',
+          trigger: 'task-core'
+        },
+        {
+          id: 'task-research',
+          title: 'Submit a fleet insight',
+          description: 'Upload evidence for a rare working or new allocation change.',
+          xp: 160,
+          completed: false,
+          badge: 'badge-researcher',
+          trigger: 'mission-progress'
+        }
       ],
       badges: [
-        { id: 'badge-tracker', title: 'Pulse Watcher', description: 'Complete 5 live tracking sessions.', icon: 'fa-solid fa-wifi', progress: 2, goal: 5, xp: 150, earned: false },
-        { id: 'badge-planner', title: 'Journey Curator', description: 'Plan 10 multimodal trips.', icon: 'fa-solid fa-route', progress: 4, goal: 10, xp: 180, earned: false },
-        { id: 'badge-night', title: 'Night Bus Navigator', description: 'Log arrivals after 23:00 for 3 nights.', icon: 'fa-solid fa-moon', progress: 3, goal: 3, xp: 220, earned: true },
-        { id: 'badge-river', title: 'River Trailblazer', description: 'Track a Thames Clipper sailing.', icon: 'fa-solid fa-ship', progress: 0, goal: 1, xp: 120, earned: false }
+        {
+          id: 'badge-tracker',
+          title: 'Pulse Watcher',
+          tier: 'Bronze',
+          description: 'Complete 5 live tracking sessions.',
+          icon: 'fa-solid fa-wifi',
+          progress: 2,
+          goal: 5,
+          xp: 160,
+          earned: false
+        },
+        {
+          id: 'badge-planner',
+          title: 'Journey Curator',
+          tier: 'Silver',
+          description: 'Plan 10 multimodal trips.',
+          icon: 'fa-solid fa-route',
+          progress: 4,
+          goal: 10,
+          xp: 210,
+          earned: false
+        },
+        {
+          id: 'badge-night',
+          title: 'Night Bus Navigator',
+          tier: 'Event',
+          description: 'Log arrivals after 23:00 for three consecutive nights.',
+          icon: 'fa-solid fa-moon',
+          progress: 3,
+          goal: 3,
+          xp: 260,
+          earned: true,
+          rare: true
+        },
+        {
+          id: 'badge-researcher',
+          title: 'Fleet Researcher',
+          tier: 'Gold',
+          description: 'Approve four operator missions.',
+          icon: 'fa-solid fa-magnifying-glass-chart',
+          progress: 1,
+          goal: 4,
+          xp: 280,
+          earned: false
+        },
+        {
+          id: 'badge-archivist',
+          title: 'Hidden Archivist',
+          tier: 'Hidden',
+          description: 'Complete three hidden Info hub missions.',
+          icon: 'fa-solid fa-lock',
+          progress: 0,
+          goal: 3,
+          xp: 320,
+          earned: false,
+          hidden: true
+        }
       ],
       roles: [
-        { id: 'role-dashboard', platform: 'RouteFlow', title: 'Pathfinder', description: 'Unlocked at Level 5.', active: true },
-        { id: 'role-discord', platform: 'Discord', title: 'Community Pathfinder', description: 'Sync via the RouteFlow bot.', active: false }
+        {
+          id: 'role-dashboard',
+          platform: 'RouteFlow',
+          title: 'Pathfinder',
+          description: 'Unlocked automatically at Level 5.',
+          requirements: { level: 5 },
+          active: false
+        },
+        {
+          id: 'role-spotter',
+          platform: 'RouteFlow',
+          title: 'Bus Spotter',
+          description: 'Reach Level 10 and earn the Pulse Watcher badge.',
+          requirements: { level: 10, badges: ['badge-tracker'] },
+          active: false
+        },
+        {
+          id: 'role-expert',
+          platform: 'RouteFlow',
+          title: 'Route Expert',
+          description: 'Level 16 with Journey Curator and Fleet Researcher badges.',
+          requirements: { level: 16, badges: ['badge-planner', 'badge-researcher'] },
+          active: false
+        },
+        {
+          id: 'role-master',
+          platform: 'Discord',
+          title: 'Fleet Master',
+          description: 'Level 24, rare badge unlocked and Discord linked.',
+          requirements: { level: 24, badges: ['badge-night', 'badge-archivist'], discord: true },
+          active: false
+        }
       ],
       miniGames: [
-        { id: 'mini-trivia', title: 'TfL Trivia Rush', description: 'Answer 3 quick-fire questions.', xp: 160, type: 'trivia', played: false },
-        { id: 'mini-pairs', title: 'Line Match', description: 'Match routes to their colours in under 60s.', xp: 140, type: 'memory', played: false },
-        { id: 'mini-streak', title: 'Streak Builder', description: 'Log in on consecutive days.', xp: 120, type: 'streak', played: false }
+        {
+          id: 'mini-guess',
+          title: 'Guess the Bus',
+          description: 'Identify the working from a cryptic clue.',
+          xp: 180,
+          type: 'guess',
+          attempts: 0,
+          maxAttempts: 2
+        },
+        {
+          id: 'mini-route',
+          title: 'Route Puzzle',
+          description: 'Rebuild a route by picking the correct termini.',
+          xp: 210,
+          type: 'puzzle',
+          attempts: 0,
+          maxAttempts: 1
+        },
+        {
+          id: 'mini-streak',
+          title: 'Streak Builder',
+          description: 'Lock in today’s streak bonus without missing a day.',
+          xp: 150,
+          type: 'streak',
+          attempts: 0,
+          maxAttempts: 1
+        }
+      ],
+      weeklyChallenges: [
+        {
+          id: 'weekly-research',
+          title: 'Research Relay',
+          description: 'Complete three missions approved by admins this week.',
+          progress: 1,
+          goal: 3,
+          xp: 220,
+          penalty: 'Missing a day drops progress by one.',
+          trigger: 'mission-complete'
+        },
+        {
+          id: 'weekly-streak',
+          title: 'Streak Sentinel',
+          description: 'Maintain a five-day login streak.',
+          progress: 2,
+          goal: 5,
+          xp: 260,
+          penalty: 'Break the streak and progress resets.',
+          trigger: 'streak'
+        }
+      ],
+      comboChallenges: [
+        {
+          id: 'combo-mini',
+          title: 'Arcade Combo',
+          description: 'Win two mini-games in a row.',
+          progress: 0,
+          goal: 2,
+          xp: 200,
+          penalty: 'A failed attempt resets the chain.',
+          trigger: 'mini-win'
+        },
+        {
+          id: 'combo-contribution',
+          title: 'Contributor Combo',
+          description: 'Complete three missions without missing a day.',
+          progress: 1,
+          goal: 3,
+          xp: 280,
+          penalty: 'Skip a day and the combo resets.',
+          trigger: 'mission-complete'
+        }
+      ],
+      missions: [
+        {
+          id: 'mission-operator',
+          title: 'Operator insight upload',
+          type: 'Operator',
+          description: 'Submit a researched operator change with supporting evidence.',
+          xp: 180,
+          completed: false,
+          badge: 'badge-researcher'
+        },
+        {
+          id: 'mission-gallery',
+          title: 'Fleet gallery expansion',
+          type: 'Media',
+          description: 'Upload two high-quality fleet images to the carousel.',
+          xp: 220,
+          completed: false,
+          badge: 'badge-archivist'
+        },
+        {
+          id: 'mission-maps',
+          title: 'Interactive map note',
+          type: 'Maps',
+          description: 'Add a verified accessibility note to the live network map.',
+          xp: 200,
+          completed: false,
+          badge: null
+        }
       ]
     });
 
-    const LEVEL_THRESHOLDS = [0, 600, 1400, 2300, 3300, 4500, 6000, 7700, 9600, 11600, 13800];
+    const LEVEL_THRESHOLDS = (() => {
+      const thresholds = [0];
+      let requirement = LEVEL_CONFIG.base;
+      for (let level = 1; level <= LEVEL_CONFIG.maxLevel; level += 1) {
+        thresholds[level] = Math.round((thresholds[level - 1] || 0) + requirement);
+        requirement *= LEVEL_CONFIG.growth;
+      }
+      return thresholds;
+    })();
 
     let currentUid = 'guest';
     let gamificationState = DEFAULT_GAMIFICATION();
     let toastTimeout;
+
+    const rootElement = document.querySelector('.dashboard');
+    const overlayElement = document.getElementById('dashboardAuthGate');
+    const lockedSections = document.querySelectorAll('[data-locked-section]');
 
     const toast = document.getElementById('dashboardToast');
     const levelNumber = document.getElementById('levelNumber');
@@ -222,6 +501,38 @@
     const activeRole = document.getElementById('activeRole');
     const discordButton = document.getElementById('discordConnectButton');
     const discordStatus = document.getElementById('discordStatus');
+    const dailyCapCopy = document.getElementById('dailyCapCopy');
+    const dailyCapText = document.getElementById('dailyCapText');
+    const comboValue = document.getElementById('comboValue');
+    const challengeSummary = document.getElementById('challengeSummary');
+    const missionSummary = document.getElementById('missionSummary');
+    const missionList = document.getElementById('missionList');
+    const weeklyChallengeList = document.getElementById('weeklyChallengeList');
+    const comboChallengeList = document.getElementById('comboChallengeList');
+    const titleElement = document.getElementById('dashboard-title');
+    const infoElement = document.getElementById('profileInfo');
+    const avatarElement = document.getElementById('profileAvatar');
+    const miniGameDialog = document.getElementById('miniGameDialog');
+    const miniGameTitle = document.getElementById('miniGameTitle');
+    const miniGameBody = document.getElementById('miniGameBody');
+    const resetTasksButton = document.getElementById('resetTasksButton');
+
+    const levelLocks = [
+      { element: document.getElementById('rolesCard'), level: 5, label: 'Reach Level 5' },
+      { element: document.getElementById('miniGamesCard'), level: 3, label: 'Reach Level 3' },
+      { element: document.getElementById('challengesCard'), level: 6, label: 'Reach Level 6' },
+      { element: document.getElementById('missionsCard'), level: 8, label: 'Level 8 + badges' }
+    ];
+
+    const guard = window.RouteflowAuthGate?.create({
+      root: rootElement,
+      overlay: overlayElement,
+      lockedSections,
+      lockedMessage: 'Sign in to work through missions and unlock challenging rewards.',
+      errorMessage: 'Authentication is temporarily unavailable. Please try again later.',
+      onLock: handleLock,
+      onUnlock: handleUnlock
+    });
 
     function storageKey(uid) {
       return `${STORAGE_PREFIX}:${uid || 'guest'}`;
@@ -244,10 +555,14 @@
           return {
             ...fallback,
             ...stored,
-            tasks: (stored.tasks || fallback.tasks).map(task => ({ ...task })),
-            badges: (stored.badges || fallback.badges).map(badge => ({ ...badge })),
-            roles: (stored.roles || fallback.roles).map(role => ({ ...role })),
-            miniGames: (stored.miniGames || fallback.miniGames).map(game => ({ ...game }))
+            combo: { ...fallback.combo, ...(stored.combo || {}) },
+            tasks: (stored.tasks || fallback.tasks).map((task) => ({ ...task })),
+            badges: (stored.badges || fallback.badges).map((badge) => ({ ...badge })),
+            roles: (stored.roles || fallback.roles).map((role) => ({ ...role })),
+            miniGames: (stored.miniGames || fallback.miniGames).map((game) => ({ ...game })),
+            weeklyChallenges: (stored.weeklyChallenges || fallback.weeklyChallenges).map((item) => ({ ...item })),
+            comboChallenges: (stored.comboChallenges || fallback.comboChallenges).map((item) => ({ ...item })),
+            missions: (stored.missions || fallback.missions).map((mission) => ({ ...mission }))
           };
         }
       } catch (error) {
@@ -276,50 +591,121 @@
       }, TOAST_DURATION);
     }
 
-    function calculateLevel(xp) {
-      let level = 1;
-      for (let i = 0; i < LEVEL_THRESHOLDS.length; i += 1) {
-        if (xp >= LEVEL_THRESHOLDS[i]) {
-          level = i + 1;
-        }
-      }
-      const prev = LEVEL_THRESHOLDS[level - 1] ?? 0;
-      const next = LEVEL_THRESHOLDS[level] ?? (prev + 1800);
-      const progress = Math.min(1, (xp - prev) / (next - prev));
-      return { level, prev, next, progress };
-    }
-
     function formatNumber(value) {
       return new Intl.NumberFormat('en-GB').format(value);
     }
 
-    function updateLevelUI() {
-      const { xp, streak } = gamificationState;
-      const { level, prev, next, progress } = calculateLevel(xp);
-      levelNumber.textContent = level;
-      xpValue.textContent = formatNumber(xp);
-      const remaining = Math.max(0, next - xp);
-      xpToNext.textContent = formatNumber(remaining);
-      xpProgressBar.style.setProperty('--progress', `${Math.round(progress * 100)}%`);
-      streakValue.textContent = streak;
-      gamificationState.roles = gamificationState.roles.map(role => {
-        if (role.id === 'role-dashboard') {
-          return { ...role, active: level >= 5 };
+    function todayKey() {
+      return new Date().toISOString().slice(0, 10);
+    }
+
+    function daysBetween(current, previous) {
+      if (!current || !previous) return Infinity;
+      const currentDate = new Date(current);
+      const previousDate = new Date(previous);
+      if (!Number.isFinite(currentDate.getTime()) || !Number.isFinite(previousDate.getTime())) {
+        return Infinity;
+      }
+      return Math.round((currentDate - previousDate) / 86400000);
+    }
+
+    function ensureDailyState(state) {
+      let dayDifference = null;
+      if (!state) return { dayDifference };
+      const today = todayKey();
+      if (state.lastDailyReset !== today) {
+        state.dailyXp = 0;
+        state.lastDailyReset = today;
+        state.miniGames = state.miniGames.map((game) => ({ ...game, attempts: 0 }));
+      }
+      if (!state.combo) {
+        state.combo = { current: 0, best: 0 };
+      }
+      const previousLogin = state.lastLoginDate;
+      if (previousLogin !== today) {
+        const diff = daysBetween(today, previousLogin);
+        if (Number.isFinite(diff)) {
+          dayDifference = diff;
+          if (diff === 1) {
+            state.streak = (state.streak || 0) + 1;
+          } else if (diff > 1) {
+            state.streak = 1;
+            state.combo.best = Math.max(state.combo.best || 0, state.combo.current || 0);
+            state.combo.current = 0;
+            state.weeklyChallenges = state.weeklyChallenges.map((challenge) => {
+              const reduced = Math.max(0, (challenge.progress || 0) - 1);
+              return { ...challenge, progress: reduced, missed: challenge.progress > reduced };
+            });
+            state.comboChallenges = state.comboChallenges.map((challenge) => ({
+              ...challenge,
+              progress: 0,
+              missed: challenge.progress > 0
+            }));
+          } else {
+            state.streak = state.streak || 1;
+          }
         }
-        if (role.id === 'role-discord') {
-          return { ...role, active: gamificationState.discordConnected };
+        state.lastLoginDate = today;
+      }
+      state.combo.best = Math.max(state.combo.best || 0, state.combo.current || 0);
+      return { dayDifference };
+    }
+
+    function calculateLevel(xp) {
+      let level = 1;
+      for (let i = 1; i < LEVEL_THRESHOLDS.length; i += 1) {
+        if (xp >= LEVEL_THRESHOLDS[i]) {
+          level = i + 1;
+        } else {
+          break;
         }
-        return role;
+      }
+      const prev = LEVEL_THRESHOLDS[level - 1] ?? 0;
+      const nextRequirement = LEVEL_THRESHOLDS[level] ?? Math.round(prev + LEVEL_CONFIG.base * Math.pow(LEVEL_CONFIG.growth, level - 1));
+      const progress = Math.min(1, (xp - prev) / (nextRequirement - prev));
+      return { level, prev, next: nextRequirement, progress };
+    }
+
+    function updateLevelLocks(level) {
+      levelLocks.forEach((lock) => {
+        if (!lock.element) return;
+        if (level >= lock.level) {
+          lock.element.removeAttribute('data-locked');
+          lock.element.removeAttribute('data-lock-label');
+        } else {
+          lock.element.setAttribute('data-locked', 'true');
+          lock.element.setAttribute('data-lock-label', lock.label);
+        }
       });
-      const active = gamificationState.roles.find(role => role.active);
-      activeRole.textContent = active ? active.title : 'Explorer';
+    }
+
+    function updateLevelUI() {
+      const { xp, streak, dailyCap = 0, dailyXp = 0, combo } = gamificationState;
+      const { level, next, prev, progress } = calculateLevel(xp);
+      if (levelNumber) levelNumber.textContent = level;
+      if (xpValue) xpValue.textContent = formatNumber(xp);
+      const remaining = Math.max(0, next - xp);
+      if (xpToNext) xpToNext.textContent = formatNumber(remaining);
+      if (xpProgressBar) xpProgressBar.style.setProperty('--progress', `${Math.round(progress * 100)}%`);
+      if (streakValue) streakValue.textContent = formatNumber(streak || 0);
+      const capRemaining = Math.max(0, dailyCap - dailyXp);
+      if (dailyCapText) {
+        dailyCapText.textContent = capRemaining > 0
+          ? `Daily cap: ${formatNumber(capRemaining)} XP remaining`
+          : 'Daily cap reached — meaningful contributions reset tomorrow.';
+      }
+      if (comboValue) {
+        comboValue.textContent = formatNumber(combo?.current || 0);
+      }
+      updateLevelLocks(level);
+      return level;
     }
 
     function renderTasks() {
       const list = document.getElementById('taskList');
       if (!list) return;
       list.innerHTML = '';
-      gamificationState.tasks.forEach(task => {
+      gamificationState.tasks.forEach((task) => {
         const item = document.createElement('li');
         item.className = `dashboard-task${task.completed ? ' is-complete' : ''}`;
         item.innerHTML = `
@@ -338,62 +724,112 @@
       });
     }
 
+    function resolveBadgeView(badge) {
+      const isHidden = badge.hidden && !badge.earned && (badge.progress || 0) === 0;
+      const title = isHidden ? 'Hidden challenge' : badge.title;
+      const description = isHidden ? 'Keep exploring RouteFlow London to reveal this badge.' : badge.description;
+      return { title, description };
+    }
+
     function renderBadges() {
       const grid = document.getElementById('badgeGrid');
       if (!grid) return;
       grid.innerHTML = '';
       let earnedCount = 0;
-      gamificationState.badges.forEach(badge => {
+      gamificationState.badges.forEach((badge) => {
         if (badge.earned) earnedCount += 1;
-        const progress = Math.min(1, badge.goal ? badge.progress / badge.goal : 1);
+        const progressValue = Math.min(1, badge.goal ? (badge.progress || 0) / badge.goal : 1);
+        const { title, description } = resolveBadgeView(badge);
         const card = document.createElement('article');
         card.className = `dashboard-badge${badge.earned ? ' is-earned' : ''}`;
         card.innerHTML = `
           <div class="dashboard-badge__icon" aria-hidden="true"><i class="${badge.icon}"></i></div>
           <div class="dashboard-badge__content">
-            <h3>${badge.title}</h3>
-            <p>${badge.description}</p>
-            <div class="dashboard-badge__progress" role="progressbar" aria-valuemin="0" aria-valuemax="${badge.goal}" aria-valuenow="${Math.min(badge.progress, badge.goal)}">
-              <div class="dashboard-badge__progress-bar" style="--progress:${Math.round(progress * 100)}%"></div>
+            <div class="dashboard-badge__header">
+              <h3>${title}</h3>
+              <span class="dashboard-badge__tier">${badge.tier || 'Bronze'}</span>
+            </div>
+            <p>${description}</p>
+            <div class="dashboard-badge__progress" role="progressbar" aria-valuemin="0" aria-valuemax="${badge.goal}" aria-valuenow="${Math.min(badge.progress || 0, badge.goal)}">
+              <div class="dashboard-badge__progress-bar" style="--progress:${Math.round(progressValue * 100)}%"></div>
             </div>
             <div class="dashboard-badge__footer">
-              <span>${badge.goal ? `${Math.min(badge.progress, badge.goal)} / ${badge.goal}` : 'Complete'}</span>
+              <span>${badge.goal ? `${Math.min(badge.progress || 0, badge.goal)} / ${badge.goal}` : 'Complete'}</span>
               <span class="dashboard-badge__xp">${badge.xp} XP</span>
-              ${!badge.earned && progress >= 1 ? '<button type="button" class="dashboard-badge__claim" data-claim="' + badge.id + '">Claim</button>' : ''}
+              ${!badge.earned && progressValue >= 1 ? `<button type="button" class="dashboard-badge__claim" data-claim="${badge.id}">Claim</button>` : ''}
             </div>
           </div>
         `;
         grid.appendChild(card);
       });
-      badgeSummary.textContent = earnedCount;
-      badgeCountLabel.textContent = `${earnedCount} badge${earnedCount === 1 ? '' : 's'} earned`;
+      if (badgeSummary) badgeSummary.textContent = earnedCount;
+      if (badgeCountLabel) {
+        badgeCountLabel.textContent = `${earnedCount}/${gamificationState.badges.length} badges earned`;
+      }
     }
 
-    function renderRoles() {
+    function meetsRoleRequirements(role, level) {
+      const requirements = role.requirements || {};
+      if (requirements.level && level < requirements.level) {
+        return false;
+      }
+      if (requirements.discord && !gamificationState.discordConnected) {
+        return false;
+      }
+      if (Array.isArray(requirements.badges) && requirements.badges.length) {
+        const earned = new Set(
+          gamificationState.badges.filter((badge) => badge.earned).map((badge) => badge.id)
+        );
+        return requirements.badges.every((badgeId) => earned.has(badgeId));
+      }
+      return true;
+    }
+
+    function renderRoles(level) {
       const container = document.getElementById('roleList');
       if (!container) return;
       container.innerHTML = '';
-      gamificationState.roles.forEach(role => {
+      let activeLabel = 'Explorer';
+      gamificationState.roles = gamificationState.roles.map((role) => {
+        const unlocked = meetsRoleRequirements(role, level);
+        const nextState = { ...role, active: unlocked };
         const card = document.createElement('article');
-        card.className = `dashboard-role${role.active ? ' is-active' : ''}`;
+        card.className = `dashboard-role${unlocked ? ' is-active' : ''}`;
+        const requirementParts = [];
+        if (role.requirements?.level) requirementParts.push(`Level ${role.requirements.level}`);
+        if (Array.isArray(role.requirements?.badges) && role.requirements.badges.length) requirementParts.push('Badge requirements met');
+        if (role.requirements?.discord) requirementParts.push('Discord linked');
         card.innerHTML = `
           <header>
             <span class="dashboard-role__platform">${role.platform}</span>
             <h3>${role.title}</h3>
           </header>
           <p>${role.description}</p>
-          <span class="dashboard-role__status">${role.active ? 'Active' : 'Locked'}</span>
+          <span class="dashboard-role__status">${unlocked ? 'Active' : `Locked · ${requirementParts.join(' · ')}`}</span>
         `;
         container.appendChild(card);
+        if (unlocked && !role.requirements?.discord) {
+          activeLabel = role.title;
+        }
+        return nextState;
       });
-      roleSyncStatus.textContent = gamificationState.discordConnected ? 'Synced' : 'Not linked';
+      if (activeRole) activeRole.textContent = activeLabel;
+      if (roleSyncStatus) {
+        roleSyncStatus.textContent = gamificationState.discordConnected ? 'Synced' : 'Not linked';
+      }
     }
 
     function renderMiniGames() {
       const container = document.getElementById('miniGameList');
       if (!container) return;
       container.innerHTML = '';
-      gamificationState.miniGames.forEach(game => {
+      let totalAttempts = 0;
+      let remainingAttempts = 0;
+      gamificationState.miniGames.forEach((game) => {
+        const attempts = game.attempts || 0;
+        totalAttempts += game.maxAttempts;
+        const left = Math.max(0, game.maxAttempts - attempts);
+        remainingAttempts += left;
         const card = document.createElement('article');
         card.className = 'dashboard-mini';
         card.innerHTML = `
@@ -401,12 +837,86 @@
           <p>${game.description}</p>
           <div class="dashboard-mini__footer">
             <span class="dashboard-mini__xp">${game.xp} XP</span>
-            <button type="button" data-mini-game="${game.id}" class="dashboard-mini__button">${game.played ? 'Replay' : 'Play'}</button>
+            <button type="button" data-mini-game="${game.id}" class="dashboard-mini__button" ${left === 0 ? 'disabled' : ''}>${left === 0 ? 'Locked' : 'Play'}</button>
           </div>
+          <p class="dashboard-mini__hint">${left} attempt${left === 1 ? '' : 's'} left today</p>
         `;
         container.appendChild(card);
       });
-      miniGameSummary.textContent = `${gamificationState.miniGames.length} mini games`;
+      if (miniGameSummary) {
+        miniGameSummary.textContent = `${remainingAttempts}/${totalAttempts} attempts left today`;
+      }
+    }
+
+    function renderChallenges() {
+      if (!weeklyChallengeList || !comboChallengeList) return;
+      weeklyChallengeList.innerHTML = '';
+      comboChallengeList.innerHTML = '';
+      const weeklyComplete = gamificationState.weeklyChallenges.filter((challenge) => challenge.progress >= challenge.goal).length;
+      const comboComplete = gamificationState.comboChallenges.filter((challenge) => challenge.progress >= challenge.goal).length;
+
+      const renderChallenge = (target, challenge) => {
+        const percent = Math.min(100, Math.round(((challenge.progress || 0) / challenge.goal) * 100));
+        const item = document.createElement('li');
+        item.className = 'dashboard-challenge';
+        if (challenge.progress >= challenge.goal) {
+          item.dataset.status = 'complete';
+        } else if (challenge.missed) {
+          item.dataset.status = 'missed';
+        }
+        item.innerHTML = `
+          <div class="dashboard-mission__title">
+            <strong>${challenge.title}</strong>
+            <span>${challenge.xp} XP</span>
+          </div>
+          <p class="dashboard-mission__copy">${challenge.description}</p>
+          <div class="dashboard-challenge__meta">
+            <span>${Math.min(challenge.progress || 0, challenge.goal)} / ${challenge.goal}</span>
+            <span>${Math.max(0, challenge.goal - (challenge.progress || 0))} to go</span>
+          </div>
+          <div class="dashboard-challenge__progress" role="progressbar" aria-valuemin="0" aria-valuemax="${challenge.goal}" aria-valuenow="${Math.min(challenge.progress || 0, challenge.goal)}">
+            <div class="dashboard-challenge__progress-bar" style="--progress:${percent}%"></div>
+          </div>
+          ${challenge.penalty ? `<p class="dashboard-challenge__penalty">${challenge.penalty}</p>` : ''}
+        `;
+        target.appendChild(item);
+      };
+
+      gamificationState.weeklyChallenges.forEach((challenge) => renderChallenge(weeklyChallengeList, challenge));
+      gamificationState.comboChallenges.forEach((challenge) => renderChallenge(comboChallengeList, challenge));
+
+      if (challengeSummary) {
+        challengeSummary.textContent = `${weeklyComplete}/${gamificationState.weeklyChallenges.length} weekly • ${comboComplete}/${gamificationState.comboChallenges.length} combo complete`;
+      }
+    }
+
+    function renderMissions() {
+      if (!missionList) return;
+      missionList.innerHTML = '';
+      let completed = 0;
+      gamificationState.missions.forEach((mission) => {
+        if (mission.completed) completed += 1;
+        const item = document.createElement('li');
+        item.className = 'dashboard-mission';
+        if (mission.completed) {
+          item.dataset.status = 'complete';
+        }
+        item.innerHTML = `
+          <div class="dashboard-mission__title">
+            <strong>${mission.title}</strong>
+            <span>${mission.type}</span>
+          </div>
+          <p class="dashboard-mission__copy">${mission.description}</p>
+          <div class="dashboard-mission__meta">
+            <span class="dashboard-mission__xp">+${mission.xp} XP</span>
+            <button type="button" class="dashboard-task__button" data-mission="${mission.id}" ${mission.completed ? 'disabled' : ''}>${mission.completed ? 'Completed' : 'Log completion'}</button>
+          </div>
+        `;
+        missionList.appendChild(item);
+      });
+      if (missionSummary) {
+        missionSummary.textContent = `${completed}/${gamificationState.missions.length} complete`;
+      }
     }
 
     function renderDiscordStatus() {
@@ -416,25 +926,68 @@
     }
 
     function renderAll() {
-      updateLevelUI();
+      const level = updateLevelUI();
       renderTasks();
       renderBadges();
-      renderRoles();
+      renderRoles(level);
       renderMiniGames();
+      renderChallenges();
+      renderMissions();
       renderDiscordStatus();
     }
 
-    function addXp(amount, reason) {
-      gamificationState.xp += amount;
-      if (reason) {
-        showToast(`${reason} • +${amount} XP`);
+    function registerComboProgress() {
+      if (!gamificationState.combo) {
+        gamificationState.combo = { current: 0, best: 0 };
       }
+      gamificationState.combo.current = (gamificationState.combo.current || 0) + 1;
+      gamificationState.combo.best = Math.max(gamificationState.combo.best || 0, gamificationState.combo.current);
+    }
+
+    function updateChallenges(trigger) {
+      const apply = (list) => list.map((challenge) => {
+        if (challenge.trigger !== trigger || challenge.progress >= challenge.goal) {
+          return { ...challenge };
+        }
+        const progress = Math.min(challenge.goal, (challenge.progress || 0) + 1);
+        return { ...challenge, progress, missed: false };
+      });
+      gamificationState.weeklyChallenges = apply(gamificationState.weeklyChallenges);
+      gamificationState.comboChallenges = apply(gamificationState.comboChallenges);
+    }
+
+    function addXp(amount, reason, options = {}) {
+      ensureDailyState(gamificationState);
+      const cap = gamificationState.dailyCap || 0;
+      const used = gamificationState.dailyXp || 0;
+      const remaining = Math.max(0, cap - used);
+      if (remaining <= 0) {
+        showToast('Daily XP cap reached — come back tomorrow.');
+        return 0;
+      }
+      const base = Math.min(amount, remaining);
+      let bonus = 0;
+      if (!options.skipBonus && (gamificationState.streak || 0) >= 3) {
+        const multiplier = Math.min(0.5, ((gamificationState.streak || 0) - 2) * 0.05);
+        bonus = Math.floor(base * multiplier);
+        if (bonus > remaining - base) {
+          bonus = remaining - base;
+        }
+      }
+      const total = base + Math.max(0, bonus);
+      gamificationState.dailyXp = (gamificationState.dailyXp || 0) + total;
+      gamificationState.xp += total;
+      if (bonus > 0) {
+        logActivity(`Streak bonus applied · +${bonus} XP`);
+      }
+      showToast(reason ? `${reason} • +${total} XP` : `+${total} XP earned`);
+      return total;
     }
 
     function incrementBadgeProgress(badgeId) {
-      gamificationState.badges = gamificationState.badges.map(badge => {
+      gamificationState.badges = gamificationState.badges.map((badge) => {
         if (badge.id === badgeId && !badge.earned) {
-          const progress = Math.min(badge.goal, (badge.progress ?? 0) + 1);
+          const progress = Math.min(badge.goal, (badge.progress || 0) + 1);
           return { ...badge, progress };
         }
         return badge;
@@ -444,22 +997,44 @@
     function completeTask(taskId) {
       let awardedXp = 0;
       let taskTitle = '';
-      let badgeRef = null;
-      gamificationState.tasks = gamificationState.tasks.map(task => {
+      gamificationState.tasks = gamificationState.tasks.map((task) => {
         if (task.id === taskId && !task.completed) {
-          awardedXp = task.xp;
+          awardedXp = addXp(task.xp, task.title);
           taskTitle = task.title;
-          badgeRef = task.badge;
+          if (task.badge) {
+            incrementBadgeProgress(task.badge);
+          }
+          registerComboProgress();
+          updateChallenges(task.trigger);
           return { ...task, completed: true };
         }
         return task;
       });
-      if (badgeRef) {
-        incrementBadgeProgress(badgeRef);
-      }
       if (awardedXp) {
-        addXp(awardedXp, `${taskTitle} complete`);
         logActivity(`Completed task: ${taskTitle}`);
+      }
+      saveState();
+      renderAll();
+    }
+
+    function completeMission(missionId) {
+      let missionTitle = '';
+      let awardedXp = 0;
+      gamificationState.missions = gamificationState.missions.map((mission) => {
+        if (mission.id === missionId && !mission.completed) {
+          awardedXp = addXp(mission.xp, mission.title);
+          missionTitle = mission.title;
+          if (mission.badge) {
+            incrementBadgeProgress(mission.badge);
+          }
+          registerComboProgress();
+          updateChallenges('mission-complete');
+          return { ...mission, completed: true };
+        }
+        return mission;
+      });
+      if (awardedXp) {
+        logActivity(`Mission completed: ${missionTitle}`);
       }
       saveState();
       renderAll();
@@ -468,106 +1043,111 @@
     function claimBadge(badgeId) {
       let badgeAward = 0;
       let badgeTitle = '';
-      gamificationState.badges = gamificationState.badges.map(badge => {
-        if (badge.id === badgeId && !badge.earned && badge.progress >= badge.goal) {
-          badgeAward = badge.xp;
+      gamificationState.badges = gamificationState.badges.map((badge) => {
+        if (badge.id === badgeId && !badge.earned && (badge.progress || 0) >= badge.goal) {
+          badgeAward = addXp(badge.xp, `${badge.title} badge`, { skipBonus: true });
           badgeTitle = badge.title;
           return { ...badge, earned: true };
         }
         return badge;
       });
       if (badgeAward) {
-        addXp(badgeAward, `${badgeTitle} badge`);
         logActivity(`Claimed badge: ${badgeTitle}`);
+        saveState();
+        renderAll();
       }
-      saveState();
-      renderAll();
     }
 
     function toggleDiscord() {
       gamificationState.discordConnected = !gamificationState.discordConnected;
       if (gamificationState.discordConnected) {
         logActivity('Discord account linked');
-        showToast('Discord linked — roles syncing now.');
       } else {
         logActivity('Discord account disconnected');
-        showToast('Discord disconnected.');
       }
       saveState();
       renderAll();
     }
 
     function openMiniGame(gameId) {
-      const game = gamificationState.miniGames.find(item => item.id === gameId);
+      const game = gamificationState.miniGames.find((item) => item.id === gameId);
       if (!game) return;
-      const dialog = document.getElementById('miniGameDialog');
-      const title = document.getElementById('miniGameTitle');
-      const body = document.getElementById('miniGameBody');
-      if (!dialog || !title || !body) return;
-
-      title.textContent = game.title;
-      if (game.type === 'trivia') {
-        body.innerHTML = `
-          <p class="dashboard-dialog__lead">Which Underground line opened most recently?</p>
+      const attempts = game.attempts || 0;
+      const attemptsLeft = Math.max(0, game.maxAttempts - attempts);
+      if (attemptsLeft <= 0) {
+        showToast('All attempts used today. Come back after the daily reset.');
+        return;
+      }
+      if (!miniGameDialog || !miniGameTitle || !miniGameBody) return;
+      miniGameTitle.textContent = game.title;
+      let bodyHtml = '';
+      if (game.type === 'guess') {
+        bodyHtml = `
+          <p class="dashboard-dialog__lead">Which registration matches the clue: "Go-Ahead’s latest electric on the 36"?</p>
           <div class="dashboard-dialog__options">
-            <button type="button" data-answer="wrong">Northern Line extension</button>
-            <button type="button" data-answer="correct">Elizabeth line</button>
-            <button type="button" data-answer="wrong">Jubilee Line</button>
+            <button type="button" data-answer="wrong">VWH 2380 on the 43</button>
+            <button type="button" data-answer="correct">SEe 94 on the 36</button>
+            <button type="button" data-answer="wrong">LT17 on the 15H</button>
           </div>
         `;
-      } else if (game.type === 'memory') {
-        body.innerHTML = `
-          <p class="dashboard-dialog__lead">Match the route to its colour:</p>
-          <ul class="dashboard-dialog__list">
-            <li><strong>Route 25</strong> — <span>Red</span></li>
-            <li><strong>Route 205</strong> — <span>Blue</span></li>
-            <li><strong>Route 15</strong> — <span>Heritage Green</span></li>
-          </ul>
-          <p class="dashboard-dialog__hint">Memorise and close the game when you're ready.</p>
-          <button type="button" class="dashboard-dialog__cta" data-complete="${game.id}">Claim XP</button>
+      } else if (game.type === 'puzzle') {
+        bodyHtml = `
+          <p class="dashboard-dialog__lead">Select the correct termini for route 135.</p>
+          <div class="dashboard-dialog__options">
+            <button type="button" data-answer="wrong">Ilford Broadway ↔ Hyde Park Corner</button>
+            <button type="button" data-answer="correct">Crossharbour ↔ Old Street</button>
+            <button type="button" data-answer="wrong">Lewisham ↔ North Greenwich</button>
+          </div>
         `;
       } else {
-        body.innerHTML = `
-          <p class="dashboard-dialog__lead">Keep your streak going! Check in daily to climb the leaderboard.</p>
-          <button type="button" class="dashboard-dialog__cta" data-complete="${game.id}">Log check-in</button>
+        bodyHtml = `
+          <p class="dashboard-dialog__lead">Lock in today’s streak bonus to keep your combo alive.</p>
+          <div class="dashboard-dialog__options">
+            <button type="button" data-answer="correct">Confirm check-in</button>
+          </div>
         `;
       }
-
-      body.querySelectorAll('[data-answer]').forEach(button => {
-        button.addEventListener('click', (event) => {
-          const correct = event.currentTarget.dataset.answer === 'correct';
-          if (correct) {
-            addXp(game.xp, `${game.title} completed`);
-            gamificationState.miniGames = gamificationState.miniGames.map(item => item.id === gameId ? { ...item, played: true } : item);
-            saveState();
-            renderAll();
-            dialog.close();
-          } else {
-            showToast('Not quite! Try again.');
-          }
-        });
-      });
-
-      body.querySelectorAll('[data-complete]').forEach(button => {
-        button.addEventListener('click', () => {
-          addXp(game.xp, `${game.title} completed`);
-          gamificationState.miniGames = gamificationState.miniGames.map(item => item.id === gameId ? { ...item, played: true } : item);
-          saveState();
-          renderAll();
-          dialog.close();
-        });
-      });
-
-      if (typeof dialog.showModal === 'function') {
-        dialog.showModal();
+      bodyHtml += `<p class="dashboard-mini__hint">${attemptsLeft} attempt${attemptsLeft === 1 ? '' : 's'} left today</p>`;
+      miniGameBody.innerHTML = bodyHtml;
+      miniGameBody.dataset.game = game.id;
+      if (typeof miniGameDialog.showModal === 'function') {
+        miniGameDialog.showModal();
       }
     }
 
+    function resolveMiniGame(gameId, success) {
+      const gameIndex = gamificationState.miniGames.findIndex((item) => item.id === gameId);
+      if (gameIndex === -1) return;
+      const game = gamificationState.miniGames[gameIndex];
+      const attempts = game.attempts || 0;
+      if (attempts >= game.maxAttempts) {
+        showToast('All attempts used today.');
+        return;
+      }
+      const updatedGame = { ...game, attempts: attempts + 1 };
+      gamificationState.miniGames.splice(gameIndex, 1, updatedGame);
+      if (success) {
+        const awarded = addXp(game.xp, game.title);
+        if (awarded) {
+          logActivity(`Won mini game: ${game.title}`);
+          registerComboProgress();
+          updateChallenges('mini-win');
+          if (miniGameBody) {
+            miniGameBody.innerHTML = '<p class="dashboard-dialog__lead">Great work — bonus XP secured.</p>';
+          }
+        }
+      } else if (miniGameBody) {
+        miniGameBody.innerHTML = '<p class="dashboard-dialog__lead">Not quite — review the Info hub clues and try again tomorrow.</p>';
+      }
+      saveState();
+      renderMiniGames();
+    }
+
     function resetTasks() {
-      gamificationState.tasks = gamificationState.tasks.map(task => ({ ...task, completed: false }));
+      gamificationState.tasks = gamificationState.tasks.map((task) => ({ ...task, completed: false }));
       saveState();
       renderAll();
-      showToast('Daily tasks reset. Ready when you are!');
+      showToast('Daily tasks reset. Fresh streak starts now.');
     }
 
     function logActivity(message) {
@@ -577,7 +1157,7 @@
       try {
         const history = safeParse(localStorage.getItem(key)) || [];
         history.unshift(message);
-        localStorage.setItem(key, JSON.stringify(history.slice(0, 10)));
+        localStorage.setItem(key, JSON.stringify(history.slice(0, 12)));
       } catch (error) {
         console.warn('RouteFlow dashboard: unable to log activity', error);
       }
@@ -587,23 +1167,18 @@
     function createFavouriteCard(uid, favourite) {
       const card = document.createElement('article');
       card.className = 'favourite-item';
-
       const header = document.createElement('div');
       header.className = 'favourite-item__header';
-
       const eyebrow = document.createElement('span');
       eyebrow.className = 'favourite-item__eyebrow';
       eyebrow.textContent = inferFavouriteType(favourite);
       header.appendChild(eyebrow);
-
       const removeButton = document.createElement('button');
       removeButton.type = 'button';
       removeButton.className = 'favourite-item__remove';
       removeButton.textContent = 'Remove';
       removeButton.addEventListener('click', async () => {
-        if (!uid || !favourite?.id) {
-          return;
-        }
+        if (!uid || !favourite?.id) return;
         try {
           removeButton.disabled = true;
           await removeFavourite(uid, favourite.id);
@@ -616,28 +1191,24 @@
         }
       });
       header.appendChild(removeButton);
-
       const title = resolveFavouriteTitle(favourite);
       const titleEl = document.createElement('h3');
       titleEl.className = 'favourite-item__title';
       titleEl.textContent = title;
-
       const metaParts = buildFavouriteMeta(favourite, title);
-
       card.append(header, titleEl);
-
       if (metaParts.length) {
         const metaEl = document.createElement('p');
         metaEl.className = 'favourite-item__meta';
         metaEl.textContent = metaParts.join(' • ');
         card.appendChild(metaEl);
       }
-
       return card;
     }
 
     async function loadFavourites(uid) {
       const grid = document.getElementById('favouritesGrid');
+      if (!grid) return;
       grid.innerHTML = '';
       if (!uid || uid === 'guest') {
         const emptyState = document.createElement('p');
@@ -669,34 +1240,97 @@
 
     function loadRecents(uid) {
       const list = document.getElementById('recentsList');
+      if (!list) return;
       list.innerHTML = '';
       const recents = getRecents(uid);
-      if (recents.length === 0) {
+      if (!recents.length) {
         list.innerHTML = '<li>No recent items.</li>';
         return;
       }
-      recents.forEach(r => {
+      recents.forEach((recent) => {
         const li = document.createElement('li');
-        const a = document.createElement('a');
-        a.href = r.url;
-        a.textContent = r.title || r.url;
-        li.appendChild(a);
+        const link = document.createElement('a');
+        link.href = recent.url;
+        link.textContent = recent.title || recent.url;
+        li.appendChild(link);
         list.appendChild(li);
       });
     }
 
     function loadActivity(uid) {
       const list = document.getElementById('activityList');
+      if (!list) return;
       list.innerHTML = '';
-      const acts = safeParse(localStorage.getItem(`activity_${uid}`)) || [];
-      if (acts.length === 0) {
+      const history = safeParse(localStorage.getItem(`activity_${uid}`)) || [];
+      if (!history.length) {
         list.innerHTML = '<li>No recent activity.</li>';
         return;
       }
-      acts.forEach(a => {
+      history.forEach((entry) => {
         const li = document.createElement('li');
-        li.textContent = a;
+        li.textContent = entry;
         list.appendChild(li);
+      });
+    }
+
+    function handleLock() {
+      currentUid = 'guest';
+      gamificationState = loadState(currentUid);
+      ensureDailyState(gamificationState);
+      if (titleElement) titleElement.textContent = 'Welcome';
+      if (infoElement) infoElement.textContent = 'Sign in to save favourites and unlock missions, roles and streak bonuses.';
+      if (avatarElement) avatarElement.src = 'user-icon.png';
+      renderAll();
+      loadActivity('guest');
+      loadRecents('guest');
+      const favouritesGrid = document.getElementById('favouritesGrid');
+      if (favouritesGrid) {
+        favouritesGrid.innerHTML = '<p class="dashboard-empty">Sign in to manage favourites.</p>';
+      }
+    }
+
+    async function handleUnlock(user) {
+      if (!user) return;
+      currentUid = user.uid;
+      gamificationState = loadState(currentUid);
+      const { dayDifference } = ensureDailyState(gamificationState);
+      if (titleElement) titleElement.textContent = `Welcome, ${user.email || 'Explorer'}`;
+      if (infoElement) infoElement.textContent = 'Your rewards sync automatically across devices and Discord.';
+      if (avatarElement) avatarElement.src = user.photoURL || 'user-icon.png';
+      if (dayDifference === 1) {
+        updateChallenges('streak');
+      }
+      renderAll();
+      try {
+        await loadFavourites(user.uid);
+      } catch (error) {
+        console.error('Failed to refresh favourites after sign in.', error);
+      }
+      loadActivity(user.uid);
+      loadRecents(user.uid);
+      saveState();
+    }
+
+    function subscribeToAuth() {
+      if (typeof firebase === 'undefined' || !firebase?.auth) {
+        guard?.lock({ reason: 'auth-missing', force: true });
+        handleLock();
+        return;
+      }
+      const auth = firebase.auth();
+      auth.onAuthStateChanged((user) => {
+        if (user) {
+          if (guard) {
+            guard.unlock({ user });
+          } else {
+            handleUnlock(user);
+          }
+        } else {
+          if (guard) {
+            guard.lock({ reason: 'signed-out', force: true });
+          }
+          handleLock();
+        }
       });
     }
 
@@ -706,54 +1340,42 @@
         completeTask(taskButton.dataset.task);
         return;
       }
-
       const badgeButton = event.target.closest('[data-claim]');
       if (badgeButton) {
         claimBadge(badgeButton.dataset.claim);
         return;
       }
-
       const miniButton = event.target.closest('[data-mini-game]');
       if (miniButton) {
         openMiniGame(miniButton.dataset.miniGame);
+        return;
+      }
+      const missionButton = event.target.closest('[data-mission]');
+      if (missionButton) {
+        completeMission(missionButton.dataset.mission);
       }
     });
+
+    if (miniGameBody) {
+      miniGameBody.addEventListener('click', (event) => {
+        const answerButton = event.target.closest('[data-answer]');
+        if (!answerButton) return;
+        const gameId = miniGameBody.dataset.game;
+        resolveMiniGame(gameId, answerButton.dataset.answer === 'correct');
+      });
+    }
 
     if (discordButton) {
       discordButton.addEventListener('click', toggleDiscord);
     }
 
-    const resetTasksButton = document.getElementById('resetTasksButton');
     if (resetTasksButton) {
       resetTasksButton.addEventListener('click', resetTasks);
     }
 
-    firebase.auth().onAuthStateChanged(async user => {
-      const title = document.getElementById('dashboard-title');
-      const info = document.getElementById('profileInfo');
-      const avatar = document.getElementById('profileAvatar');
-      if (user) {
-        currentUid = user.uid;
-        gamificationState = loadState(currentUid);
-        title.textContent = `Welcome, ${user.email}`;
-        avatar.src = user.photoURL || 'user-icon.png';
-        info.textContent = 'Your rewards sync automatically across devices and Discord.';
-        await loadFavourites(user.uid);
-        loadActivity(user.uid);
-        loadRecents(user.uid);
-      } else {
-        currentUid = 'guest';
-        gamificationState = loadState(currentUid);
-        title.textContent = 'Welcome';
-        avatar.src = 'user-icon.png';
-        info.textContent = 'Sign in to save favourites and track your rewards everywhere.';
-        const favouritesGrid = document.getElementById('favouritesGrid');
-        favouritesGrid.innerHTML = '<p class="dashboard-empty">Sign in to manage favourites.</p>';
-        loadActivity('guest');
-        loadRecents('guest');
-      }
-      renderAll();
-    });
+    subscribeToAuth();
+    renderAll();
+
   </script>
 </body>
 </html>

--- a/fleet.css
+++ b/fleet.css
@@ -311,6 +311,205 @@ body.dark-mode .fleet-highlight__list li {
   border-color: rgba(148, 163, 184, 0.2);
 }
 
+.fleet-operators__header {
+  display: grid;
+  gap: 1.4rem;
+  align-items: flex-start;
+}
+
+@media (min-width: 768px) {
+  .fleet-operators__header {
+    grid-template-columns: 1fr auto;
+    align-items: center;
+  }
+}
+
+.fleet-operators__tabs {
+  display: flex;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+}
+
+.fleet-operators__tab {
+  border: 1px solid rgba(29, 126, 240, 0.28);
+  background: rgba(29, 126, 240, 0.08);
+  color: var(--primary);
+  border-radius: 999px;
+  padding: 0.5rem 1.1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background var(--transition), color var(--transition), border-color var(--transition);
+}
+
+.fleet-operators__tab.is-active {
+  background: linear-gradient(120deg, rgba(29, 126, 240, 0.85), rgba(0, 54, 136, 0.95));
+  color: #fff;
+  border-color: transparent;
+}
+
+body.dark-mode .fleet-operators__tab {
+  border-color: rgba(148, 172, 214, 0.4);
+  background: rgba(148, 172, 214, 0.14);
+  color: rgba(226, 232, 240, 0.9);
+}
+
+body.dark-mode .fleet-operators__tab.is-active {
+  background: linear-gradient(120deg, rgba(29, 126, 240, 0.7), rgba(76, 161, 255, 0.85));
+  color: #fff;
+}
+
+.fleet-operators__panels {
+  margin-top: 1.4rem;
+}
+
+.fleet-operators__panel {
+  border-radius: 18px;
+  border: 1px solid rgba(29, 126, 240, 0.14);
+  background: rgba(15, 23, 42, 0.04);
+  padding: 1.4rem;
+}
+
+body.dark-mode .fleet-operators__panel {
+  border-color: rgba(148, 172, 214, 0.25);
+  background: rgba(11, 24, 46, 0.78);
+}
+
+.fleet-operators__stats {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.9rem;
+}
+
+.fleet-operators__stats li {
+  background: rgba(29, 126, 240, 0.08);
+  border-radius: 14px;
+  padding: 0.85rem 1rem;
+  line-height: 1.5;
+}
+
+body.dark-mode .fleet-operators__stats li {
+  background: rgba(29, 126, 240, 0.22);
+  color: rgba(226, 232, 240, 0.92);
+}
+
+.fleet-showcase__header {
+  margin-bottom: 1.4rem;
+}
+
+.fleet-carousel {
+  position: relative;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 1rem;
+  align-items: center;
+}
+
+@media (max-width: 760px) {
+  .fleet-carousel {
+    grid-template-columns: 1fr;
+  }
+
+  .fleet-carousel__control[data-carousel-prev],
+  .fleet-carousel__control[data-carousel-next] {
+    justify-self: center;
+  }
+}
+
+.fleet-carousel__viewport {
+  width: 100%;
+  display: grid;
+}
+
+.fleet-carousel__item {
+  border-radius: 20px;
+  background: rgba(15, 23, 42, 0.04);
+  border: 1px solid rgba(29, 126, 240, 0.14);
+  overflow: hidden;
+  display: grid;
+  gap: 1rem;
+  padding: 1rem 1rem 1.4rem;
+}
+
+body.dark-mode .fleet-carousel__item {
+  background: rgba(11, 24, 46, 0.78);
+  border-color: rgba(148, 172, 214, 0.25);
+}
+
+.fleet-carousel__item img {
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  object-fit: cover;
+  border-radius: 14px;
+}
+
+.fleet-carousel__meta h3 {
+  margin: 0;
+}
+
+.fleet-carousel__meta p {
+  margin: 0.4rem 0 0;
+  color: rgba(15, 23, 42, 0.75);
+}
+
+body.dark-mode .fleet-carousel__meta p {
+  color: rgba(226, 232, 240, 0.82);
+}
+
+.fleet-carousel__control {
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  border: 1px solid rgba(29, 126, 240, 0.25);
+  background: rgba(29, 126, 240, 0.12);
+  color: var(--primary);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background var(--transition), color var(--transition);
+}
+
+.fleet-carousel__control:hover,
+.fleet-carousel__control:focus-visible {
+  background: rgba(29, 126, 240, 0.28);
+}
+
+body.dark-mode .fleet-carousel__control {
+  border-color: rgba(148, 172, 214, 0.35);
+  background: rgba(148, 172, 214, 0.18);
+  color: rgba(226, 232, 240, 0.9);
+}
+
+.fleet-carousel__dots {
+  margin-top: 1rem;
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+}
+
+.fleet-carousel__dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(29, 126, 240, 0.25);
+  cursor: pointer;
+}
+
+.fleet-carousel__dot.is-active {
+  background: rgba(29, 126, 240, 0.9);
+}
+
+body.dark-mode .fleet-carousel__dot {
+  background: rgba(148, 172, 214, 0.3);
+}
+
+body.dark-mode .fleet-carousel__dot.is-active {
+  background: rgba(148, 172, 214, 0.9);
+}
+
 .fleet-highlight__list span {
   font-weight: 600;
 }

--- a/fleet.html
+++ b/fleet.html
@@ -23,9 +23,29 @@
   </head>
   <body>
     <div id="navbar-container"></div>
+    <section
+      class="auth-gate"
+      id="fleetAuthGate"
+      role="alertdialog"
+      aria-modal="true"
+      aria-labelledby="fleetGateTitle"
+      aria-live="assertive"
+      hidden
+    >
+      <div class="auth-gate__panel">
+        <p class="auth-gate__eyebrow">Fleet tools locked</p>
+        <h2 class="auth-gate__title" id="fleetGateTitle">Sign in to browse RouteFlow fleet intelligence</h2>
+        <p class="auth-gate__message" data-auth-gate-message>Sign in to unlock this area.</p>
+        <button type="button" class="auth-gate__cta" data-auth-gate-login>
+          <i class="fa-solid fa-lock-open" aria-hidden="true"></i>
+          <span>Sign in to continue</span>
+        </button>
+        <p class="auth-gate__hint">Routes, disruptions and the Info hub remain open to everyone.</p>
+      </div>
+    </section>
 
-    <main class="fleet-page">
-      <section class="fleet-card fleet-hero">
+    <main class="fleet-page" data-auth-locked="true">
+      <section class="fleet-card fleet-hero" data-locked-section data-lock-label="Sign in">
         <div class="fleet-hero__heading">
           <p class="fleet-hero__eyebrow">Fleet database</p>
           <h1>London buses organised by registration</h1>
@@ -59,7 +79,7 @@
         </dl>
       </section>
 
-      <section class="fleet-card fleet-controls" aria-labelledby="fleetFilters">
+      <section class="fleet-card fleet-controls" data-locked-section data-lock-label="Sign in" aria-labelledby="fleetFilters">
         <div class="fleet-controls__intro">
           <div>
             <h2 id="fleetFilters">Search and filter</h2>
@@ -100,7 +120,52 @@
       </section>
 
       <section
+        class="fleet-card fleet-operators"
+        data-locked-section
+        data-lock-label="Sign in"
+        aria-labelledby="operatorExplorerHeading"
+      >
+        <header class="fleet-operators__header">
+          <div>
+            <p class="fleet-hero__eyebrow">Operator explorer</p>
+            <h2 id="operatorExplorerHeading">Scan the network by operator focus</h2>
+            <p>Switch tabs to compare allocations, engineering notes and upcoming expansions across the biggest London operators.</p>
+          </div>
+          <nav class="fleet-operators__tabs" role="tablist" aria-label="Operator focus">
+            <button type="button" class="fleet-operators__tab is-active" id="operatorTabAbellio" data-operator-tab="abellio" role="tab" aria-selected="true" aria-controls="operatorPanelAbellio">Abellio London</button>
+            <button type="button" class="fleet-operators__tab" id="operatorTabGoAhead" data-operator-tab="goahead" role="tab" aria-selected="false" aria-controls="operatorPanelGoAhead">Go-Ahead London</button>
+            <button type="button" class="fleet-operators__tab" id="operatorTabStagecoach" data-operator-tab="stagecoach" role="tab" aria-selected="false" aria-controls="operatorPanelStagecoach">Stagecoach London</button>
+          </nav>
+        </header>
+        <div class="fleet-operators__panels">
+          <div class="fleet-operators__panel is-active" id="operatorPanelAbellio" data-operator-panel="abellio" role="tabpanel" aria-labelledby="operatorTabAbellio">
+            <ul class="fleet-operators__stats">
+              <li><strong>Electric hubs:</strong> Battersea and Walworth lead zero-emission rollouts.</li>
+              <li><strong>Fleet refresh:</strong> 47 new Enviro400EVs scheduled through Q3.</li>
+              <li><strong>Research missions:</strong> Focus on cross-river services and night allocations.</li>
+            </ul>
+          </div>
+          <div class="fleet-operators__panel" id="operatorPanelGoAhead" data-operator-panel="goahead" role="tabpanel" aria-labelledby="operatorTabGoAhead" hidden>
+            <ul class="fleet-operators__stats">
+              <li><strong>Network reach:</strong> River Road and Camberwell hubs feed express corridors.</li>
+              <li><strong>Hybrid conversions:</strong> Retrofits underway on 25 Gemini 3 units.</li>
+              <li><strong>Badge synergy:</strong> Missions prioritise river services and Thames tunnel diversions.</li>
+            </ul>
+          </div>
+          <div class="fleet-operators__panel" id="operatorPanelStagecoach" data-operator-panel="stagecoach" role="tabpanel" aria-labelledby="operatorTabStagecoach" hidden>
+            <ul class="fleet-operators__stats">
+              <li><strong>Route reshapes:</strong> East London restructures after Superloop launches.</li>
+              <li><strong>Heritage tracking:</strong> Withdrawn Tridents archived with gallery links.</li>
+              <li><strong>Challenge tip:</strong> Combo missions reward engineering note submissions.</li>
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <section
         class="fleet-card fleet-highlights"
+        data-locked-section
+        data-lock-label="Sign in"
         aria-labelledby="fleetHighlightsHeading"
       >
         <header class="fleet-highlights__header">
@@ -124,11 +189,68 @@
             <h3 id="rareWorkingHighlight">Rare workings</h3>
             <ul id="rareWorkingList" class="fleet-highlight__list"></ul>
           </article>
+          <article class="fleet-highlight" aria-labelledby="withdrawnHighlight">
+            <h3 id="withdrawnHighlight">Withdrawn history</h3>
+            <ul id="withdrawnHighlightList" class="fleet-highlight__list"></ul>
+          </article>
+        </div>
+      </section>
+
+      <section
+        class="fleet-card fleet-showcase"
+        data-locked-section
+        data-lock-label="Sign in"
+        aria-labelledby="fleetShowcaseHeading"
+      >
+        <header class="fleet-showcase__header">
+          <div>
+            <p class="fleet-hero__eyebrow">Gallery missions</p>
+            <h2 id="fleetShowcaseHeading">Carousel snapshots of notable fleet stories</h2>
+            <p>Swipe through bus model profiles, rare liveries and withdrawn legends. Completing gallery missions boosts your XP and badge progress.</p>
+          </div>
+        </header>
+        <div class="fleet-carousel" aria-live="polite">
+          <button type="button" class="fleet-carousel__control" data-carousel-prev aria-label="Show previous fleet story">
+            <i class="fa-solid fa-chevron-left" aria-hidden="true"></i>
+          </button>
+          <div class="fleet-carousel__viewport" id="fleetCarouselViewport">
+            <article class="fleet-carousel__item is-active" data-carousel-index="0">
+              <img src="bus1.jpg" alt="Go-Ahead London Enviro400EV in service" />
+              <div class="fleet-carousel__meta">
+                <h3>Enviro400EV expansion</h3>
+                <p>Zero-emission deckers roll out across south-west corridors with rapid charging at Battersea and Merton.</p>
+              </div>
+            </article>
+            <article class="fleet-carousel__item" data-carousel-index="1" hidden>
+              <img src="bus2.jpg" alt="Stagecoach London heritage Trident" />
+              <div class="fleet-carousel__meta">
+                <h3>Heritage Trident archive</h3>
+                <p>Withdrawn Tridents receive dedicated history cards, including final workings and enthusiast photography.</p>
+              </div>
+            </article>
+            <article class="fleet-carousel__item" data-carousel-index="2" hidden>
+              <img src="bus3.jpg" alt="Abellio London hydrogen bus" />
+              <div class="fleet-carousel__meta">
+                <h3>Hydrogen pioneers</h3>
+                <p>Hydrogen double-deckers trial new refuelling at Perivale, unlocking hidden badge pathways for data contributors.</p>
+              </div>
+            </article>
+          </div>
+          <button type="button" class="fleet-carousel__control" data-carousel-next aria-label="Show next fleet story">
+            <i class="fa-solid fa-chevron-right" aria-hidden="true"></i>
+          </button>
+        </div>
+        <div class="fleet-carousel__dots" role="tablist" aria-label="Select fleet showcase slide">
+          <button type="button" class="fleet-carousel__dot is-active" data-carousel-dot="0" aria-label="Enviro400EV expansion"></button>
+          <button type="button" class="fleet-carousel__dot" data-carousel-dot="1" aria-label="Heritage Trident archive"></button>
+          <button type="button" class="fleet-carousel__dot" data-carousel-dot="2" aria-label="Hydrogen pioneers"></button>
         </div>
       </section>
 
       <section
         class="fleet-card fleet-table"
+        data-locked-section
+        data-lock-label="Sign in"
         aria-labelledby="fleetTableHeading"
       >
         <div class="fleet-table__header">
@@ -171,7 +293,7 @@
         </p>
       </section>
 
-      <section class="fleet-card fleet-form" aria-labelledby="fleetFormHeading">
+      <section class="fleet-card fleet-form" data-locked-section data-lock-label="Sign in" aria-labelledby="fleetFormHeading">
         <div class="fleet-form__intro">
           <div>
             <p class="fleet-hero__eyebrow">Community updates</p>
@@ -303,6 +425,8 @@
 
       <section
         class="fleet-card fleet-admin"
+        data-locked-section
+        data-lock-label="Sign in"
         aria-labelledby="adminPortalHeading"
       >
         <header class="fleet-admin__intro">
@@ -421,6 +545,145 @@
     <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-app-compat.js"></script>
     <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-auth-compat.js"></script>
     <script src="main.js"></script>
+    <script src="auth-guard.js"></script>
+    <script>
+      document.addEventListener('DOMContentLoaded', () => {
+        const pageRoot = document.querySelector('.fleet-page');
+        const overlay = document.getElementById('fleetAuthGate');
+        const lockedSections = document.querySelectorAll('[data-locked-section]');
+        const heroLead = document.querySelector('.fleet-hero__lead');
+
+        const gate = window.RouteflowAuthGate?.create({
+          root: pageRoot,
+          overlay,
+          lockedSections,
+          lockedMessage: 'Sign in to unlock fleet analytics, submissions and history archives.',
+          errorMessage: 'Authentication is temporarily unavailable. Please try again later.',
+          onLock: () => {
+            if (heroLead) {
+              heroLead.textContent = 'Create a free account to unlock missions, carousels and role-linked fleet submissions.';
+            }
+          },
+          onUnlock: () => {
+            if (heroLead) {
+              heroLead.textContent = 'Build and maintain a live catalogue of the London fleet. New registrations automatically generate profiles, while enthusiast changes stay in review until an admin approves them.';
+            }
+          }
+        });
+
+        const applyAuthState = (user) => {
+          if (user) {
+            gate?.unlock({ user });
+          } else {
+            gate?.lock({ reason: 'signed-out', force: true });
+          }
+        };
+
+        if (typeof firebase === 'undefined' || !firebase?.auth) {
+          applyAuthState(null);
+        } else {
+          const auth = firebase.auth();
+          auth.onAuthStateChanged((user) => {
+            applyAuthState(user);
+          });
+        }
+
+        const tabs = Array.from(document.querySelectorAll('[data-operator-tab]'));
+        const panels = Array.from(document.querySelectorAll('[data-operator-panel]'));
+        const activateTab = (tab) => {
+          if (!tab) return;
+          const key = tab.dataset.operatorTab;
+          tabs.forEach((candidate) => {
+            const isActive = candidate === tab;
+            candidate.classList.toggle('is-active', isActive);
+            candidate.setAttribute('aria-selected', isActive ? 'true' : 'false');
+            candidate.setAttribute('tabindex', isActive ? '0' : '-1');
+          });
+          panels.forEach((panel) => {
+            const isActive = panel.dataset.operatorPanel === key;
+            panel.classList.toggle('is-active', isActive);
+            panel.toggleAttribute('hidden', !isActive);
+          });
+        };
+
+        tabs.forEach((tab) => {
+          tab.addEventListener('click', () => activateTab(tab));
+        });
+
+        const tablist = document.querySelector('.fleet-operators__tabs');
+        if (tablist) {
+          tablist.addEventListener('keydown', (event) => {
+            if (!['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(event.key)) return;
+            event.preventDefault();
+            const currentIndex = tabs.findIndex((tab) => tab.classList.contains('is-active'));
+            if (event.key === 'Home') {
+              activateTab(tabs[0]);
+              tabs[0]?.focus();
+              return;
+            }
+            if (event.key === 'End') {
+              const lastTab = tabs[tabs.length - 1];
+              activateTab(lastTab);
+              lastTab?.focus();
+              return;
+            }
+            const direction = event.key === 'ArrowLeft' ? -1 : 1;
+            const nextIndex = (currentIndex + direction + tabs.length) % tabs.length;
+            const nextTab = tabs[nextIndex];
+            activateTab(nextTab);
+            nextTab?.focus();
+          });
+        }
+
+        if (!tabs.some((tab) => tab.classList.contains('is-active'))) {
+          activateTab(tabs[0]);
+        } else {
+          tabs.forEach((tab) => {
+            tab.setAttribute('tabindex', tab.classList.contains('is-active') ? '0' : '-1');
+          });
+        }
+
+        const items = Array.from(document.querySelectorAll('.fleet-carousel__item'));
+        const dots = Array.from(document.querySelectorAll('[data-carousel-dot]'));
+        let activeIndex = 0;
+
+        const showSlide = (index) => {
+          if (!items.length) return;
+          const total = items.length;
+          const targetIndex = (index + total) % total;
+          activeIndex = targetIndex;
+          items.forEach((item, itemIndex) => {
+            const isActive = itemIndex === targetIndex;
+            item.classList.toggle('is-active', isActive);
+            item.toggleAttribute('hidden', !isActive);
+          });
+          dots.forEach((dot, dotIndex) => {
+            const isActive = dotIndex === targetIndex;
+            dot.classList.toggle('is-active', isActive);
+            dot.setAttribute('aria-selected', isActive ? 'true' : 'false');
+          });
+        };
+
+        document.querySelector('[data-carousel-prev]')?.addEventListener('click', () => {
+          showSlide(activeIndex - 1);
+        });
+
+        document.querySelector('[data-carousel-next]')?.addEventListener('click', () => {
+          showSlide(activeIndex + 1);
+        });
+
+        dots.forEach((dot) => {
+          dot.addEventListener('click', () => {
+            const next = Number(dot.dataset.carouselDot);
+            if (Number.isInteger(next)) {
+              showSlide(next);
+            }
+          });
+        });
+
+        showSlide(0);
+      });
+    </script>
     <script src="fleet.js"></script>
   </body>
 </html>

--- a/fleet.js
+++ b/fleet.js
@@ -686,7 +686,8 @@
   function renderHighlights(elements) {
     const newList = document.getElementById("newBusList");
     const rareList = document.getElementById("rareWorkingList");
-    if (!newList || !rareList) return;
+    const withdrawnList = document.getElementById("withdrawnHighlightList");
+    if (!newList || !rareList || !withdrawnList) return;
 
     const buses = Object.values(state.buses);
     const newest = buses
@@ -701,6 +702,9 @@
       .sort(
         (a, b) => new Date(b.lastUpdated || 0) - new Date(a.lastUpdated || 0),
       );
+    const withdrawn = buses
+      .filter((bus) => String(bus.status).toLowerCase() !== "active")
+      .sort((a, b) => new Date(b.lastUpdated || b.registrationDate || 0) - new Date(a.lastUpdated || a.registrationDate || 0));
 
     newList.innerHTML = newest.length
       ? newest
@@ -715,10 +719,20 @@
           .map((bus) => highlightItem(bus))
           .join("")
       : '<li class="pending-empty">No rare workings logged yet.</li>';
+
+    withdrawnList.innerHTML = withdrawn.length
+      ? withdrawn
+          .slice(0, 6)
+          .map((bus) => highlightItem(bus))
+          .join("")
+      : '<li class="pending-empty">Withdrawn history unlocks once contributions are approved.</li>';
   }
 
   function highlightItem(bus) {
-    const subtitle = [bus.operator, bus.garage].filter(Boolean).join(" • ");
+    const status = bus.status && String(bus.status).toLowerCase() !== "active" ? bus.status : null;
+    const subtitle = [bus.operator, bus.garage, status]
+      .filter(Boolean)
+      .join(" • ");
     return `<li><span>${escapeHtml(bus.registration)}</span><small>${escapeHtml(subtitle || "Awaiting details")}</small></li>`;
   }
 

--- a/index.html
+++ b/index.html
@@ -196,13 +196,13 @@
 
     <section class="landing-blog card" id="latest-blog">
       <header class="landing-blog__header">
-        <p class="landing-blog__eyebrow">From the RouteFlow blog</p>
-        <h2>Latest stories and release notes</h2>
+        <p class="landing-blog__eyebrow">From the RouteFlow Info hub</p>
+        <h2>Latest briefs and release notes</h2>
         <p>Fresh updates drop straight onto the homepage once you publish them in the admin console.</p>
       </header>
       <div class="landing-blog__grid" data-blog-list data-blog-limit="3" data-blog-variant="card" data-blog-empty="Check back soon for new stories."></div>
       <footer class="landing-blog__footer">
-        <a class="landing-blog__cta" href="blog.html">Browse all posts</a>
+        <a class="landing-blog__cta" href="info.html">Explore the Info hub</a>
         <span class="landing-blog__hint">Managed entirely from the admin console.</span>
       </footer>
     </section>
@@ -233,7 +233,7 @@
   </footer>
 
   <script src="navbar-loader.js"></script>
-  <script src="blog.js" type="module"></script>
+  <script src="info.js" type="module"></script>
   <script>
     const form = document.getElementById('newsletter-form');
     const responseMessage = document.getElementById('response-message');

--- a/info.html
+++ b/info.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Blog - RouteFlow London</title>
+  <title>Info Hub | RouteFlow London</title>
   <link rel="icon" href="images/New_Routflow_London_Logo.png" type="image/png" />
   <link href="https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible:wght@400;600&family=Inter:wght@400;600;800&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
@@ -15,16 +15,16 @@
 
   <main class="blog-shell">
     <section class="blog-hero card">
-      <p class="blog-hero__eyebrow">RouteFlow stories</p>
-      <h1>Updates, deep dives and quick reads about travelling smarter in London.</h1>
-      <p>Each article is curated from the admin console so fresh consultations, enthusiast spotlights and weekly news roundups stay easy to browse.</p>
+      <p class="blog-hero__eyebrow">RouteFlow info</p>
+      <h1>Your briefing room for slow-and-steady progress across London transport.</h1>
+      <p>The Info hub blends network explainers, enthusiast research and platform release notes so everyone can catch up before they dive into challenges.</p>
       <div class="blog-hero__meta">
         <div>
-          <span class="blog-hero__label">Latest update</span>
+          <span class="blog-hero__label">Latest brief</span>
           <time id="blogLatestDate">—</time>
         </div>
         <div>
-          <span class="blog-hero__label">Total posts</span>
+          <span class="blog-hero__label">Published briefs</span>
           <strong id="blogTotalPosts">0</strong>
         </div>
       </div>
@@ -33,11 +33,11 @@
     <section class="blog-list card">
       <div class="blog-list__header">
         <div>
-          <h2>Browse by interest</h2>
-          <p>Switch categories to focus on bus models, upcoming consultations or weekly transport highlights.</p>
+          <h2>Browse by focus</h2>
+          <p>Filter the archive to surface operator spotlights, policy updates and enthusiast investigations.</p>
         </div>
-        <div class="blog-filters" id="blogFilters" role="tablist" aria-label="Filter blog posts by category">
-          <button type="button" class="blog-filter" data-blog-filter="all" data-active="true" role="tab" aria-selected="true">All updates</button>
+        <div class="blog-filters" id="blogFilters" role="tablist" aria-label="Filter info briefs by category">
+          <button type="button" class="blog-filter" data-blog-filter="all" data-active="true" role="tab" aria-selected="true">All briefs</button>
           <button type="button" class="blog-filter" data-blog-filter="Learn about bus models" role="tab" aria-selected="false">Learn about bus models</button>
           <button type="button" class="blog-filter" data-blog-filter="New London Consultations" role="tab" aria-selected="false">New London Consultations</button>
           <button type="button" class="blog-filter" data-blog-filter="Weekly London Transport News" role="tab" aria-selected="false">Weekly London Transport News</button>
@@ -50,11 +50,11 @@
       <article class="blog-spotlight card">
         <div class="blog-spotlight__header">
           <p class="blog-hero__eyebrow">Deep dives</p>
-          <h2>Learn about bus models</h2>
-          <p>Get to know the newest zero-emission types, refurbishments and enthusiast favourites on the road.</p>
+          <h2>Bus model deep dives</h2>
+          <p>Get to know the newest zero-emission types, refurbishment programmes and enthusiast favourites on the road.</p>
         </div>
         <div class="blog-spotlight__list" data-blog-list data-blog-variant="compact" data-blog-limit="3" data-blog-tags="Learn about bus models" data-blog-empty="Model spotlights are on their way."></div>
-        <a class="blog-spotlight__link" href="#blogFilters" data-blog-category-group="blogFilters" data-blog-category-link="Learn about bus models">Show all bus model articles</a>
+        <a class="blog-spotlight__link" href="#blogFilters" data-blog-category-group="blogFilters" data-blog-category-link="Learn about bus models">Show all model briefs</a>
       </article>
 
       <article class="blog-spotlight card">
@@ -74,7 +74,7 @@
           <p>Crisp roundups pull together service changes, rare workings and stories worth sharing each week.</p>
         </div>
         <div class="blog-spotlight__list" data-blog-list data-blog-variant="compact" data-blog-limit="3" data-blog-tags="Weekly London Transport News" data-blog-empty="Weekly roundups will appear once published."></div>
-        <a class="blog-spotlight__link" href="#blogFilters" data-blog-category-group="blogFilters" data-blog-category-link="Weekly London Transport News">View weekly news posts</a>
+        <a class="blog-spotlight__link" href="#blogFilters" data-blog-category-group="blogFilters" data-blog-category-link="Weekly London Transport News">View weekly news briefs</a>
       </article>
     </section>
   </main>
@@ -100,7 +100,7 @@
   <script src="main.js"></script>
   <script type="module">
     import { getStoredBlogPosts } from './data-store.js';
-    import './blog.js';
+    import './info.js';
 
     const updateStats = () => {
       const posts = getStoredBlogPosts();

--- a/info.js
+++ b/info.js
@@ -15,7 +15,7 @@ const formatPublishedDate = (value) => {
 
 const resolvePostUrl = (post) => {
   const slug = (post?.id && String(post.id)) || '';
-  return slug ? `blog.html#blog-${slug}` : 'blog.html';
+  return slug ? `info.html#info-${slug}` : 'info.html';
 };
 
 const createTagPill = (tag) => {
@@ -105,7 +105,7 @@ const createHeroImage = (post) => {
   figure.className = 'blog-post__media';
   const image = document.createElement('img');
   image.src = post.heroImage;
-  image.alt = post.title ? `${post.title} illustration` : 'Blog illustration';
+  image.alt = post.title ? `${post.title} illustration` : 'Info illustration';
   figure.appendChild(image);
   return figure;
 };
@@ -116,7 +116,7 @@ const createBlogElement = (post, variant = 'card', index = 0) => {
     .concat(post.featured ? 'blog-post--featured' : [])
     .join(' ');
   if (post.id) {
-    article.id = `blog-${post.id}`;
+    article.id = `info-${post.id}`;
   }
 
   const titleLevel = variant === 'full' ? 'h2' : 'h3';
@@ -151,7 +151,7 @@ const createBlogElement = (post, variant = 'card', index = 0) => {
     const cta = document.createElement('a');
     cta.href = resolvePostUrl(post);
     cta.className = 'blog-post__cta';
-    cta.textContent = 'Read the full update';
+    cta.textContent = 'Read the full brief';
     article.appendChild(cta);
   }
 

--- a/style.css
+++ b/style.css
@@ -3063,3 +3063,150 @@ body.dark-mode .legal-section p {
     padding: 1.6rem 1.4rem;
   }
 }
+
+/* ------------------------------
+  Authentication gating overlay
+-------------------------------*/
+
+.auth-gate {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  padding: clamp(1.5rem, 4vw, 3rem);
+  background: rgba(4, 12, 28, 0.68);
+  backdrop-filter: blur(14px);
+  z-index: 1200;
+  transition: opacity var(--transition), visibility var(--transition);
+}
+
+.auth-gate[hidden] {
+  display: none;
+}
+
+.auth-gate__panel {
+  max-width: 520px;
+  width: min(520px, 100%);
+  border-radius: 28px;
+  padding: clamp(1.8rem, 4vw, 2.6rem);
+  background: linear-gradient(140deg, rgba(255, 255, 255, 0.92), rgba(230, 239, 255, 0.88));
+  box-shadow: 0 24px 64px rgba(0, 24, 84, 0.28);
+  text-align: center;
+  border: 1px solid rgba(255, 255, 255, 0.7);
+}
+
+body.dark-mode .auth-gate__panel {
+  background: linear-gradient(140deg, rgba(9, 16, 38, 0.94), rgba(23, 36, 76, 0.86));
+  border-color: rgba(84, 125, 210, 0.28);
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.55);
+}
+
+.auth-gate__eyebrow {
+  margin: 0;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: var(--accent-blue);
+}
+
+.auth-gate__title {
+  margin: 0.9rem 0 0.6rem;
+  font-size: clamp(1.35rem, 3vw, 1.8rem);
+}
+
+.auth-gate__message {
+  margin: 0;
+  color: rgba(11, 23, 54, 0.72);
+}
+
+body.dark-mode .auth-gate__message {
+  color: rgba(230, 239, 255, 0.82);
+}
+
+.auth-gate__cta {
+  margin-top: 1.6rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.6rem;
+  padding: 0.85rem 1.6rem;
+  border-radius: 999px;
+  border: none;
+  font-size: 1rem;
+  font-weight: 600;
+  background: linear-gradient(120deg, var(--accent-blue), var(--primary));
+  color: #fff;
+  cursor: pointer;
+  box-shadow: 0 20px 32px rgba(29, 126, 240, 0.28);
+  transition: transform var(--transition), box-shadow var(--transition);
+}
+
+.auth-gate__cta:hover,
+.auth-gate__cta:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 26px 42px rgba(29, 126, 240, 0.36);
+}
+
+.auth-gate__hint {
+  margin: 1rem 0 0;
+  font-size: 0.95rem;
+  color: rgba(11, 23, 54, 0.6);
+}
+
+body.dark-mode .auth-gate__hint {
+  color: rgba(230, 239, 255, 0.75);
+}
+
+[data-auth-locked='true'] {
+  position: relative;
+}
+
+[data-auth-locked='true'] [data-locked-section] {
+  position: relative;
+  opacity: 0.45;
+  filter: grayscale(0.3);
+  pointer-events: none;
+}
+
+[data-auth-locked='true'] [data-locked-section]::after {
+  content: attr(data-lock-label);
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  background: rgba(4, 12, 28, 0.82);
+  color: #fff;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+body.dark-mode [data-auth-locked='true'] [data-locked-section]::after {
+  background: rgba(6, 20, 48, 0.88);
+}
+
+[data-locked='true'] {
+  position: relative;
+  opacity: 0.55;
+  pointer-events: none;
+}
+
+[data-locked='true']::after {
+  content: attr(data-lock-label);
+  position: absolute;
+  inset: 1rem auto auto 1rem;
+  padding: 0.35rem 0.75rem;
+  background: rgba(4, 12, 28, 0.82);
+  color: #fff;
+  border-radius: 999px;
+  font-size: 0.68rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  box-shadow: 0 10px 24px rgba(2, 6, 18, 0.32);
+}
+
+body.dark-mode [data-locked='true']::after {
+  background: rgba(6, 20, 48, 0.88);
+}

--- a/withdrawn table.html
+++ b/withdrawn table.html
@@ -276,7 +276,7 @@
       <a href="withdrawn.html">Withdrawn</a>
       <a href="disruptions.html">Disruptions</a>
       <a href="fleet.html">Fleet</a>
-      <a href="blog.html">Blog</a>
+      <a href="info.html">Info</a>
       <div class="navbar__indicator" id="navbarIndicator"></div>
     </nav>
 
@@ -305,7 +305,7 @@
     <a href="withdrawn.html">Withdrawn</a>
     <a href="disruptions.html">Disruptions</a>
     <a href="fleet.html">Fleet</a>
-    <a href="blog.html">Blog</a>
+    <a href="info.html">Info</a>
     <hr>
     <div id="mobileAccountMenu">
       <!-- Dynamic content via JS -->


### PR DESCRIPTION
## Summary
- add a reusable authentication gate and apply it to the dashboard and fleet experiences
- deepen the dashboard loop with streak-aware XP tracking, gated badges, missions, weekly/combo challenges, and mini-game limits
- rebuild the fleet page with operator tabs, carousel highlights, improved forms, and keyboard-friendly controls
- rename the public blog into an Info Hub, refreshing navigation, homepage promos, and admin publishing copy

## Testing
- not run (project has no automated test suite)


------
https://chatgpt.com/codex/tasks/task_e_68ccfd17b4a48322acce37ef2e01ac32