### PR TITLE
Ensure profile notes timestamps exist during init

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -865,6 +865,30 @@ def init_database() -> None:
             )
             cursor.execute(
                 """
+                ALTER TABLE profile_notes
+                    ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ,
+                    ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ;
+                """
+            )
+            cursor.execute(
+                """
+                UPDATE profile_notes
+                SET created_at = COALESCE(created_at, NOW()),
+                    updated_at = COALESCE(updated_at, NOW())
+                WHERE created_at IS NULL OR updated_at IS NULL;
+                """
+            )
+            cursor.execute(
+                """
+                ALTER TABLE profile_notes
+                    ALTER COLUMN created_at SET DEFAULT NOW(),
+                    ALTER COLUMN created_at SET NOT NULL,
+                    ALTER COLUMN updated_at SET DEFAULT NOW(),
+                    ALTER COLUMN updated_at SET NOT NULL;
+                """
+            )
+            cursor.execute(
+                """
                 CREATE TABLE IF NOT EXISTS profile_favourites (
                     uid TEXT NOT NULL,
                     favourite_id TEXT NOT NULL,


### PR DESCRIPTION
## Summary
- backfill missing created_at and updated_at columns for profile_notes during database initialisation
- normalise null timestamp values and enforce defaults so preview smoke tests can update notes safely

## Testing
- python -m backend.neon_ci_check


------
https://chatgpt.com/codex/tasks/task_e_68cfc5cc845083228881c5c5744e6bec