### PR TITLE
Add Neon smoke test job to workflow

### DIFF
--- a/.github/workflows/neon-branch.yml
+++ b/.github/workflows/neon-branch.yml
@@ -94,6 +94,34 @@ jobs:
 #          compare_branch: preview/pr-${{ github.event.number }}-${{ needs.setup.outputs.branch }}
 #          api_key: ${{ secrets.NEON_API_KEY }}
 
+  backend_smoke_tests:
+    name: Backend Smoke Tests (Neon)
+    needs:
+      - setup
+      - create_neon_branch
+    if: |
+      github.event_name == 'pull_request' && (
+      github.event.action == 'synchronize'
+      || github.event.action == 'opened'
+      || github.event.action == 'reopened')
+      && needs.create_neon_branch.result == 'success'
+    runs-on: ubuntu-latest
+    env:
+      DATABASE_URL: ${{ needs.create_neon_branch.outputs.db_url_with_pooler }}
+      FIREBASE_API_KEY: dummy-ci-key
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install backend dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run Neon preview smoke test
+        run: python -m backend.neon_ci_check
+
   delete_neon_branch:
     name: Delete Neon Branch
     needs: setup

--- a/backend/neon_ci_check.py
+++ b/backend/neon_ci_check.py
@@ -1,0 +1,106 @@
+"""CI helper utilities for verifying Neon preview branches.
+
+This module performs a minimal smoke test against the Postgres database
+provisioned for pull requests via the Neon GitHub Actions workflow. It ensures
+that core tables are created and writable so that preview environments can rely
+on the branch before deploying a backend instance.
+"""
+
+from __future__ import annotations
+
+import sys
+import uuid
+
+from . import api
+
+
+def _insert_sample_note(cursor, uid: str, note_id: str, title: str, content: str) -> None:
+    """Insert or update a single profile note and verify the stored payload."""
+    cursor.execute(
+        """
+        INSERT INTO profile_notes (uid, note_id, title, content)
+        VALUES (%s, %s, %s, %s)
+        ON CONFLICT (uid, note_id)
+        DO UPDATE SET
+            title = EXCLUDED.title,
+            content = EXCLUDED.content,
+            updated_at = NOW()
+        RETURNING title, content;
+        """,
+        (uid, note_id, title, content),
+    )
+    persisted_title, persisted_content = cursor.fetchone()
+    if persisted_title != title or persisted_content != content:
+        raise RuntimeError(
+            "Inserted note payload does not match returned row from Neon preview branch."
+        )
+
+
+def _assert_note_round_trip(cursor, uid: str, note_id: str, title: str, content: str) -> None:
+    """Fetch the note to confirm read-after-write behaviour."""
+    cursor.execute(
+        "SELECT title, content FROM profile_notes WHERE uid = %s AND note_id = %s",
+        (uid, note_id),
+    )
+    row = cursor.fetchone()
+    if row != (title, content):
+        raise RuntimeError(
+            f"Preview branch returned an unexpected note payload: {row!r}"
+        )
+
+
+def _cleanup_sample_note(cursor, uid: str, note_id: str) -> None:
+    """Remove the CI note to keep preview branches tidy."""
+    cursor.execute(
+        "DELETE FROM profile_notes WHERE uid = %s AND note_id = %s",
+        (uid, note_id),
+    )
+
+
+def run_smoke_test() -> str:
+    """Execute the Neon preview branch smoke test.
+
+    Returns the identifier of the inserted note so callers can include it in log
+    output if required.
+    """
+
+    api.init_database()
+
+    uid = "ci-preview-user"
+    note_id = f"ci-note-{uuid.uuid4().hex}"
+    title = "Neon Workflow Smoke Test"
+    content = "Ensuring preview database tables are ready."
+
+    with api.get_connection() as connection:
+        with connection.cursor() as cursor:
+            _insert_sample_note(cursor, uid, note_id, title, content)
+        connection.commit()
+
+        with connection.cursor() as cursor:
+            _assert_note_round_trip(cursor, uid, note_id, title, content)
+            _cleanup_sample_note(cursor, uid, note_id)
+        connection.commit()
+
+    return note_id
+
+
+def main() -> None:
+    try:
+        note_id = run_smoke_test()
+    except Exception as exc:  # pragma: no cover - defensive logging for CI
+        print("Neon preview smoke test failed:", exc, file=sys.stderr)
+        raise
+    else:
+        print(
+            "Neon preview smoke test completed successfully.",
+            f"Inserted note id: {note_id}",
+        )
+    finally:
+        try:
+            api.connection_pool.closeall()
+        except Exception:  # pragma: no cover - ensure CI never hides the root error
+            pass
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a backend smoke test job that runs against the Neon preview branch for each PR
- create a reusable Python helper that exercises the profile notes table on the preview database

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68cfacca22608322958390020f4597bb