### PR TITLE
Revamp tracking suggestions and info modal

### DIFF
--- a/data-store.js
+++ b/data-store.js
@@ -169,7 +169,7 @@ const DEFAULT_BLOG_POSTS = sanitiseBlogCollection([
       'to support airport travel, while a slimmed timetable affects Woolwich Ferry crossings late Sunday.',
     author: 'Network desk',
     publishedAt: '2025-05-23T16:30:00.000Z',
-    tags: ['Weekly London Transport News']
+    tags: ['Live News']
   },
   {
     id: 'blog-consultation-summer-2025',
@@ -181,7 +181,7 @@ const DEFAULT_BLOG_POSTS = sanitiseBlogCollection([
       'branch would join the orbital express family. We have highlighted the closing dates and supporting documents for each.',
     author: 'Policy and planning',
     publishedAt: '2025-05-21T09:00:00.000Z',
-    tags: ['New London Consultations']
+    tags: ['Guides']
   },
   {
     id: 'blog-bus-models-electric-era',
@@ -193,7 +193,7 @@ const DEFAULT_BLOG_POSTS = sanitiseBlogCollection([
       'while keeping capacity identical for school peaks.',
     author: 'Fleet editor',
     publishedAt: '2025-05-18T13:15:00.000Z',
-    tags: ['Learn about bus models']
+    tags: ['Models']
   },
   {
     id: 'blog-weekly-roundup-2025-05-16',
@@ -205,7 +205,7 @@ const DEFAULT_BLOG_POSTS = sanitiseBlogCollection([
       'works restrict traffic to single lanes in each direction.',
     author: 'Network desk',
     publishedAt: '2025-05-16T16:45:00.000Z',
-    tags: ['Weekly London Transport News']
+    tags: ['Live News']
   },
   {
     id: 'blog-consultation-night-bus-refresh',
@@ -217,7 +217,7 @@ const DEFAULT_BLOG_POSTS = sanitiseBlogCollection([
       'the consultation before it closes on 14 June.',
     author: 'Policy and planning',
     publishedAt: '2025-05-14T08:20:00.000Z',
-    tags: ['New London Consultations']
+    tags: ['Guides']
   },
   {
     id: 'blog-bus-models-refurb',
@@ -229,7 +229,7 @@ const DEFAULT_BLOG_POSTS = sanitiseBlogCollection([
       'spot them first.',
     author: 'Fleet editor',
     publishedAt: '2025-05-10T11:00:00.000Z',
-    tags: ['Learn about bus models']
+    tags: ['Models']
   },
   {
     id: 'blog-city-pulse',
@@ -241,7 +241,7 @@ const DEFAULT_BLOG_POSTS = sanitiseBlogCollection([
       'surfacing accessibility information, the platform is designed to feel personal from the moment you sign in.',
     author: 'RouteFlow London team',
     publishedAt: '2025-04-18T09:30:00.000Z',
-    tags: ['Product updates']
+    tags: ['Operators']
   },
   {
     id: 'blog-arrivals-refresh',
@@ -253,7 +253,7 @@ const DEFAULT_BLOG_POSTS = sanitiseBlogCollection([
       'everything refresh automatically without losing your place.',
     author: 'Product design',
     publishedAt: '2025-05-06T07:45:00.000Z',
-    tags: ['Tracking', 'Design']
+    tags: ['Guides']
   },
   {
     id: 'blog-journey-studio',
@@ -265,7 +265,7 @@ const DEFAULT_BLOG_POSTS = sanitiseBlogCollection([
       'timings so you know exactly what to expect.',
     author: 'Journey planning',
     publishedAt: '2025-05-12T11:15:00.000Z',
-    tags: ['Planning']
+    tags: ['Guides']
   }
 ]);
 

--- a/info.html
+++ b/info.html
@@ -18,36 +18,45 @@
   <main id="main-content" class="blog-shell" aria-labelledby="infoTitle">
     <section class="blog-hero card">
       <div class="blog-hero__content">
-        <p class="blog-hero__eyebrow">RouteFlow info</p>
-        <h1 id="infoTitle">Your briefing room for confident journeys across London transport.</h1>
-        <p>Browse explainers, enthusiast research and release notes in one organised hub. Use the quick links or search to jump straight to what matters.</p>
-        <div class="blog-hero__actions" role="group" aria-label="Jump to popular topics">
+        <p class="blog-hero__eyebrow">Info hub</p>
+        <h1 id="infoTitle">RouteFlow London's knowledge centre for live news and deep dives.</h1>
+        <p>Catch breaking network updates, learn about the operators behind the fleet, and explore enthusiast guides all from one organised space.</p>
+        <div class="blog-hero__actions" role="group" aria-label="Jump to featured topics">
           <a
             class="blog-hero__action"
             href="#infoCollections"
             data-blog-category-group="blogFilters"
-            data-blog-category-link="Learn about bus models"
-          >
-            <i class="fa-solid fa-bus" aria-hidden="true"></i>
-            <span>Bus models</span>
-          </a>
-          <a
-            class="blog-hero__action"
-            href="#infoCollections"
-            data-blog-category-group="blogFilters"
-            data-blog-category-link="New London Consultations"
-          >
-            <i class="fa-solid fa-scroll" aria-hidden="true"></i>
-            <span>Consultations</span>
-          </a>
-          <a
-            class="blog-hero__action"
-            href="#infoCollections"
-            data-blog-category-group="blogFilters"
-            data-blog-category-link="Weekly London Transport News"
+            data-blog-category-link="Live News"
           >
             <i class="fa-solid fa-newspaper" aria-hidden="true"></i>
-            <span>Weekly news</span>
+            <span>Live news</span>
+          </a>
+          <a
+            class="blog-hero__action"
+            href="#infoCollections"
+            data-blog-category-group="blogFilters"
+            data-blog-category-link="Operators"
+          >
+            <i class="fa-solid fa-people-group" aria-hidden="true"></i>
+            <span>Operators</span>
+          </a>
+          <a
+            class="blog-hero__action"
+            href="#infoCollections"
+            data-blog-category-group="blogFilters"
+            data-blog-category-link="Models"
+          >
+            <i class="fa-solid fa-bus" aria-hidden="true"></i>
+            <span>Models</span>
+          </a>
+          <a
+            class="blog-hero__action"
+            href="#infoCollections"
+            data-blog-category-group="blogFilters"
+            data-blog-category-link="Guides"
+          >
+            <i class="fa-solid fa-compass" aria-hidden="true"></i>
+            <span>Guides</span>
           </a>
         </div>
       </div>
@@ -80,9 +89,10 @@
           aria-label="Filter info briefs by category"
         >
           <button type="button" class="blog-filter" data-blog-filter="all" data-active="true" role="tab" aria-selected="true">All briefs</button>
-          <button type="button" class="blog-filter" data-blog-filter="Learn about bus models" role="tab" aria-selected="false">Learn about bus models</button>
-          <button type="button" class="blog-filter" data-blog-filter="New London Consultations" role="tab" aria-selected="false">New London Consultations</button>
-          <button type="button" class="blog-filter" data-blog-filter="Weekly London Transport News" role="tab" aria-selected="false">Weekly London Transport News</button>
+          <button type="button" class="blog-filter" data-blog-filter="Live News" role="tab" aria-selected="false">Live news</button>
+          <button type="button" class="blog-filter" data-blog-filter="Operators" role="tab" aria-selected="false">Operators</button>
+          <button type="button" class="blog-filter" data-blog-filter="Models" role="tab" aria-selected="false">Models</button>
+          <button type="button" class="blog-filter" data-blog-filter="Guides" role="tab" aria-selected="false">Guides</button>
         </div>
         <p class="blog-collections__hint">Tip: combine a category with search to get straight to the right brief.</p>
       </aside>
@@ -106,34 +116,49 @@
     <section class="blog-spotlights">
       <article class="blog-spotlight card">
         <div class="blog-spotlight__header">
-          <p class="blog-hero__eyebrow">Deep dives</p>
-          <h2>Bus model deep dives</h2>
-          <p>Get to know the newest zero-emission types, refurbishment programmes and enthusiast favourites on the road.</p>
+          <p class="blog-hero__eyebrow">Live updates</p>
+          <h2>Network headlines</h2>
+          <p>Stay ahead of service changes, disruptions and rare workings with our live news snapshots.</p>
         </div>
-        <div class="blog-spotlight__list" data-blog-list data-blog-variant="compact" data-blog-limit="3" data-blog-tags="Learn about bus models" data-blog-empty="Model spotlights are on their way."></div>
-        <a class="blog-spotlight__link" href="#blogFilters" data-blog-category-group="blogFilters" data-blog-category-link="Learn about bus models">Show all model briefs</a>
+        <div class="blog-spotlight__list" data-blog-list data-blog-variant="compact" data-blog-limit="3" data-blog-tags="Live News" data-blog-empty="Live updates will appear here soon."></div>
+        <a class="blog-spotlight__link" href="#blogFilters" data-blog-category-group="blogFilters" data-blog-category-link="Live News">See all live news</a>
       </article>
 
       <article class="blog-spotlight card">
         <div class="blog-spotlight__header">
-          <p class="blog-hero__eyebrow">Consultations</p>
-          <h2>New London consultations</h2>
-          <p>Track proposals and service changes so you can prepare for what the network might look like next.</p>
+          <p class="blog-hero__eyebrow">Operators</p>
+          <h2>Operator insights</h2>
+          <p>Understand who runs the capital's routes, depot moves and allocation tweaks shaping everyday journeys.</p>
         </div>
-        <div class="blog-spotlight__list" data-blog-list data-blog-variant="compact" data-blog-limit="3" data-blog-tags="New London Consultations" data-blog-empty="Consultation coverage will appear here soon."></div>
-        <a class="blog-spotlight__link" href="#blogFilters" data-blog-category-group="blogFilters" data-blog-category-link="New London Consultations">See consultation updates</a>
+        <div class="blog-spotlight__list" data-blog-list data-blog-variant="compact" data-blog-limit="3" data-blog-tags="Operators" data-blog-empty="Operator briefings are coming soon."></div>
+        <a class="blog-spotlight__link" href="#blogFilters" data-blog-category-group="blogFilters" data-blog-category-link="Operators">Browse operator stories</a>
       </article>
 
       <article class="blog-spotlight card">
         <div class="blog-spotlight__header">
-          <p class="blog-hero__eyebrow">Roundup</p>
-          <h2>Weekly London transport news</h2>
-          <p>Crisp roundups pull together service changes, rare workings and stories worth sharing each week.</p>
+          <p class="blog-hero__eyebrow">Fleet focus</p>
+          <h2>Model guides</h2>
+          <p>Explore the buses, trams and stock types on the network with visuals, allocations and enthusiast notes.</p>
         </div>
-        <div class="blog-spotlight__list" data-blog-list data-blog-variant="compact" data-blog-limit="3" data-blog-tags="Weekly London Transport News" data-blog-empty="Weekly roundups will appear once published."></div>
-        <a class="blog-spotlight__link" href="#blogFilters" data-blog-category-group="blogFilters" data-blog-category-link="Weekly London Transport News">View weekly news briefs</a>
+        <div class="blog-spotlight__list" data-blog-list data-blog-variant="compact" data-blog-limit="3" data-blog-tags="Models" data-blog-empty="Model spotlights are on their way."></div>
+        <a class="blog-spotlight__link" href="#blogFilters" data-blog-category-group="blogFilters" data-blog-category-link="Models">Show all model guides</a>
       </article>
     </section>
+  <div class="blog-modal" id="blogModal" hidden>
+    <div class="blog-modal__dialog" role="dialog" aria-modal="true" aria-labelledby="blogModalTitle">
+      <button type="button" class="blog-modal__close" id="blogModalClose" aria-label="Close info brief">
+        <i class="fa-solid fa-xmark" aria-hidden="true"></i>
+      </button>
+      <figure class="blog-modal__media" id="blogModalMedia" hidden></figure>
+      <div class="blog-modal__body">
+        <h2 class="blog-modal__title" id="blogModalTitle"></h2>
+        <p class="blog-modal__meta" id="blogModalMeta"></p>
+        <div class="blog-modal__tags" id="blogModalTags"></div>
+        <div class="blog-modal__content" id="blogModalContent"></div>
+      </div>
+    </div>
+  </div>
+
   </main>
 
   <footer class="site-footer" aria-label="Footer">

--- a/info.js
+++ b/info.js
@@ -13,11 +13,6 @@ const formatPublishedDate = (value) => {
   });
 };
 
-const resolvePostUrl = (post) => {
-  const slug = (post?.id && String(post.id)) || '';
-  return slug ? `info.html#info-${slug}` : 'info.html';
-};
-
 const createTagPill = (tag) => {
   const pill = document.createElement('span');
   pill.className = 'blog-tag';
@@ -28,87 +23,148 @@ const createTagPill = (tag) => {
 const renderTags = (tags = []) => {
   const unique = Array.isArray(tags) ? tags.filter(Boolean) : [];
   if (!unique.length) return null;
-  const list = document.createElement('div');
-  list.className = 'blog-post__tags';
+  const fragment = document.createDocumentFragment();
   unique.forEach((tag) => {
-    list.appendChild(createTagPill(tag));
+    fragment.appendChild(createTagPill(tag));
   });
-  return list;
+  return fragment;
 };
 
-const renderContent = (post, variant) => {
-  const body = document.createElement('div');
-  body.className = 'blog-post__body';
-
+const buildModalContent = (post) => {
+  const fragment = document.createDocumentFragment();
+  const blocks = [];
   if (post.summary) {
-    const summary = document.createElement('p');
-    summary.className = 'blog-post__summary';
-    summary.textContent = post.summary;
-    body.appendChild(summary);
+    blocks.push(post.summary);
+  }
+  if (post.content) {
+    blocks.push(
+      ...String(post.content)
+        .split(/\n{2,}/)
+        .map((block) => block.trim())
+        .filter(Boolean)
+    );
+  }
+  blocks.forEach((text) => {
+    const paragraph = document.createElement('p');
+    paragraph.textContent = text;
+    fragment.appendChild(paragraph);
+  });
+  return fragment;
+};
+
+const modalElements = {
+  container: document.getElementById('blogModal'),
+  dialog: document.querySelector('#blogModal .blog-modal__dialog'),
+  close: document.getElementById('blogModalClose'),
+  media: document.getElementById('blogModalMedia'),
+  title: document.getElementById('blogModalTitle'),
+  meta: document.getElementById('blogModalMeta'),
+  tags: document.getElementById('blogModalTags'),
+  content: document.getElementById('blogModalContent')
+};
+
+let lastFocusedElement = null;
+
+const closeBlogModal = () => {
+  if (!modalElements.container) return;
+  modalElements.container.hidden = true;
+  document.body?.removeAttribute('data-overlay-open');
+  if (modalElements.media) {
+    modalElements.media.innerHTML = '';
+    modalElements.media.hidden = true;
+  }
+  if (modalElements.tags) {
+    modalElements.tags.innerHTML = '';
+  }
+  if (modalElements.content) {
+    modalElements.content.innerHTML = '';
+  }
+  if (lastFocusedElement?.focus) {
+    lastFocusedElement.focus({ preventScroll: true });
+  }
+  lastFocusedElement = null;
+};
+
+const openBlogModal = (post, trigger) => {
+  if (!modalElements.container || !modalElements.dialog) return;
+  lastFocusedElement = trigger || document.activeElement;
+
+  if (modalElements.title) {
+    modalElements.title.textContent = post.title || 'Info brief';
   }
 
-  if (variant === 'full' && post.content) {
-    const paragraphs = String(post.content)
-      .split(/\n{2,}/)
-      .map((block) => block.trim())
-      .filter(Boolean);
+  if (modalElements.meta) {
+    const parts = [];
+    if (post.publishedAt) {
+      const time = document.createElement('time');
+      time.dateTime = post.publishedAt;
+      time.textContent = formatPublishedDate(post.publishedAt);
+      parts.push(time);
+    }
+    if (post.author) {
+      const author = document.createElement('span');
+      author.textContent = parts.length ? ` • ${post.author}` : post.author;
+      parts.push(author);
+    }
+    modalElements.meta.innerHTML = '';
+    parts.forEach((node) => modalElements.meta.appendChild(node));
+  }
 
-    if (paragraphs.length) {
-      const detail = document.createElement('details');
-      detail.className = 'blog-post__details';
-      detail.open = true;
-
-      const summaryToggle = document.createElement('summary');
-      summaryToggle.textContent = 'Full story';
-      detail.appendChild(summaryToggle);
-
-      paragraphs.forEach((text) => {
-        const paragraph = document.createElement('p');
-        paragraph.textContent = text;
-        detail.appendChild(paragraph);
-      });
-
-      body.appendChild(detail);
+  if (modalElements.tags) {
+    const tags = renderTags(post.tags);
+    modalElements.tags.innerHTML = '';
+    if (tags) {
+      modalElements.tags.appendChild(tags);
     }
   }
 
-  return body;
-};
-
-const createMetaLine = (post) => {
-  const meta = document.createElement('p');
-  meta.className = 'blog-post__meta';
-
-  const time = document.createElement('time');
-  time.dateTime = post.publishedAt;
-  time.textContent = formatPublishedDate(post.publishedAt);
-  meta.appendChild(time);
-
-  if (post.author) {
-    const author = document.createElement('span');
-    author.textContent = ` • ${post.author}`;
-    meta.appendChild(author);
+  if (modalElements.content) {
+    modalElements.content.innerHTML = '';
+    const body = buildModalContent(post);
+    if (body.childNodes.length) {
+      modalElements.content.appendChild(body);
+    }
   }
 
-  if (post.readTime) {
-    const read = document.createElement('span');
-    read.textContent = ` • ${post.readTime} min read`;
-    meta.appendChild(read);
+  if (modalElements.media) {
+    modalElements.media.innerHTML = '';
+    if (post.heroImage) {
+      const image = document.createElement('img');
+      image.src = post.heroImage;
+      image.alt = post.title ? `${post.title} cover image` : 'Info hub cover image';
+      modalElements.media.appendChild(image);
+      modalElements.media.hidden = false;
+    } else {
+      modalElements.media.hidden = true;
+    }
   }
 
-  return meta;
+  modalElements.container.hidden = false;
+  document.body?.setAttribute('data-overlay-open', 'true');
+  modalElements.close?.focus({ preventScroll: true });
 };
 
-const createHeroImage = (post) => {
-  if (!post.heroImage) return null;
-  const figure = document.createElement('figure');
-  figure.className = 'blog-post__media';
-  const image = document.createElement('img');
-  image.src = post.heroImage;
-  image.alt = post.title ? `${post.title} illustration` : 'Info illustration';
-  figure.appendChild(image);
-  return figure;
+const handleModalKeydown = (event) => {
+  if (event.key === 'Escape') {
+    event.preventDefault();
+    closeBlogModal();
+  }
 };
+
+if (modalElements.container) {
+  modalElements.container.addEventListener('click', (event) => {
+    if (event.target === modalElements.container) {
+      closeBlogModal();
+    }
+  });
+}
+
+modalElements.close?.addEventListener('click', (event) => {
+  event.preventDefault();
+  closeBlogModal();
+});
+
+document.addEventListener('keydown', handleModalKeydown);
 
 const createBlogElement = (post, variant = 'card', index = 0) => {
   const article = document.createElement('article');
@@ -119,42 +175,36 @@ const createBlogElement = (post, variant = 'card', index = 0) => {
     article.id = `info-${post.id}`;
   }
 
+  const trigger = document.createElement('button');
+  trigger.type = 'button';
+  trigger.className = 'blog-post__trigger';
+  trigger.setAttribute('aria-label', `Open ${post.title || 'info brief'}`);
+
+  const cover = document.createElement('div');
+  cover.className = 'blog-post__cover';
+  if (post.heroImage) {
+    const image = document.createElement('img');
+    image.src = post.heroImage;
+    image.alt = post.title ? `${post.title} cover` : 'Info hub cover';
+    cover.appendChild(image);
+  } else {
+    cover.style.background = 'linear-gradient(135deg, rgba(0, 54, 136, 0.18), rgba(255, 71, 87, 0.16))';
+  }
+  trigger.appendChild(cover);
+
+  const overlay = document.createElement('div');
+  overlay.className = 'blog-post__overlay';
+
   const titleLevel = variant === 'full' ? 'h2' : 'h3';
-  const title = document.createElement(titleLevel);
-  title.className = 'blog-post__title';
+  const heading = document.createElement(titleLevel);
+  heading.className = 'blog-post__title';
+  heading.textContent = post.title || 'Untitled brief';
+  overlay.appendChild(heading);
 
-  const link = document.createElement('a');
-  link.href = resolvePostUrl(post);
-  link.textContent = post.title;
-  link.className = 'blog-post__link';
-  title.appendChild(link);
+  trigger.appendChild(overlay);
+  trigger.addEventListener('click', () => openBlogModal(post, trigger));
 
-  const header = document.createElement('header');
-  header.className = 'blog-post__header';
-  header.appendChild(title);
-  header.appendChild(createMetaLine(post));
-
-  const tags = renderTags(post.tags);
-  if (tags) {
-    header.appendChild(tags);
-  }
-
-  const heroImage = createHeroImage(post);
-  if (heroImage && variant !== 'compact') {
-    article.appendChild(heroImage);
-  }
-
-  article.appendChild(header);
-  article.appendChild(renderContent(post, variant));
-
-  if (variant !== 'full') {
-    const cta = document.createElement('a');
-    cta.href = resolvePostUrl(post);
-    cta.className = 'blog-post__cta';
-    cta.textContent = 'Read the full brief';
-    article.appendChild(cta);
-  }
-
+  article.appendChild(trigger);
   article.dataset.index = String(index);
   return article;
 };
@@ -300,7 +350,7 @@ const renderBlogLists = () => {
       element,
       limit: Number.isFinite(limit) && limit > 0 ? limit : null,
       variant: element.dataset.blogVariant || 'card',
-      emptyMessage: element.dataset.blogEmpty || 'No blog posts available yet.',
+      emptyMessage: element.dataset.blogEmpty || 'No briefs available yet.',
       tags: parseTagList(element.dataset.blogTags),
       filterGroup: element.dataset.blogFilterGroup || null,
       activeFilter: 'all'
@@ -347,3 +397,4 @@ if (document.readyState === 'loading') {
 } else {
   renderBlogLists();
 }
+

--- a/routes.html
+++ b/routes.html
@@ -111,9 +111,6 @@
           <div id="routeOverlayVehicles" class="route-overlay__vehicles"></div>
         </section>
       </div>
-      <footer class="route-overlay__footer">
-        <a id="routeOverlayTracker" class="route-overlay__cta" href="tracking.html">Open tracker</a>
-      </footer>
     </div>
   </div>
 

--- a/style.css
+++ b/style.css
@@ -7,10 +7,12 @@
    Core design tokens
 ------------------------------------------------------------- */
 :root {
-  --primary: #155eef;
-  --primary-dark: #0f4ad0;
-  --accent-blue: #155eef;
-  --accent-blue-dark: #0f4ad0;
+  --primary: #003688;
+  --primary-dark: #002866;
+  --accent-blue: #003688;
+  --accent-blue-dark: #002866;
+  --accent-red: #ff4757;
+  --accent-red-dark: #e63d4b;
 
   --background-light: #f3f5fb;
   --foreground-light: #111935;
@@ -61,8 +63,8 @@ body {
   font-weight: 400;
   line-height: 1.65;
   letter-spacing: 0.01em;
-  background: radial-gradient(circle at top left, rgba(21, 94, 239, 0.08) 0%, transparent 60%),
-              radial-gradient(circle at 120% 10%, rgba(12, 31, 82, 0.12) 0%, transparent 55%),
+  background: radial-gradient(circle at top left, rgba(0, 54, 136, 0.12) 0%, transparent 60%),
+              radial-gradient(circle at 110% 12%, rgba(255, 71, 87, 0.08) 0%, transparent 58%),
               var(--background-light);
   color: var(--foreground-light);
   -webkit-font-smoothing: antialiased;
@@ -70,8 +72,8 @@ body {
 }
 
 body.dark-mode {
-  background: radial-gradient(circle at top, rgba(21, 94, 239, 0.18) 0%, transparent 50%),
-              radial-gradient(circle at 20% 80%, rgba(79, 105, 255, 0.12) 0%, transparent 60%),
+  background: radial-gradient(circle at top, rgba(0, 54, 136, 0.26) 0%, transparent 50%),
+              radial-gradient(circle at 18% 78%, rgba(255, 71, 87, 0.16) 0%, transparent 62%),
               var(--background-dark);
   color: var(--foreground-dark);
 
@@ -1735,10 +1737,8 @@ body.dark-mode .landing-preview {
 
 .blog-post {
   position: relative;
-  display: grid;
-  gap: 1rem;
-  padding: clamp(1.2rem, 2.6vw, 1.6rem);
-  border-radius: var(--radius-md);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
   border: 1px solid var(--glass-border);
   background: var(--surface-elevated-light);
   box-shadow: var(--shadow-medium);
@@ -1747,37 +1747,58 @@ body.dark-mode .landing-preview {
 
 .blog-post:hover,
 .blog-post:focus-within {
-  transform: translateY(-4px);
-  box-shadow: 0 26px 60px rgba(21, 38, 75, 0.18);
-  border-color: rgba(21, 94, 239, 0.28);
+  transform: translateY(-6px);
+  box-shadow: 0 30px 70px rgba(0, 54, 136, 0.18);
+  border-color: rgba(255, 71, 87, 0.25);
 }
 
-.blog-post__header {
+.blog-post__trigger {
+  border: none;
+  background: none;
+  padding: 0;
+  margin: 0;
   display: grid;
-  gap: 0.5rem;
+  text-align: left;
+  color: inherit;
+  cursor: pointer;
+  width: 100%;
+}
+
+.blog-post__cover {
+  position: relative;
+  aspect-ratio: 4 / 3;
+  overflow: hidden;
+}
+
+.blog-post__cover img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transform: scale(1.02);
+  transition: transform var(--transition);
+}
+
+.blog-post:hover .blog-post__cover img,
+.blog-post:focus-within .blog-post__cover img {
+  transform: scale(1.07);
+}
+
+.blog-post__overlay {
+  display: grid;
+  gap: 0.55rem;
+  padding: clamp(1.1rem, 2.5vw, 1.6rem);
 }
 
 .blog-post__title {
   margin: 0;
-  font-size: clamp(1.15rem, 2.4vw, 1.35rem);
-}
-
-.blog-post__link {
-  color: inherit;
-  text-decoration: none;
-  transition: color var(--transition);
-}
-
-.blog-post__link:hover,
-.blog-post__link:focus-visible {
-  color: var(--accent-blue);
-  outline: none;
+  font-size: clamp(1.1rem, 2.3vw, 1.35rem);
+  line-height: 1.35;
 }
 
 .blog-post__meta {
   margin: 0;
+  font-size: 0.92rem;
   color: var(--text-muted-light);
-  font-size: 0.95rem;
 }
 
 .blog-post__tags {
@@ -1789,66 +1810,145 @@ body.dark-mode .landing-preview {
 .blog-tag {
   display: inline-flex;
   align-items: center;
-  padding: 0.25rem 0.75rem;
+  padding: 0.3rem 0.85rem;
   border-radius: 999px;
-  background: rgba(21, 94, 239, 0.12);
-  color: var(--accent-blue);
+  background: rgba(255, 71, 87, 0.12);
+  color: var(--accent-red);
   font-weight: 600;
   font-size: 0.78rem;
 }
 
-.blog-post__body {
-  display: grid;
-  gap: 0.75rem;
-}
-
-.blog-post__summary {
-  margin: 0;
-  color: var(--text-muted-light);
-}
-
-.blog-post__details {
-  border-radius: var(--radius-sm);
-  background: rgba(17, 25, 53, 0.06);
-  padding: 0.75rem 1rem;
-}
-
-.blog-post__details summary {
-  font-weight: 600;
-  cursor: pointer;
-}
-
-.blog-post__details p {
-  margin: 0.6rem 0 0;
-  color: var(--text-subtle-light);
-}
-
-.blog-post__cta {
-  font-weight: 600;
-  text-decoration: none;
-  color: var(--accent-blue);
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-}
-
-.blog-post__cta::after {
-  content: '\f061';
-  font-family: 'Font Awesome 6 Free';
-  font-weight: 900;
-  font-size: 0.85rem;
-}
-
 .blog-post--compact {
-  background: rgba(17, 25, 53, 0.04);
   box-shadow: none;
+  background: rgba(0, 54, 136, 0.06);
+}
+
+.blog-post--compact .blog-post__overlay {
   padding: 1rem 1.2rem;
 }
 
-.blog-post--compact .blog-post__body,
-.blog-post--compact .blog-post__cta,
-.blog-post--compact .blog-post__details {
+.blog-post--compact .blog-post__meta,
+.blog-post--compact .blog-post__tags {
   display: none;
+}
+
+.blog-modal {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  padding: clamp(1.8rem, 6vw, 3rem);
+  background: rgba(5, 12, 28, 0.6);
+  backdrop-filter: blur(18px);
+  z-index: 1600;
+  animation: blog-modal-fade var(--transition) ease both;
+}
+
+.blog-modal[hidden] {
+  display: none;
+}
+
+.blog-modal__dialog {
+  width: min(760px, 100%);
+  max-height: min(90vh, 960px);
+  overflow-y: auto;
+  background: var(--card-bg-light);
+  border-radius: var(--radius-xl);
+  border: 1px solid rgba(0, 54, 136, 0.18);
+  box-shadow: 0 36px 120px rgba(0, 14, 32, 0.4);
+  display: grid;
+  gap: 0;
+  animation: blog-modal-scale var(--transition) ease both;
+  position: relative;
+}
+
+.blog-modal__media img {
+  width: 100%;
+  height: auto;
+  border-top-left-radius: var(--radius-xl);
+  border-top-right-radius: var(--radius-xl);
+  display: block;
+}
+
+.blog-modal__body {
+  padding: clamp(1.6rem, 3vw, 2.2rem);
+  display: grid;
+  gap: 1rem;
+}
+
+.blog-modal__title {
+  margin: 0;
+  font-size: clamp(1.5rem, 3vw, 2rem);
+  line-height: 1.3;
+}
+
+.blog-modal__meta {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--text-muted-light);
+}
+
+.blog-modal__content {
+  display: grid;
+  gap: 0.9rem;
+  color: var(--text-subtle-light);
+}
+
+.blog-modal__content p {
+  margin: 0;
+}
+
+.blog-modal__close {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  border: none;
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.55);
+  color: #fff;
+  width: 2.5rem;
+  height: 2.5rem;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  transition: background var(--transition), transform var(--transition);
+}
+
+.blog-modal__close:hover,
+.blog-modal__close:focus-visible {
+  background: var(--accent-red);
+  transform: scale(1.05);
+}
+
+.blog-modal__tags {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.blog-modal__tags .blog-tag {
+  background: rgba(0, 54, 136, 0.12);
+  color: var(--accent-blue);
+}
+
+@keyframes blog-modal-fade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes blog-modal-scale {
+  from {
+    opacity: 0;
+    transform: translateY(12px) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
 }
 
 .blog-empty {

--- a/tracking.css
+++ b/tracking.css
@@ -36,7 +36,7 @@
   font-size: 0.78rem;
   letter-spacing: 0.18em;
   text-transform: uppercase;
-  color: var(--accent-blue);
+  color: var(--accent-red);
   font-weight: 700;
 }
 
@@ -59,16 +59,22 @@
 }
 
 .tracking-hero__highlights li {
-  background: rgba(41, 121, 255, 0.08);
+  background: linear-gradient(135deg, rgba(0, 54, 136, 0.12), rgba(255, 71, 87, 0.08));
   border-radius: 14px;
   padding: 1rem;
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
+  transition: transform var(--transition), box-shadow var(--transition);
+}
+
+.tracking-hero__highlights li:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 20px 40px rgba(0, 54, 136, 0.18);
 }
 
 body.dark-mode .tracking-hero__highlights li {
-  background: rgba(88, 110, 255, 0.25);
+  background: linear-gradient(135deg, rgba(0, 54, 136, 0.28), rgba(255, 71, 87, 0.18));
   color: #f6f7ff;
 }
 
@@ -76,12 +82,12 @@ body.dark-mode .tracking-hero__highlights li {
   font-size: 0.8rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  opacity: 0.7;
+  opacity: 0.75;
 }
 
 body.dark-mode .tracking-hero__highlights span {
-  opacity: 0.85;
-  color: rgba(226, 232, 255, 0.85);
+  opacity: 0.9;
+  color: rgba(226, 232, 255, 0.92);
 }
 
 body.dark-mode .tracking-hero__content p,
@@ -132,23 +138,26 @@ body.dark-mode .tracking-board__timestamp {
 
 .tracking-board__timestamp {
   font-size: 0.85rem;
-  opacity: 0.7;
+  opacity: 0.75;
 }
 
 .tracking-chip {
-  border: 1px solid rgba(41, 121, 255, 0.3);
+  border: 1px solid rgba(255, 71, 87, 0.3);
   border-radius: 999px;
-  background: rgba(41, 121, 255, 0.08);
+  background: linear-gradient(135deg, rgba(255, 71, 87, 0.1), rgba(0, 54, 136, 0.1));
   color: var(--accent-blue);
   font-weight: 600;
   padding: 0.45rem 1.1rem;
   cursor: pointer;
+  transition: transform var(--transition), box-shadow var(--transition);
 }
 
 .tracking-chip:hover,
 .tracking-chip:focus-visible {
-  background: var(--accent-blue);
+  background: linear-gradient(135deg, var(--accent-blue), var(--accent-red));
   color: #fff;
+  transform: translateY(-1px);
+  box-shadow: 0 12px 22px rgba(0, 54, 136, 0.28);
 }
 
 .tracking-search__field {
@@ -159,7 +168,8 @@ body.dark-mode .tracking-board__timestamp {
   border: 1px solid rgba(15, 23, 42, 0.12);
   border-radius: 14px;
   padding: 0.6rem 0.8rem;
-  background: rgba(255, 255, 255, 0.9);
+  background: rgba(255, 255, 255, 0.95);
+  box-shadow: 0 24px 40px rgba(0, 14, 38, 0.12);
 }
 
 body.dark-mode .tracking-search__field {
@@ -179,15 +189,22 @@ body.dark-mode .tracking-search__field {
   border: none;
   border-radius: 999px;
   padding: 0.5rem 1.2rem;
-  background: var(--accent-blue);
+  background: linear-gradient(135deg, var(--accent-blue), var(--accent-red));
   color: #fff;
   font-weight: 600;
   cursor: pointer;
+  transition: transform var(--transition), box-shadow var(--transition);
 }
 
 .tracking-search__field button:disabled {
   opacity: 0.6;
   cursor: not-allowed;
+}
+
+.tracking-search__field button:not(:disabled):hover,
+.tracking-search__field button:not(:disabled):focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 30px rgba(0, 54, 136, 0.26);
 }
 
 .tracking-search__results {
@@ -202,6 +219,7 @@ body.dark-mode .tracking-search__field {
   max-height: 420px;
   overflow-y: auto;
   z-index: 20;
+  border: 1px solid rgba(0, 54, 136, 0.12);
 }
 
 body.dark-mode .tracking-search__results {
@@ -209,34 +227,62 @@ body.dark-mode .tracking-search__results {
   box-shadow: 0 22px 36px rgba(0, 0, 0, 0.6);
 }
 
-.result {
+.tracking-result {
   padding: 0.85rem 1rem;
+  border: none;
   border-bottom: 1px solid rgba(15, 23, 42, 0.08);
   cursor: pointer;
   display: flex;
   gap: 0.8rem;
   align-items: center;
+  width: 100%;
+  background: transparent;
+  text-align: left;
+  transition: background var(--transition), transform var(--transition);
 }
 
-.result:last-child {
+.tracking-result:last-child {
   border-bottom: none;
 }
 
-.result:hover {
-  background: rgba(41, 121, 255, 0.12);
+.tracking-result:hover,
+.tracking-result:focus-visible {
+  background: rgba(255, 71, 87, 0.12);
+  outline: none;
+  transform: translateY(-1px);
 }
 
-.r-main {
+.tracking-result__main {
   flex: 1;
 }
 
-.r-title {
+.tracking-result__title {
   font-weight: 700;
 }
 
-.r-sub {
+.tracking-result__meta {
   font-size: 0.85rem;
   opacity: 0.75;
+}
+
+.tracking-result__badge {
+  font-weight: 700;
+  font-size: 0.75rem;
+  color: var(--accent-blue);
+  background: rgba(0, 54, 136, 0.08);
+  border-radius: 999px;
+  padding: 0.15rem 0.6rem;
+}
+
+.tracking-match {
+  color: var(--accent-red);
+  font-weight: 700;
+}
+
+.tracking-search__empty {
+  padding: 1rem;
+  font-size: 0.9rem;
+  color: var(--text-subtle-light);
 }
 
 .tracking-board__rows {


### PR DESCRIPTION
## Summary
- Restore the tracking page layout while adding fuzzy TfL stop suggestions, richer arrivals rendering, and refreshed hero styling.
- Rebuild the Info hub to surface cover/title cards with a modal reader, new category filters, and updated default content taxonomy.
- Refresh the routes directory overlay to sort stops via TfL sequences, drop tracker buttons from cards, and align styling with the new palette.
- Update shared styling tokens to the TfL-inspired red/blue scheme and add modal + tracking UI polish.

## Testing
- Not run (static frontend project).

------
https://chatgpt.com/codex/tasks/task_e_68ce653d897483228e6f2da5f96c1600