### PR TITLE
Fix authentication availability and hide admin UI

### DIFF
--- a/components/auth-modal.html
+++ b/components/auth-modal.html
@@ -27,10 +27,6 @@
         Don't have an account?
         <a href="#" id="showSignup" class="auth-modal__link">Create one</a>
       </p>
-      <p class="auth-modal__switch">
-        Managing the platform?
-        <a href="#" id="showAdminLogin" class="auth-modal__link">Administrator sign-in</a>
-      </p>
     </div>
 
     <div class="auth-modal__panel" id="signupFormContainer" hidden>
@@ -53,10 +49,6 @@
         Already have an account?
         <a href="#" id="showLogin" class="auth-modal__link">Log in</a>
       </p>
-      <p class="auth-modal__switch">
-        RouteFlow staff?
-        <a href="#" id="showAdminFromSignup" class="auth-modal__link">Use the admin console</a>
-      </p>
     </div>
 
     <div class="auth-modal__panel" id="resetFormContainer" hidden>
@@ -77,25 +69,5 @@
       </p>
     </div>
 
-    <div class="auth-modal__panel" id="adminFormContainer" hidden>
-      <h2 class="auth-modal__title">Administrator access</h2>
-      <p class="auth-modal__subtitle">Sign in with a RouteFlow London admin account to manage the network.</p>
-      <form id="adminLoginForm" class="auth-modal__form" autocomplete="off">
-        <label class="auth-modal__field" for="adminEmail">
-          <span>Admin email</span>
-          <input type="email" id="adminEmail" name="adminEmail" required autocomplete="username" />
-        </label>
-        <label class="auth-modal__field" for="adminPassword">
-          <span>Password</span>
-          <input type="password" id="adminPassword" name="adminPassword" required autocomplete="current-password" />
-        </label>
-        <button type="submit" class="auth-modal__primary">Enter admin console</button>
-        <div class="auth-modal__error" id="adminLoginError" role="alert" hidden></div>
-      </form>
-      <p class="auth-modal__switch">
-        Need a different sign-in?
-        <a href="#" id="showLoginFromAdmin" class="auth-modal__link">Back to regular login</a>
-      </p>
-    </div>
   </div>
 </div>

--- a/components/navbar.html
+++ b/components/navbar.html
@@ -28,7 +28,6 @@
         <div class="navbar__auth-guest" data-auth-state="signed-out">
           <button type="button" class="navbar__btn navbar__btn--ghost" data-auth-action="login">Login</button>
           <button type="button" class="navbar__btn navbar__btn--primary" data-auth-action="signup">Sign Up</button>
-          <button type="button" class="navbar__btn navbar__btn--ghost" data-auth-action="admin-login">Admin</button>
         </div>
         <div class="navbar__profile" data-auth-state="signed-in" hidden>
           <button type="button" class="navbar__profile-toggle" data-profile-toggle aria-haspopup="true" aria-expanded="false">
@@ -82,7 +81,6 @@
         <div class="navbar__drawer-section" data-auth-state="signed-out">
           <button type="button" class="navbar__drawer-action" data-auth-action="login">Login</button>
           <button type="button" class="navbar__drawer-action navbar__drawer-action--primary" data-auth-action="signup">Sign Up</button>
-          <button type="button" class="navbar__drawer-action" data-auth-action="admin-login">Admin</button>
         </div>
         <div class="navbar__drawer-section" data-auth-state="signed-in" hidden>
           <a href="profile.html" class="navbar__drawer-action" data-auth-action="profile">Profile</a>


### PR DESCRIPTION
## Summary
- ensure Firebase configuration and SDK scripts load automatically before initialising authentication so sign-in is available across static pages
- update auth handlers to await Firebase readiness and improve error handling for email/password and Google sign-in
- remove the dedicated admin sign-in buttons so admin navigation only appears after an authenticated admin session

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cd0becdba88322ba420a724dde7550