### PR TITLE
Implement Firebase-driven profile sync and admin role tooling

### DIFF
--- a/components/auth-modal.html
+++ b/components/auth-modal.html
@@ -42,6 +42,18 @@
       <h2 class="auth-modal__title">Join RouteFlow London</h2>
       <p class="auth-modal__subtitle">Create an account to sync favourites and preferences everywhere.</p>
       <form id="signupForm" class="auth-modal__form" autocomplete="off">
+        <label class="auth-modal__field" for="signupDisplayName">
+          <span>Name</span>
+          <input
+            type="text"
+            id="signupDisplayName"
+            name="signupDisplayName"
+            required
+            autocomplete="name"
+            maxlength="80"
+            placeholder="How should RouteFlow address you?"
+          />
+        </label>
         <label class="auth-modal__field" for="signupEmail">
           <span>Email</span>
           <input

--- a/config.js
+++ b/config.js
@@ -1,8 +1,17 @@
 (function initialiseRouteflowConfig() {
   const existing = window.__ROUTEFLOW_CONFIG__ || {};
+  const defaultFirebaseConfig = {
+    apiKey: 'AIzaSyDuedLuagA4IXc9ZMG9wvoak-sRrhtFZfo',
+    authDomain: 'routeflow-london.firebaseapp.com',
+    projectId: 'routeflow-london',
+    storageBucket: 'routeflow-london.firebasestorage.app',
+    messagingSenderId: '368346241440',
+    appId: '1:368346241440:web:7cc87d551420459251ecc5'
+  };
+
   const firebaseConfig = existing.firebase && typeof existing.firebase === 'object'
-    ? existing.firebase
-    : {};
+    ? { ...defaultFirebaseConfig, ...existing.firebase }
+    : { ...defaultFirebaseConfig };
   const discordConfig = existing.discord && typeof existing.discord === 'object'
     ? existing.discord
     : {};

--- a/profile.css
+++ b/profile.css
@@ -471,6 +471,117 @@ body.dark-mode .profile-editor__field input[type='file'] {
   pointer-events: none;
 }
 
+/* Note creation modal */
+.profile-note-modal {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  z-index: 60;
+}
+
+.profile-note-modal[hidden] {
+  display: none;
+}
+
+.profile-note-modal__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.55);
+  backdrop-filter: blur(8px);
+}
+
+.profile-note-modal__dialog {
+  position: relative;
+  background: var(--card-bg-light);
+  border-radius: 18px;
+  box-shadow: 0 16px 45px rgba(15, 23, 42, 0.28);
+  padding: 1.8rem;
+  max-width: min(520px, 100%);
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+body.dark-mode .profile-note-modal__dialog {
+  background: var(--card-bg-dark);
+  box-shadow: 0 20px 55px rgba(0, 0, 0, 0.55);
+}
+
+.profile-note-modal__header h2 {
+  margin: 0;
+  font-size: 1.35rem;
+}
+
+.profile-note-modal__header p {
+  margin: 0.35rem 0 0 0;
+  font-size: 0.95rem;
+  opacity: 0.8;
+}
+
+.profile-note-modal__body {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.profile-note-modal__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.profile-note-modal__field span {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.profile-note-modal__field input,
+.profile-note-modal__field textarea {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid rgba(15, 23, 42, 0.12);
+  padding: 0.75rem 1rem;
+  font-family: inherit;
+  font-size: 0.95rem;
+  transition: border-color var(--transition), box-shadow var(--transition);
+}
+
+body.dark-mode .profile-note-modal__field input,
+body.dark-mode .profile-note-modal__field textarea {
+  background: rgba(255, 255, 255, 0.06);
+  border-color: rgba(148, 163, 184, 0.25);
+  color: inherit;
+}
+
+.profile-note-modal__field input:focus,
+.profile-note-modal__field textarea:focus {
+  outline: none;
+  border-color: var(--accent-blue);
+  box-shadow: 0 0 0 3px rgba(0, 97, 255, 0.18);
+}
+
+.profile-note-modal__error {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--accent-red, #ff4757);
+  min-height: 1.2rem;
+}
+
+.profile-note-modal__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.profile-note-modal__dialog[aria-busy='true'] {
+  opacity: 0.65;
+  pointer-events: none;
+}
+
 body.modal-open {
   overflow: hidden;
 }

--- a/profile.html
+++ b/profile.html
@@ -118,6 +118,52 @@
       </form>
     </div>
 
+    <div
+      class="profile-note-modal"
+      id="profileNoteModal"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="profileNoteTitle"
+      hidden
+    >
+      <div class="profile-note-modal__backdrop" data-note-modal-dismiss></div>
+      <form class="profile-note-modal__dialog" id="profileNoteForm" novalidate>
+        <header class="profile-note-modal__header">
+          <h2 id="profileNoteTitle">Create a personal note</h2>
+          <p>Pin reminders about disruptions, journeys, or fleet sightings only you can see.</p>
+        </header>
+        <div class="profile-note-modal__body">
+          <label class="profile-note-modal__field" for="profileNoteName">
+            <span>Title</span>
+            <input
+              type="text"
+              id="profileNoteName"
+              name="noteName"
+              required
+              maxlength="120"
+              placeholder="Service change or journey"
+            />
+          </label>
+          <label class="profile-note-modal__field" for="profileNoteContent">
+            <span>Details</span>
+            <textarea
+              id="profileNoteContent"
+              name="noteContent"
+              required
+              rows="5"
+              maxlength="1000"
+              placeholder="Write a quick reminder for yourself"
+            ></textarea>
+          </label>
+          <p class="profile-note-modal__error" id="profileNoteError" role="alert" aria-live="assertive"></p>
+        </div>
+        <footer class="profile-note-modal__actions">
+          <button type="submit" class="profile-chip profile-chip--primary" id="profileNoteSave">Save note</button>
+          <button type="button" class="profile-chip profile-chip--ghost" id="profileNoteCancel" data-note-modal-dismiss>Cancel</button>
+        </footer>
+      </form>
+    </div>
+
     <section class="profile-grid">
       <article class="profile-card profile-card--stats" id="profileStatsCard">
         <header class="profile-card__header">

--- a/style.css
+++ b/style.css
@@ -2108,6 +2108,366 @@ body.dark-mode .site-footer {
 }
 
 /* ------------------------------------------------------------
+   Admin console
+------------------------------------------------------------- */
+.admin-page {
+  width: min(1100px, 100%);
+  margin: clamp(2rem, 6vw, 3rem) auto clamp(3rem, 8vw, 4rem) auto;
+  padding: 0 clamp(1rem, 4vw, 2.5rem);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.4rem, 3vw, 2.2rem);
+}
+
+.admin-page[aria-busy='true'] {
+  opacity: 0.65;
+}
+
+.admin-message {
+  border-radius: var(--radius-md);
+  padding: 1rem 1.25rem;
+  border-left: 4px solid var(--accent-blue);
+  background: rgba(21, 94, 239, 0.1);
+  color: var(--foreground-light);
+  box-shadow: 0 14px 30px rgba(15, 23, 42, 0.08);
+}
+
+.admin-message--info {
+  border-left-color: var(--accent-blue);
+}
+
+.admin-message--error {
+  border-left-color: var(--accent-red, #ff4757);
+  background: rgba(255, 71, 87, 0.1);
+}
+
+.admin-warning {
+  margin: 0;
+  padding: 0.9rem 1.1rem;
+  border-radius: var(--radius-md);
+  background: rgba(255, 193, 7, 0.12);
+  border: 1px solid rgba(255, 193, 7, 0.35);
+  color: #8a5b00;
+}
+
+body.dark-mode .admin-warning {
+  background: rgba(255, 193, 7, 0.2);
+  border-color: rgba(255, 193, 7, 0.45);
+  color: #ffdd8a;
+}
+
+.admin-feedback {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--text-muted-light);
+}
+
+.admin-feedback[data-tone='error'] {
+  color: var(--accent-red, #ff4757);
+}
+
+.admin-feedback[data-tone='success'] {
+  color: #15803d;
+}
+
+body.dark-mode .admin-feedback {
+  color: rgba(226, 232, 240, 0.8);
+}
+
+.admin-panels {
+  display: grid;
+  gap: clamp(1.4rem, 3vw, 2.1rem);
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.admin-panel {
+  background: var(--card-bg-light);
+  border-radius: 20px;
+  padding: clamp(1.4rem, 3vw, 1.9rem);
+  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.12);
+  border: 1px solid rgba(15, 23, 42, 0.06);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+body.dark-mode .admin-panel {
+  background: var(--card-bg-dark);
+  border-color: rgba(148, 163, 184, 0.18);
+  box-shadow: 0 26px 64px rgba(0, 0, 0, 0.55);
+}
+
+.admin-panel__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.admin-panel__header h2 {
+  margin: 0;
+  font-size: 1.3rem;
+}
+
+.admin-panel__description {
+  margin: 0;
+  color: var(--text-muted-light);
+  font-size: 0.95rem;
+}
+
+body.dark-mode .admin-panel__description {
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.admin-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+}
+
+.admin-form__grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.admin-form__grid--compact {
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.admin-form__group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.admin-form__group label {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.admin-form__group input,
+.admin-form__group textarea,
+.admin-form__group select {
+  border-radius: 14px;
+  border: 1px solid rgba(15, 23, 42, 0.12);
+  padding: 0.65rem 0.85rem;
+  font: inherit;
+  transition: border-color var(--transition), box-shadow var(--transition);
+}
+
+.admin-form__group textarea {
+  min-height: 120px;
+  resize: vertical;
+}
+
+.admin-form__group input:focus,
+.admin-form__group textarea:focus,
+.admin-form__group select:focus {
+  outline: none;
+  border-color: var(--accent-blue);
+  box-shadow: 0 0 0 3px rgba(21, 94, 239, 0.2);
+}
+
+body.dark-mode .admin-form__group input,
+body.dark-mode .admin-form__group textarea,
+body.dark-mode .admin-form__group select {
+  background: rgba(255, 255, 255, 0.06);
+  border-color: rgba(148, 163, 184, 0.22);
+  color: inherit;
+}
+
+.admin-form__group--fieldset {
+  padding: 1rem;
+  border-radius: 16px;
+  border: 1px dashed rgba(15, 23, 42, 0.18);
+}
+
+.admin-form__group--fieldset legend {
+  font-weight: 600;
+  padding: 0 0.35rem;
+}
+
+body.dark-mode .admin-form__group--fieldset {
+  border-color: rgba(148, 163, 184, 0.28);
+}
+
+.admin-form__group--stacked {
+  grid-column: 1 / -1;
+}
+
+.admin-form__group--checkbox {
+  flex-direction: row;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.admin-form__group--checkbox input[type='checkbox'] {
+  width: 1.1rem;
+  height: 1.1rem;
+}
+
+.admin-checkboxes {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.admin-checkbox {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.05);
+  border: 1px solid rgba(15, 23, 42, 0.1);
+  font-size: 0.85rem;
+}
+
+.admin-checkbox input {
+  width: 0.95rem;
+  height: 0.95rem;
+}
+
+body.dark-mode .admin-checkbox {
+  background: rgba(148, 163, 184, 0.14);
+  border-color: rgba(148, 163, 184, 0.22);
+}
+
+.admin-form__actions {
+  display: flex;
+  gap: 0.85rem;
+  flex-wrap: wrap;
+}
+
+.admin-button {
+  background: var(--accent-blue);
+  color: #fff;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  padding: 0.6rem 1.4rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform var(--transition), box-shadow var(--transition), background var(--transition);
+}
+
+.admin-button:hover,
+.admin-button:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 22px rgba(21, 94, 239, 0.25);
+}
+
+.admin-button--secondary {
+  background: transparent;
+  color: var(--accent-blue);
+  border-color: rgba(21, 94, 239, 0.45);
+}
+
+.admin-button--secondary:hover,
+.admin-button--secondary:focus-visible {
+  background: rgba(21, 94, 239, 0.12);
+}
+
+.admin-empty {
+  margin: 0;
+  padding: 1rem;
+  border-radius: var(--radius-md);
+  background: rgba(15, 23, 42, 0.04);
+  color: var(--text-muted-light);
+}
+
+body.dark-mode .admin-empty {
+  background: rgba(148, 163, 184, 0.1);
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.admin-role-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.admin-role-list[aria-busy='true'] {
+  opacity: 0.6;
+}
+
+.admin-role-list__items {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.admin-role-list__item {
+  background: rgba(15, 23, 42, 0.05);
+  border-radius: 14px;
+  padding: 0.85rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+body.dark-mode .admin-role-list__item {
+  background: rgba(148, 163, 184, 0.12);
+}
+
+.admin-role-list__meta {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--text-muted-light);
+}
+
+body.dark-mode .admin-role-list__meta {
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.admin-table-wrapper {
+  margin-top: 0.5rem;
+}
+
+.admin-table__actions {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}
+
+.admin-tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin: 0.35rem 0 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.admin-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(21, 94, 239, 0.12);
+  color: var(--accent-blue);
+  font-size: 0.82rem;
+}
+
+.admin-blog-summary {
+  margin: 0.35rem 0 0 0;
+  font-size: 0.92rem;
+  color: var(--text-muted-light);
+}
+
+body.dark-mode .admin-tag {
+  background: rgba(99, 102, 241, 0.28);
+  color: #c7d2fe;
+}
+
+body.dark-mode .admin-blog-summary {
+  color: rgba(226, 232, 240, 0.75);
+}
+
+/* ------------------------------------------------------------
    Admin dashboard
 ------------------------------------------------------------- */
 .admin-dashboard {


### PR DESCRIPTION
## Summary
- default the app to the provided Firebase credentials and expose helper APIs for Firestore-backed profiles, Discord sync, and admin role utilities
- expand the authentication flow to capture display names, keep profile summaries in sync, and surface Google sign-in/admin checks in the UI
- refresh the profile page with Firestore-backed greetings plus a modal note composer, and add an admin role management panel with accompanying styles and stats updates

## Testing
- not run (front-end project without automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68ce6dc2218c8322b061b7b2d2079245