### PR TITLE
Persist dashboard progress in database

### DIFF
--- a/dashboard-progress.js
+++ b/dashboard-progress.js
@@ -1,0 +1,108 @@
+const API_BASE_URL = (window.__ROUTEFLOW_API_BASE__ || '/api').replace(/\/$/, '');
+
+const buildDashboardPath = (uid) => `${API_BASE_URL}/profile/${encodeURIComponent(uid)}/dashboard`;
+
+const parseJsonResponse = async (response) => {
+  const contentType = response.headers.get('content-type') || '';
+  if (!contentType.includes('application/json')) {
+    return null;
+  }
+  try {
+    return await response.json();
+  } catch (error) {
+    console.warn('RouteFlow dashboard progress: failed to parse response payload.', error);
+    return null;
+  }
+};
+
+const getCurrentUser = () => {
+  const routeflowAuth = window.RouteflowAuth;
+  if (routeflowAuth?.getCurrentUser) {
+    try {
+      return routeflowAuth.getCurrentUser();
+    } catch (error) {
+      console.error('RouteFlow dashboard progress: unable to read user from RouteflowAuth.', error);
+    }
+  }
+  try {
+    if (typeof firebase !== 'undefined' && typeof firebase.auth === 'function') {
+      const auth = firebase.auth();
+      return auth?.currentUser || null;
+    }
+  } catch (error) {
+    console.error('RouteFlow dashboard progress: unable to resolve Firebase auth user.', error);
+  }
+  return null;
+};
+
+const ensureAuthenticatedUser = (uid) => {
+  const user = getCurrentUser();
+  if (!user || user.uid !== uid) {
+    throw new Error('You must be signed in to sync dashboard progress.');
+  }
+  if (typeof user.getIdToken !== 'function') {
+    throw new Error('A connected RouteFlow account is required to sync progress.');
+  }
+  return user;
+};
+
+const authorisedRequest = async (uid, { method = 'GET', body = null } = {}) => {
+  const user = ensureAuthenticatedUser(uid);
+  const token = await user.getIdToken();
+  const headers = {
+    Authorization: `Bearer ${token}`
+  };
+  let requestBody = body;
+  if (requestBody !== null && requestBody !== undefined) {
+    headers['Content-Type'] = 'application/json';
+    requestBody = JSON.stringify(requestBody);
+  }
+
+  const response = await fetch(buildDashboardPath(uid), {
+    method,
+    headers,
+    body: requestBody
+  });
+
+  const payload = await parseJsonResponse(response);
+
+  if (!response.ok) {
+    const message = payload?.error || 'Unable to complete dashboard progress request.';
+    const error = new Error(message);
+    error.status = response.status;
+    error.payload = payload;
+    throw error;
+  }
+
+  return payload;
+};
+
+export async function getDashboardState(uid) {
+  if (!uid) return null;
+  try {
+    const payload = await authorisedRequest(uid, { method: 'GET' });
+    if (payload && typeof payload === 'object') {
+      return payload.state ?? null;
+    }
+    return null;
+  } catch (error) {
+    if (error?.status === 404) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+export async function saveDashboardState(uid, state) {
+  if (!uid) {
+    throw new Error('A user id is required to save dashboard progress.');
+  }
+  const payload = await authorisedRequest(uid, {
+    method: 'PUT',
+    body: { state: state && typeof state === 'object' ? state : {} }
+  });
+  if (payload && typeof payload === 'object') {
+    return payload.state ?? {};
+  }
+  return state && typeof state === 'object' ? state : {};
+}

--- a/dashboard.html
+++ b/dashboard.html
@@ -248,10 +248,12 @@
     import { getRecents } from './recents.js';
     import { inferFavouriteType, resolveFavouriteTitle, buildFavouriteMeta } from './favourite-utils.js';
     import { connectDiscord, disconnectDiscord, subscribeToDiscordStatus, getDiscordStatus, isDiscordConfigured } from './discord-auth.js';
+    import { getDashboardState, saveDashboardState } from './dashboard-progress.js';
 
     const STORAGE_PREFIX = 'routeflow:gamification';
     const TOAST_DURATION = 4000;
     const LEVEL_CONFIG = { base: 420, growth: 1.48, maxLevel: 40 };
+    const REMOTE_SAVE_DEBOUNCE_MS = 800;
 
     const DEFAULT_GAMIFICATION = () => ({
       xp: 1820,
@@ -501,6 +503,10 @@
     let currentUid = 'guest';
     let gamificationState = DEFAULT_GAMIFICATION();
     let toastTimeout;
+    let remoteSaveTimer = null;
+    let pendingRemoteState = null;
+    let pendingRemoteUid = null;
+    let remoteLoadPromise = null;
 
     const rootElement = document.querySelector('.dashboard');
     const overlayElement = document.getElementById('dashboardAuthGate');
@@ -670,23 +676,27 @@
       }
     }
 
+    function mergeWithDefaults(source = {}) {
+      const fallback = DEFAULT_GAMIFICATION();
+      return {
+        ...fallback,
+        ...source,
+        combo: { ...fallback.combo, ...((source && source.combo) || {}) },
+        tasks: ((source && source.tasks) || fallback.tasks).map((task) => ({ ...task })),
+        badges: ((source && source.badges) || fallback.badges).map((badge) => ({ ...badge })),
+        roles: ((source && source.roles) || fallback.roles).map((role) => ({ ...role })),
+        miniGames: ((source && source.miniGames) || fallback.miniGames).map((game) => ({ ...game })),
+        weeklyChallenges: ((source && source.weeklyChallenges) || fallback.weeklyChallenges).map((item) => ({ ...item })),
+        comboChallenges: ((source && source.comboChallenges) || fallback.comboChallenges).map((item) => ({ ...item })),
+        missions: ((source && source.missions) || fallback.missions).map((mission) => ({ ...mission }))
+      };
+    }
+
     function loadState(uid) {
       try {
         const stored = safeParse(localStorage.getItem(storageKey(uid)));
         if (stored && typeof stored === 'object') {
-          const fallback = DEFAULT_GAMIFICATION();
-          return {
-            ...fallback,
-            ...stored,
-            combo: { ...fallback.combo, ...(stored.combo || {}) },
-            tasks: (stored.tasks || fallback.tasks).map((task) => ({ ...task })),
-            badges: (stored.badges || fallback.badges).map((badge) => ({ ...badge })),
-            roles: (stored.roles || fallback.roles).map((role) => ({ ...role })),
-            miniGames: (stored.miniGames || fallback.miniGames).map((game) => ({ ...game })),
-            weeklyChallenges: (stored.weeklyChallenges || fallback.weeklyChallenges).map((item) => ({ ...item })),
-            comboChallenges: (stored.comboChallenges || fallback.comboChallenges).map((item) => ({ ...item })),
-            missions: (stored.missions || fallback.missions).map((mission) => ({ ...mission }))
-          };
+          return mergeWithDefaults(stored);
         }
       } catch (error) {
         console.warn('RouteFlow dashboard: unable to load gamification state', error);
@@ -694,11 +704,110 @@
       return DEFAULT_GAMIFICATION();
     }
 
-    function saveState() {
+    function saveState(options = {}) {
       try {
         localStorage.setItem(storageKey(currentUid), JSON.stringify(gamificationState));
       } catch (error) {
         console.warn('RouteFlow dashboard: unable to save gamification state', error);
+      }
+      if (!options.skipRemote) {
+        queueRemoteSave();
+      }
+    }
+
+    function cloneGamificationState(state) {
+      try {
+        return JSON.parse(JSON.stringify(state || {}));
+      } catch (error) {
+        console.warn('RouteFlow dashboard: unable to clone gamification state for sync', error);
+        if (state && typeof state === 'object') {
+          return { ...state };
+        }
+        return {};
+      }
+    }
+
+    async function persistRemoteState(uid, state) {
+      if (!uid || uid === 'guest') return;
+      try {
+        await saveDashboardState(uid, state);
+      } catch (error) {
+        console.warn('RouteFlow dashboard: unable to sync progress with the cloud', error);
+      }
+    }
+
+    function queueRemoteSave() {
+      if (!currentUid || currentUid === 'guest') {
+        return;
+      }
+      pendingRemoteState = cloneGamificationState(gamificationState);
+      pendingRemoteUid = currentUid;
+      if (remoteSaveTimer) {
+        clearTimeout(remoteSaveTimer);
+      }
+      remoteSaveTimer = setTimeout(() => {
+        const state = pendingRemoteState;
+        const uid = pendingRemoteUid;
+        pendingRemoteState = null;
+        pendingRemoteUid = null;
+        remoteSaveTimer = null;
+        if (uid && uid !== 'guest' && state) {
+          persistRemoteState(uid, state);
+        }
+      }, REMOTE_SAVE_DEBOUNCE_MS);
+    }
+
+    function flushRemoteSave() {
+      if (remoteSaveTimer) {
+        clearTimeout(remoteSaveTimer);
+        remoteSaveTimer = null;
+      }
+      const state = pendingRemoteState;
+      const uid = pendingRemoteUid;
+      pendingRemoteState = null;
+      pendingRemoteUid = null;
+      if (uid && uid !== 'guest' && state) {
+        persistRemoteState(uid, state);
+      }
+    }
+
+    async function fetchRemoteProgress(uid, options = {}) {
+      if (!uid || uid === 'guest') {
+        return;
+      }
+      if (remoteLoadPromise && !options.force) {
+        try {
+          await remoteLoadPromise;
+        } catch (error) {
+          // Ignore previous load errors.
+        }
+      }
+      const loadTask = (async () => {
+        try {
+          const state = await getDashboardState(uid);
+          if (uid !== currentUid) {
+            return;
+          }
+          if (state && typeof state === 'object') {
+            gamificationState = mergeWithDefaults(state);
+            ensureDailyState(gamificationState);
+            saveState({ skipRemote: true });
+            queueRemoteSave();
+            renderAll();
+          } else if (state === null) {
+            queueRemoteSave();
+          }
+        } catch (error) {
+          console.warn('RouteFlow dashboard: unable to load saved progress from the cloud', error);
+        }
+      })();
+      remoteLoadPromise = loadTask;
+      try {
+        await loadTask;
+      } finally {
+        if (remoteLoadPromise === loadTask) {
+          remoteLoadPromise = null;
+        }
       }
     }
 
@@ -1487,6 +1596,7 @@
     }
 
     function handleLock() {
+      flushRemoteSave();
       currentUid = 'guest';
       gamificationState = loadState(currentUid);
       ensureDailyState(gamificationState);
@@ -1505,6 +1615,7 @@
 
     async function handleUnlock(user) {
       if (!user) return;
+      flushRemoteSave();
       currentUid = user.uid;
       gamificationState = loadState(currentUid);
       const { dayDifference } = ensureDailyState(gamificationState);
@@ -1516,6 +1627,7 @@
         updateChallenges('streak');
       }
       renderAll();
+      fetchRemoteProgress(user.uid);
       try {
         await loadFavourites(user.uid);
       } catch (error) {
@@ -1523,7 +1635,7 @@
       }
       loadActivity(user.uid);
       loadRecents(user.uid);
-      saveState();
+      saveState({ skipRemote: true });
     }
 
     const handleAuthStateChange = (user) => {
@@ -1652,10 +1764,19 @@
       updateDiscordConnection(status, { save: true, log: shouldLog, renderAll: shouldLog });
     });
 
-    window.addEventListener('beforeunload', () => {
+    const handleBeforeUnload = () => {
+      flushRemoteSave();
       if (typeof unsubscribeDiscord === 'function') {
         unsubscribeDiscord();
         unsubscribeDiscord = null;
+      }
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    window.addEventListener('pagehide', flushRemoteSave);
+    document.addEventListener('visibilitychange', () => {
+      if (document.visibilityState === 'hidden') {
+        flushRemoteSave();
       }
     });
 


### PR DESCRIPTION
## Summary
- add a Postgres-backed `dashboard_progress` table and API endpoints for syncing dashboard state
- create a browser helper that reads/writes dashboard progress through the authenticated profile API
- update the dashboard experience to merge server data, queue cloud saves, and flush changes when the page closes

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68cfb01f83a48322ade090a51d0fdda2