### PR TITLE
Make Neon CI check lazy-load database connections

### DIFF
--- a/backend/neon_ci_check.py
+++ b/backend/neon_ci_check.py
@@ -97,7 +97,7 @@ def main() -> None:
         )
     finally:
         try:
-            api.connection_pool.closeall()
+            api.close_connection_pool()
         except Exception:  # pragma: no cover - ensure CI never hides the root error
             pass
 


### PR DESCRIPTION
## Summary
- avoid creating the PostgreSQL connection pool during backend import
- add lazy database initialisation hooks so preview smoke tests can run without network access
- expose a safe helper for closing the pooled connections used by the Neon smoke test

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68cfd542058c832289b2d0589fdd9c0d