### PR TITLE
Handle missing option category on fleet page

### DIFF
--- a/fleet.html
+++ b/fleet.html
@@ -445,16 +445,6 @@
         </form>
       </section>
 
-      <section class="fleet-card fleet-admin-note" aria-labelledby="fleetAdminNote">
-        <div>
-          <p class="fleet-hero__eyebrow">Admin update</p>
-          <h2 id="fleetAdminNote">Fleet moderation has moved</h2>
-          <p>
-            Administrators can now review submissions and manage dropdown values from the
-            dedicated <a href="admin.html">RouteFlow admin portal</a>.
-          </p>
-        </div>
-      </section>
     </main>
 
     <footer class="site-footer" aria-label="Footer">

--- a/fleet.js
+++ b/fleet.js
@@ -468,7 +468,11 @@
     applyAdminUi(elements);
 
     populateAllSelects(elements);
-    renderOptionList(elements, elements.optionCategory.value);
+    if (elements.optionCategory) {
+      renderOptionList(elements, elements.optionCategory.value);
+    } else {
+      renderOptionList(elements, null);
+    }
     renderTable(elements);
     renderHighlights(elements);
     updateStats(elements);
@@ -754,7 +758,11 @@
       applyFleetState(remoteState);
       sortOptionLists();
       populateAllSelects(elements);
-      renderOptionList(elements, elements.optionCategory.value);
+      if (elements.optionCategory) {
+        renderOptionList(elements, elements.optionCategory.value);
+      } else {
+        renderOptionList(elements, null);
+      }
       renderTable(elements);
       renderHighlights(elements);
       updateStats(elements);
@@ -1642,6 +1650,11 @@
   function renderOptionList(elements, field) {
     const { optionList } = elements;
     if (!optionList) return;
+    if (!field) {
+      optionList.innerHTML =
+        '<li class="option-empty">Select a field to view options.</li>';
+      return;
+    }
     const options = state.options[field] || [];
     if (!options.length) {
       optionList.innerHTML =


### PR DESCRIPTION
## Summary
- remove the outdated "Fleet moderation has moved" admin notice from the fleet page
- guard option list rendering so the page no longer errors when admin controls are absent and show a neutral empty-state message

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cf9d434074832280a47d3943168522