### PR TITLE
Ensure admin changes persist and profile extras sync

### DIFF
--- a/fleet.css
+++ b/fleet.css
@@ -815,14 +815,6 @@ body.dark-mode .fleet-form__extras small {
   align-items: flex-end;
 }
 
-.fleet-admin__hint {
-  color: rgba(15, 23, 42, 0.6);
-}
-
-body.dark-mode .fleet-admin__hint {
-  color: rgba(226, 232, 240, 0.7);
-}
-
 .fleet-admin__panel {
   margin-top: 1.75rem;
   border-top: 1px solid var(--fleet-border-light);

--- a/fleet.html
+++ b/fleet.html
@@ -452,9 +452,6 @@
             >
               Access admin tools
             </button>
-            <small class="fleet-admin__hint"
-              >Demo access code: <code>fleet-admin</code></small
-            >
           </div>
         </header>
         <div id="adminPanel" class="fleet-admin__panel" hidden>

--- a/info.js
+++ b/info.js
@@ -1,4 +1,4 @@
-import { getStoredBlogPosts } from './data-store.js';
+import { getStoredBlogPosts, refreshBlogPosts } from './data-store.js';
 
 const formatPublishedDate = (value) => {
   if (!value) return '—';
@@ -249,7 +249,12 @@ const matchesSearchTerm = (post, term) => {
 
 let searchTerm = '';
 
-const renderBlogLists = () => {
+const renderBlogLists = async () => {
+  try {
+    await refreshBlogPosts();
+  } catch (error) {
+    console.warn('Unable to refresh blog posts before rendering.', error);
+  }
   const containers = Array.from(document.querySelectorAll('[data-blog-list]'));
   if (!containers.length) return;
 
@@ -392,9 +397,15 @@ const renderBlogLists = () => {
   }
 };
 
+const initialiseBlogLists = () => {
+  renderBlogLists().catch((error) => {
+    console.error('Failed to render blog lists.', error);
+  });
+};
+
 if (document.readyState === 'loading') {
-  document.addEventListener('DOMContentLoaded', renderBlogLists, { once: true });
+  document.addEventListener('DOMContentLoaded', initialiseBlogLists, { once: true });
 } else {
-  renderBlogLists();
+  initialiseBlogLists();
 }
 

--- a/style.css
+++ b/style.css
@@ -911,6 +911,25 @@ body.dark-mode .route-overlay {
   padding-right: 0.4rem;
 }
 
+.route-overlay__direction {
+  margin: 0.6rem 0 0.2rem;
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--text-muted-light);
+}
+
+.route-overlay__direction:first-child {
+  margin-top: 0;
+}
+
+.route-overlay__stops-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
 .route-overlay__stop {
   border: 1px solid rgba(15, 23, 42, 0.12);
   border-radius: var(--radius-md);

--- a/withdrawn.js
+++ b/withdrawn.js
@@ -1,4 +1,4 @@
-import { getStoredWithdrawnRoutes, STORAGE_KEYS } from './data-store.js';
+import { getStoredWithdrawnRoutes, refreshWithdrawnRoutes, STORAGE_KEYS } from './data-store.js';
 
 const selectors = {
   table: document.getElementById('withdrawnTable'),
@@ -116,8 +116,13 @@ const refreshFromStorage = () => {
   filterRows(state.searchTerm || '');
 };
 
-const initialise = () => {
+const initialise = async () => {
   if (!selectors.table) return;
+  try {
+    await refreshWithdrawnRoutes();
+  } catch (error) {
+    console.warn('Unable to refresh withdrawn routes before rendering.', error);
+  }
   renderStoredRoutes();
   computeStats();
   filterRows('');
@@ -128,9 +133,15 @@ const initialise = () => {
 };
 
 if (document.readyState === 'loading') {
-  document.addEventListener('DOMContentLoaded', initialise, { once: true });
+  document.addEventListener('DOMContentLoaded', () => {
+    initialise().catch((error) => {
+      console.error('Failed to initialise withdrawn routes view.', error);
+    });
+  }, { once: true });
 } else {
-  initialise();
+  initialise().catch((error) => {
+    console.error('Failed to initialise withdrawn routes view.', error);
+  });
 }
 
 window.addEventListener('storage', (event) => {


### PR DESCRIPTION
## Summary
- require Firebase administrator authentication for fleet moderation endpoints and wire the fleet page into Firebase auth events instead of the legacy code gate
- remove the demo admin code hint from the fleet page and drop the unused CSS hook
- normalise profile extras so display names, avatars and gender are saved via the backend and reflected in the hero card

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68cf01caf9b083229671192f6445c3c5