### PR TITLE
Handle fleet API 404 with bundled fallback data

### DIFF
--- a/fleet.js
+++ b/fleet.js
@@ -525,7 +525,17 @@
   }
 
   async function fetchFleetStateFromApi() {
-    return requestJson("/fleet");
+    try {
+      return await requestJson("/fleet");
+    } catch (error) {
+      if (error?.status === 404) {
+        console.warn(
+          "Fleet API unavailable (404). Falling back to bundled dataset.",
+        );
+        return clone(DEFAULT_STATE);
+      }
+      throw error;
+    }
   }
 
   async function submitFleetUpdateToApi(bus) {


### PR DESCRIPTION
## Summary
- treat fleet API 404 responses as a signal that the backend is unavailable
- fall back to the bundled fleet dataset instead of surfacing an error toast

## Testing
- not run (no automated tests provided)

------
https://chatgpt.com/codex/tasks/task_e_68cf2625f6288322b2fecb9e6558a0a0