### PR TITLE
Improve tracking search suggestion context

### DIFF
--- a/tracking.css
+++ b/tracking.css
@@ -911,7 +911,7 @@ body.dark-mode .tracking-result:focus-visible {
   flex: 1;
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: 0.35rem;
 }
 
 .tracking-result__title {
@@ -932,6 +932,29 @@ body.dark-mode .tracking-result__meta {
   color: rgba(226, 232, 255, 0.72);
 }
 
+.tracking-result__lines {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.tracking-result__line {
+  display: inline-flex;
+  align-items: center;
+  font-weight: 700;
+  font-size: 0.72rem;
+  letter-spacing: 0.05em;
+  color: var(--accent-blue);
+  background: rgba(0, 54, 136, 0.12);
+  border-radius: 999px;
+  padding: 0.18rem 0.55rem;
+}
+
+body.dark-mode .tracking-result__line {
+  color: #dbeafe;
+  background: rgba(88, 110, 255, 0.22);
+}
+
 .tracking-result__badge {
   font-weight: 700;
   font-size: 0.75rem;
@@ -944,6 +967,27 @@ body.dark-mode .tracking-result__meta {
 body.dark-mode .tracking-result__badge {
   color: #dbeafe;
   background: rgba(88, 110, 255, 0.22);
+}
+
+.tracking-result__reason {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.75rem;
+  color: var(--text-subtle-light);
+}
+
+.tracking-result__reason i {
+  font-size: 0.8rem;
+  color: var(--accent-blue);
+}
+
+body.dark-mode .tracking-result__reason {
+  color: rgba(226, 232, 255, 0.72);
+}
+
+body.dark-mode .tracking-result__reason i {
+  color: #c7d2fe;
 }
 
 .tracking-match {


### PR DESCRIPTION
## Summary
- show richer tracking search suggestions with served line badges, match reason text and clearer mode labels
- deduplicate available modes, capture line names from TfL stop data and fold them into scoring/highlighting

## Testing
- node --check tracking.js

------
https://chatgpt.com/codex/tasks/task_e_68d026c6c55883229929e6fbdfd2f459