### PR TITLE
Create mobile-first app shell

### DIFF
--- a/mobile-app.css
+++ b/mobile-app.css
@@ -1,0 +1,1001 @@
+/*
+  RouteFlow London mobile-first app shell
+  This stylesheet overrides the desktop-first layout so every page renders
+  like a dedicated mobile app no matter the viewport size.
+*/
+
+:root {
+  --primary: #325fff;
+  --primary-dark: #1f3ed9;
+  --accent-blue: #325fff;
+  --accent-blue-dark: #1f3ed9;
+  --accent-red: #ff6b81;
+  --accent-red-dark: #e4566a;
+  --background-light: #f4f6ff;
+  --foreground-light: #08142f;
+  --background-dark: #040717;
+  --foreground-dark: #f6f8ff;
+  --card-bg-light: rgba(255, 255, 255, 0.92);
+  --card-bg-dark: rgba(16, 23, 43, 0.92);
+  --surface-muted-light: rgba(255, 255, 255, 0.74);
+  --surface-muted-dark: rgba(25, 31, 55, 0.78);
+  --surface-elevated-light: rgba(255, 255, 255, 0.95);
+  --surface-elevated-dark: rgba(18, 24, 46, 0.92);
+  --glass-border: rgba(30, 38, 84, 0.14);
+  --glass-border-dark: rgba(120, 135, 208, 0.35);
+  --border-strong-light: rgba(30, 38, 84, 0.22);
+  --border-strong-dark: rgba(120, 135, 208, 0.4);
+  --text-muted-light: rgba(8, 20, 47, 0.72);
+  --text-subtle-light: rgba(8, 20, 47, 0.56);
+  --text-muted-dark: rgba(230, 234, 255, 0.82);
+  --text-subtle-dark: rgba(230, 234, 255, 0.68);
+  --shadow-soft: 0 28px 60px rgba(15, 23, 42, 0.2);
+  --shadow-soft-dark: 0 36px 80px rgba(0, 0, 0, 0.65);
+  --shadow-medium: 0 22px 48px rgba(15, 23, 42, 0.18);
+  --shadow-medium-dark: 0 30px 56px rgba(0, 0, 0, 0.58);
+  --radius-sm: 14px;
+  --radius-md: 20px;
+  --radius-lg: 26px;
+  --radius-xl: 34px;
+  --content-max: min(420px, 100%);
+  --app-shell-max: min(420px, 100%);
+  --app-shell-spacing: clamp(1.1rem, 3.6vw, 1.6rem);
+  --app-shell-padding: clamp(1.6rem, 6vw, 2.6rem);
+  --app-shell-shadow: 0 30px 60px rgba(15, 23, 42, 0.22);
+  --app-shell-shadow-dark: 0 36px 78px rgba(0, 0, 0, 0.65);
+}
+
+body.dark-mode {
+  --card-bg-light: var(--card-bg-dark);
+  --surface-muted-light: var(--surface-muted-dark);
+  --surface-elevated-light: var(--surface-elevated-dark);
+  --glass-border: var(--glass-border-dark);
+  --border-strong-light: var(--border-strong-dark);
+  --text-muted-light: var(--text-muted-dark);
+  --text-subtle-light: var(--text-subtle-dark);
+  --shadow-soft: var(--shadow-soft-dark);
+  --shadow-medium: var(--shadow-medium-dark);
+}
+
+body {
+  min-height: 100dvh;
+  margin: 0;
+  padding: var(--app-shell-padding) clamp(0.9rem, 4vw, 1.6rem) clamp(5.8rem, 9vw, 6.8rem);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: clamp(1.2rem, 4vw, 2rem);
+  font-family: var(--font-sans, 'Inter', 'Segoe UI', system-ui, sans-serif);
+  background:
+    radial-gradient(130% 100% at -5% 0%, rgba(88, 128, 255, 0.35) 0%, rgba(88, 128, 255, 0) 60%),
+    radial-gradient(130% 120% at 105% -15%, rgba(255, 145, 163, 0.32) 0%, rgba(255, 145, 163, 0) 60%),
+    var(--background-light);
+  color: var(--foreground-light);
+  -webkit-font-smoothing: antialiased;
+  overflow-x: hidden;
+}
+
+body.dark-mode {
+  background:
+    radial-gradient(120% 100% at -10% -10%, rgba(82, 102, 255, 0.4) 0%, rgba(82, 102, 255, 0) 55%),
+    radial-gradient(120% 120% at 110% 0%, rgba(255, 113, 158, 0.35) 0%, rgba(255, 113, 158, 0) 55%),
+    var(--background-dark);
+  color: var(--foreground-dark);
+}
+
+body.high-contrast {
+  background: #ffffff;
+  color: #000000;
+}
+
+body.dark-mode.high-contrast {
+  background: #000000;
+  color: #ffffff;
+}
+
+#navbar-container,
+main,
+.site-footer,
+.auth-gate {
+  width: var(--app-shell-max);
+  max-width: var(--app-shell-max);
+}
+
+#navbar-container,
+main,
+.site-footer {
+  margin-inline: auto;
+}
+
+main {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1rem, 3vw, 1.6rem);
+  padding: 0;
+}
+
+main > section,
+main > article,
+main > .card {
+  width: 100%;
+  box-sizing: border-box;
+}
+
+[class$="shell"],
+[class$="page"],
+.dashboard {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.1rem, 3.6vw, 1.7rem);
+  margin: 0;
+  padding: 0;
+}
+
+.skip-link {
+  left: 50%;
+  transform: translateX(-50%);
+  top: clamp(0.6rem, 3vw, 1rem);
+  z-index: 1400;
+}
+
+h1,
+h2,
+h3,
+h4 {
+  color: inherit;
+  line-height: 1.2;
+  letter-spacing: -0.01em;
+  margin-block: 0 0.4rem;
+}
+
+p {
+  margin: 0;
+  color: var(--text-muted-light);
+}
+
+body.dark-mode p {
+  color: var(--text-muted-dark);
+}
+
+a {
+  color: var(--accent-blue);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+a:hover,
+a:focus-visible {
+  text-decoration: underline;
+  text-decoration-thickness: 0.15em;
+  text-underline-offset: 0.2em;
+}
+
+button,
+input,
+select,
+textarea {
+  font-family: inherit;
+}
+
+.card,
+section.card {
+  background: var(--card-bg-light);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--glass-border);
+  box-shadow: var(--app-shell-shadow);
+  backdrop-filter: blur(18px);
+  padding: clamp(1.2rem, 4vw, 1.8rem);
+}
+
+body.dark-mode .card,
+body.dark-mode section.card {
+  background: var(--card-bg-dark);
+  border-color: var(--glass-border);
+  box-shadow: var(--app-shell-shadow-dark);
+}
+
+.badge,
+.chip,
+.tracking-chip,
+.network-chip,
+.dashboard-pill,
+.navbar__btn,
+.landing-hero__button,
+.planning-submit {
+  border-radius: 999px;
+}
+
+/* ------------------------------------------------------------
+   Navigation
+------------------------------------------------------------- */
+.navbar {
+  position: sticky;
+  top: clamp(0.6rem, 3vw, 1.1rem);
+  inset-inline: 0;
+  background: transparent;
+  border: none;
+  box-shadow: none;
+  padding: 0;
+  z-index: 1300;
+}
+
+.navbar__inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.8rem;
+  width: 100%;
+  padding: 0.85rem 1.1rem;
+  border-radius: var(--radius-lg);
+  background: var(--surface-elevated-light);
+  border: 1px solid var(--glass-border);
+  box-shadow: var(--app-shell-shadow);
+  backdrop-filter: blur(24px);
+}
+
+body.dark-mode .navbar__inner {
+  background: rgba(13, 18, 35, 0.92);
+  border-color: rgba(114, 130, 208, 0.32);
+  box-shadow: var(--app-shell-shadow-dark);
+}
+
+.navbar__brand {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  color: inherit;
+  text-decoration: none;
+}
+
+.navbar__brand img {
+  height: 32px;
+  width: 32px;
+  border-radius: 12px;
+  box-shadow: 0 8px 20px rgba(49, 79, 167, 0.2);
+}
+
+.navbar__brand-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.navbar__brand-name {
+  font-size: 1.05rem;
+  font-weight: 700;
+}
+
+.navbar__brand-tagline {
+  font-size: 0.68rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--text-subtle-light);
+}
+
+.navbar__desktop {
+  display: none !important;
+}
+
+.navbar__actions {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.navbar__auth {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.navbar__btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  padding: 0.5rem 1.05rem;
+  font-weight: 600;
+  border: 1px solid transparent;
+  background: rgba(50, 95, 255, 0.08);
+  color: var(--accent-blue);
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, color 0.2s ease;
+}
+
+.navbar__btn--primary {
+  background: linear-gradient(135deg, var(--accent-blue), var(--accent-red));
+  color: #fff;
+  box-shadow: 0 18px 38px rgba(50, 95, 255, 0.28);
+}
+
+.navbar__btn--ghost {
+  border-color: rgba(50, 95, 255, 0.28);
+  background: transparent;
+  color: var(--accent-blue);
+}
+
+.navbar__btn:hover,
+.navbar__btn:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 22px 44px rgba(50, 95, 255, 0.22);
+}
+
+.navbar__profile-toggle {
+  border-radius: 16px;
+  border: 1px solid rgba(50, 95, 255, 0.22);
+  background: rgba(50, 95, 255, 0.08);
+  padding: 0.45rem 0.9rem;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+}
+
+.navbar__toggle {
+  width: 42px;
+  height: 42px;
+  border-radius: 14px;
+  border: 1px solid rgba(50, 95, 255, 0.25);
+  background: linear-gradient(160deg, rgba(50, 95, 255, 0.12), rgba(255, 107, 129, 0.1));
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.navbar__toggle:hover,
+.navbar__toggle:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 20px 40px rgba(50, 95, 255, 0.28);
+}
+
+.navbar__toggle-bar {
+  width: 18px;
+  height: 2px;
+  border-radius: 999px;
+  background: currentColor;
+}
+
+.navbar__drawer {
+  position: fixed;
+  left: 50%;
+  bottom: clamp(1.2rem, 5vw, 2.4rem);
+  width: min(100% - clamp(1.8rem, 8vw, 3rem), var(--app-shell-max));
+  max-height: min(75dvh, 520px);
+  transform: translate(-50%, 120%);
+  transition: transform 0.35s cubic-bezier(.32, .94, .6, 1);
+  background: var(--surface-elevated-light);
+  border-radius: 28px;
+  border: 1px solid var(--glass-border);
+  box-shadow: 0 40px 90px rgba(10, 18, 42, 0.38);
+  padding-bottom: 1.2rem;
+  overflow: hidden;
+  z-index: 1400;
+}
+
+.navbar__drawer[data-open="true"] {
+  transform: translate(-50%, 0);
+}
+
+body.dark-mode .navbar__drawer {
+  background: rgba(13, 18, 35, 0.94);
+  border-color: rgba(114, 130, 208, 0.32);
+  box-shadow: 0 48px 100px rgba(0, 0, 0, 0.7);
+}
+
+.navbar__drawer-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.1rem 1.4rem 0.9rem;
+  font-weight: 700;
+  border-bottom: 1px solid rgba(50, 95, 255, 0.12);
+}
+
+.navbar__drawer-scroll {
+  padding: 1.1rem 1.4rem 1.6rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.4rem;
+  overflow-y: auto;
+  max-height: calc(min(75dvh, 520px) - 3.2rem);
+}
+
+.navbar__drawer-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.navbar__drawer-link {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  border-radius: 18px;
+  font-weight: 600;
+  color: inherit;
+  background: rgba(50, 95, 255, 0.08);
+}
+
+.navbar__drawer-link.is-active,
+.navbar__drawer-link[aria-current="page"] {
+  background: linear-gradient(120deg, rgba(50, 95, 255, 0.18), rgba(255, 107, 129, 0.18));
+  color: var(--accent-blue);
+  box-shadow: 0 18px 38px rgba(50, 95, 255, 0.25);
+}
+
+.navbar__drawer-section-title {
+  font-size: 0.78rem;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: var(--text-subtle-light);
+  margin-bottom: 0.6rem;
+}
+
+.navbar__drawer-buttons {
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+}
+
+.navbar__drawer-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 1.1rem;
+  border-radius: 16px;
+  border: 1px solid rgba(50, 95, 255, 0.22);
+  font-weight: 600;
+  background: rgba(50, 95, 255, 0.08);
+  color: var(--accent-blue);
+  text-decoration: none;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.navbar__drawer-button--primary {
+  background: linear-gradient(135deg, var(--accent-blue), var(--accent-red));
+  color: #fff;
+  border-color: transparent;
+  box-shadow: 0 20px 44px rgba(50, 95, 255, 0.28);
+}
+
+.navbar__drawer-button--ghost {
+  background: transparent;
+}
+
+.navbar__drawer-button:hover,
+.navbar__drawer-button:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 22px 46px rgba(50, 95, 255, 0.22);
+}
+
+.navbar__drawer-button--destructive {
+  border-color: rgba(244, 63, 94, 0.25);
+  color: #f43f5e;
+  background: rgba(244, 63, 94, 0.08);
+}
+
+.navbar__drawer-divider {
+  height: 1px;
+  background: rgba(50, 95, 255, 0.12);
+}
+
+.navbar__backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(5, 10, 25, 0.45);
+  backdrop-filter: blur(6px);
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.25s ease;
+  z-index: 1300;
+}
+
+.navbar__backdrop[data-visible="true"] {
+  opacity: 1;
+  visibility: visible;
+}
+
+/* ------------------------------------------------------------
+   Footer
+------------------------------------------------------------- */
+.site-footer {
+  background: var(--surface-elevated-light);
+  border: 1px solid var(--glass-border);
+  box-shadow: var(--app-shell-shadow);
+  border-radius: var(--radius-lg);
+  padding: clamp(1.4rem, 4vw, 1.8rem);
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+}
+
+body.dark-mode .site-footer {
+  background: rgba(13, 18, 35, 0.92);
+  border-color: rgba(114, 130, 208, 0.32);
+  box-shadow: var(--app-shell-shadow-dark);
+}
+
+.site-footer__inner {
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+}
+
+.site-footer__brand {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.site-footer__name {
+  font-weight: 700;
+  font-size: 1.1rem;
+}
+
+.site-footer__description {
+  color: var(--text-subtle-light);
+}
+
+.site-footer__nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 0.75rem;
+  font-weight: 600;
+}
+
+.site-footer__nav a {
+  padding: 0.45rem 0.8rem;
+  border-radius: 12px;
+  background: rgba(50, 95, 255, 0.08);
+}
+
+.site-footer__social {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.site-footer__social a {
+  width: 40px;
+  height: 40px;
+  border-radius: 14px;
+  background: rgba(50, 95, 255, 0.12);
+  display: grid;
+  place-items: center;
+  color: var(--accent-blue);
+}
+
+.site-footer__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+  color: var(--text-subtle-light);
+}
+
+/* ------------------------------------------------------------
+   Landing page
+------------------------------------------------------------- */
+.landing {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.1rem, 3.6vw, 1.7rem);
+}
+
+.landing-hero {
+  position: relative;
+  overflow: hidden;
+  color: #fff;
+  background: radial-gradient(circle at top left, rgba(255, 255, 255, 0.18) 0%, transparent 60%),
+              linear-gradient(140deg, rgba(50, 95, 255, 0.95), rgba(255, 107, 129, 0.95));
+  padding: clamp(1.6rem, 5vw, 2.2rem);
+  border-radius: var(--radius-lg);
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+}
+
+.landing-hero__content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+}
+
+.landing-hero__lead {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.landing-hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.landing-hero__button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.45rem;
+  padding: 0.75rem 1.4rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.18);
+  color: #fff;
+  box-shadow: 0 20px 46px rgba(0, 0, 0, 0.25);
+  text-decoration: none;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.landing-hero__button--primary {
+  background: #fff;
+  color: var(--accent-blue);
+  border-color: transparent;
+}
+
+.landing-hero__button:hover,
+.landing-hero__button:focus-visible {
+  transform: translateY(-3px);
+  box-shadow: 0 28px 60px rgba(0, 0, 0, 0.3);
+}
+
+.landing-hero__metrics {
+  display: flex;
+  gap: 0.7rem;
+  overflow-x: auto;
+  padding-bottom: 0.3rem;
+  margin: 0;
+}
+
+.landing-hero__metrics div {
+  min-width: 150px;
+  padding: 0.75rem 1rem;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.16);
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.landing-hero__preview {
+  background: rgba(255, 255, 255, 0.2);
+  border-radius: 22px;
+  padding: 1rem 1.2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  backdrop-filter: blur(20px);
+}
+
+.landing-panels,
+.landing-gamify__grid,
+.landing-devices,
+.landing-tools__grid,
+.landing-blog__grid,
+.landing-testimonials__grid,
+.landing-faq__grid {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.landing-panel,
+.landing-gamify__item,
+.landing-tool,
+.landing-blog__card,
+.landing-testimonial,
+.landing-faq__item {
+  background: var(--card-bg-light);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--glass-border);
+  padding: 1.2rem;
+  box-shadow: var(--app-shell-shadow);
+}
+
+body.dark-mode .landing-panel,
+body.dark-mode .landing-gamify__item,
+body.dark-mode .landing-tool,
+body.dark-mode .landing-blog__card,
+body.dark-mode .landing-testimonial,
+body.dark-mode .landing-faq__item {
+  background: var(--card-bg-dark);
+  border-color: var(--glass-border);
+}
+
+.landing-panel {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.landing-panel__icon {
+  width: 42px;
+  height: 42px;
+  border-radius: 14px;
+  display: grid;
+  place-items: center;
+  background: rgba(50, 95, 255, 0.12);
+  color: var(--accent-blue);
+}
+
+.landing-gamify__header,
+.landing-tools__header,
+.landing-blog__header,
+.landing-testimonials__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.landing-devices__card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.landing-devices__mock {
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+  background: var(--surface-elevated-light);
+  padding: 1.1rem;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--glass-border);
+}
+
+body.dark-mode .landing-devices__mock {
+  background: rgba(13, 18, 35, 0.92);
+}
+
+.landing-cta {
+  background: linear-gradient(135deg, rgba(50, 95, 255, 0.92), rgba(255, 107, 129, 0.92));
+  color: #fff;
+  text-align: center;
+  padding: clamp(1.6rem, 5vw, 2.2rem);
+  border-radius: var(--radius-lg);
+  box-shadow: 0 30px 60px rgba(0, 0, 0, 0.35);
+}
+
+.landing-cta a {
+  color: #fff;
+  text-decoration: underline;
+}
+
+/* ------------------------------------------------------------
+   Dashboard
+------------------------------------------------------------- */
+.dashboard {
+  gap: clamp(1rem, 3vw, 1.6rem);
+}
+
+.dashboard .card {
+  padding: clamp(1.2rem, 4vw, 1.7rem);
+}
+
+.dashboard-hero {
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+  background: linear-gradient(145deg, rgba(50, 95, 255, 0.92), rgba(20, 32, 86, 0.92));
+  color: #fff;
+  border-radius: var(--radius-lg);
+  padding: clamp(1.4rem, 4.6vw, 2.1rem);
+  box-shadow: 0 32px 66px rgba(0, 0, 0, 0.35);
+}
+
+.dashboard-hero__stats,
+.dashboard-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.dashboard-card__header {
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.dashboard-pill {
+  padding: 0.65rem 1.2rem;
+  background: rgba(255, 255, 255, 0.18);
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  color: #fff;
+}
+
+/* ------------------------------------------------------------
+   Tracking
+------------------------------------------------------------- */
+.tracking-shell {
+  gap: clamp(1rem, 3vw, 1.6rem);
+}
+
+.tracking-hero {
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+  background: linear-gradient(150deg, rgba(50, 95, 255, 0.94), rgba(44, 26, 88, 0.94));
+  color: #fff;
+  border-radius: var(--radius-lg);
+  padding: clamp(1.4rem, 4vw, 2rem);
+  overflow: hidden;
+}
+
+.tracking-hero__body {
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+}
+
+.tracking-hero__visual {
+  order: -1;
+}
+
+.tracking-hero__highlights {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin: 0;
+}
+
+.tracking-hero__highlights li {
+  display: flex;
+  gap: 0.7rem;
+  align-items: center;
+  padding: 0.75rem 1rem;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.16);
+}
+
+.tracking-layout {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.tracking-board__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.tracking-board__actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.tracking-search__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  align-items: flex-start;
+}
+
+/* ------------------------------------------------------------
+   Planning
+------------------------------------------------------------- */
+.planning-layout {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.planning-form,
+.planning-side__card,
+.planning-results {
+  padding: clamp(1.2rem, 4vw, 1.8rem);
+}
+
+.planning-form__row,
+.planning-checkboxes {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+/* ------------------------------------------------------------
+   Network / Routes
+------------------------------------------------------------- */
+.network-hero__stats,
+.network-toolbar,
+.network-filters {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.network-toolbar {
+  padding: clamp(1.2rem, 4vw, 1.6rem);
+}
+
+.routes-grid,
+.network-flow,
+.network-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+/* ------------------------------------------------------------
+   Profile & Settings
+------------------------------------------------------------- */
+.profile-shell,
+.settings-page,
+.fleet-page,
+.disruptions-page,
+.info-shell,
+.withdrawn-page {
+  gap: clamp(1rem, 3vw, 1.6rem);
+}
+
+.profile-hero,
+.fleet-hero {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  align-items: center;
+  text-align: center;
+}
+
+.profile-hero__actions,
+.fleet-controls__intro,
+.fleet-controls__grid,
+.profile-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  align-items: stretch;
+}
+
+.settings-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.setting-row {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0.75rem;
+}
+
+.settings-actions {
+  display: flex;
+  justify-content: center;
+}
+
+/* ------------------------------------------------------------
+   Utilities
+------------------------------------------------------------- */
+.landing-panel__icon i,
+.tracking-hero__highlight-icon i,
+.network-flow__link i,
+.site-footer__social i {
+  font-size: 1rem;
+}
+
+.auth-gate__panel {
+  max-width: var(--app-shell-max);
+}
+
+@media (min-width: 520px) {
+  .landing-hero__metrics {
+    justify-content: flex-start;
+  }
+}
+

--- a/site.js
+++ b/site.js
@@ -1,4 +1,18 @@
 (function initialiseSite() {
+  const MOBILE_STYLESHEET_ID = 'routeflow-mobile-shell';
+
+  const ensureMobileStylesheet = () => {
+    if (document.getElementById(MOBILE_STYLESHEET_ID)) {
+      return;
+    }
+    const link = document.createElement('link');
+    link.id = MOBILE_STYLESHEET_ID;
+    link.rel = 'stylesheet';
+    link.href = 'mobile-app.css';
+    link.media = 'all';
+    document.head.appendChild(link);
+  };
+
   const setCurrentYear = () => {
     const year = new Date().getFullYear();
     document.querySelectorAll('[data-current-year]').forEach(node => {
@@ -6,8 +20,13 @@
     });
   };
 
+  ensureMobileStylesheet();
+
   if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', setCurrentYear, { once: true });
+    document.addEventListener('DOMContentLoaded', () => {
+      ensureMobileStylesheet();
+      setCurrentYear();
+    }, { once: true });
   } else {
     setCurrentYear();
   }


### PR DESCRIPTION
## Summary
- add a dedicated `mobile-app.css` to transform every page into a mobile-styled app experience with new tokens, navigation, layout and card treatments
- update `site.js` to inject the mobile stylesheet automatically so every page shares the new design

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d039b707e88322b987269c46cfb148