### PR TITLE
Normalize API base URL handling

### DIFF
--- a/admin.js
+++ b/admin.js
@@ -34,7 +34,20 @@ const FALLBACK_ADMIN_OVERRIDES = new Map([
 
 const TAG_OPTIONS = ['Regular', 'Night', 'School', 'Special', 'Express'];
 
-const FLEET_API_BASE = (window.__ROUTEFLOW_API_BASE__ || '/api').replace(/\/$/, '');
+function resolveApiBase(defaultBase = '/api') {
+  const rawBase = typeof window !== 'undefined' ? window.__ROUTEFLOW_API_BASE__ : undefined;
+  if (typeof rawBase !== 'string') {
+    return defaultBase;
+  }
+  const trimmed = rawBase.trim();
+  if (!trimmed || trimmed === '/') {
+    return defaultBase;
+  }
+  const normalised = trimmed.replace(/\/+$/, '');
+  return normalised || defaultBase;
+}
+
+const FLEET_API_BASE = resolveApiBase('/api');
 
 const FLEET_FIELD_LABELS = {
   fleetNumber: 'Fleet number',

--- a/dashboard-progress.js
+++ b/dashboard-progress.js
@@ -1,4 +1,17 @@
-const API_BASE_URL = (window.__ROUTEFLOW_API_BASE__ || '/api').replace(/\/$/, '');
+function resolveApiBase(defaultBase = '/api') {
+  const rawBase = typeof window !== 'undefined' ? window.__ROUTEFLOW_API_BASE__ : undefined;
+  if (typeof rawBase !== 'string') {
+    return defaultBase;
+  }
+  const trimmed = rawBase.trim();
+  if (!trimmed || trimmed === '/') {
+    return defaultBase;
+  }
+  const normalised = trimmed.replace(/\/+$/, '');
+  return normalised || defaultBase;
+}
+
+const API_BASE_URL = resolveApiBase('/api');
 
 const buildDashboardPath = (uid) => `${API_BASE_URL}/profile/${encodeURIComponent(uid)}/dashboard`;
 

--- a/favourites.js
+++ b/favourites.js
@@ -1,4 +1,17 @@
-const API_BASE_URL = (window.__ROUTEFLOW_API_BASE__ || '/api').replace(/\/$/, '');
+function resolveApiBase(defaultBase = '/api') {
+  const rawBase = typeof window !== 'undefined' ? window.__ROUTEFLOW_API_BASE__ : undefined;
+  if (typeof rawBase !== 'string') {
+    return defaultBase;
+  }
+  const trimmed = rawBase.trim();
+  if (!trimmed || trimmed === '/') {
+    return defaultBase;
+  }
+  const normalised = trimmed.replace(/\/+$/, '');
+  return normalised || defaultBase;
+}
+
+const API_BASE_URL = resolveApiBase('/api');
 
 const buildProfilePath = (uid, suffix = '') => {
   const safeSuffix = suffix ? (suffix.startsWith('/') ? suffix : `/${suffix}`) : '';

--- a/fleet.js
+++ b/fleet.js
@@ -1,7 +1,20 @@
 (function () {
   "use strict";
 
-  const API_BASE_URL = (window.__ROUTEFLOW_API_BASE__ || "/api").replace(/\/$/, "");
+  function resolveApiBase(defaultBase = "/api") {
+    const rawBase = typeof window !== "undefined" ? window.__ROUTEFLOW_API_BASE__ : undefined;
+    if (typeof rawBase !== "string") {
+      return defaultBase;
+    }
+    const trimmed = rawBase.trim();
+    if (!trimmed || trimmed === "/") {
+      return defaultBase;
+    }
+    const normalised = trimmed.replace(/\/+$/, "");
+    return normalised || defaultBase;
+  }
+
+  const API_BASE_URL = resolveApiBase("/api");
 
   const FALLBACK_ADMIN_OVERRIDES = new Map([
     [

--- a/notes.js
+++ b/notes.js
@@ -1,4 +1,17 @@
-const API_BASE_URL = (window.__ROUTEFLOW_API_BASE__ || '/api').replace(/\/$/, '');
+function resolveApiBase(defaultBase = '/api') {
+  const rawBase = typeof window !== 'undefined' ? window.__ROUTEFLOW_API_BASE__ : undefined;
+  if (typeof rawBase !== 'string') {
+    return defaultBase;
+  }
+  const trimmed = rawBase.trim();
+  if (!trimmed || trimmed === '/') {
+    return defaultBase;
+  }
+  const normalised = trimmed.replace(/\/+$/, '');
+  return normalised || defaultBase;
+}
+
+const API_BASE_URL = resolveApiBase('/api');
 
 const buildProfilePath = (uid, suffix = '') => {
   const safeSuffix = suffix ? (suffix.startsWith('/') ? suffix : `/${suffix}`) : '';


### PR DESCRIPTION
## Summary
- ensure every client script normalises the configured API base before building fleet/profile endpoints
- fall back to the default `/api` prefix whenever the override is missing or resolves to an empty slash

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cfcccf4d8c8322b11b95b66a6f8499