### PR TITLE
Add persistent mobile app dock navigation

### DIFF
--- a/mobile-app.css
+++ b/mobile-app.css
@@ -43,6 +43,9 @@
   --app-shell-padding: clamp(1.6rem, 6vw, 2.6rem);
   --app-shell-shadow: 0 30px 60px rgba(15, 23, 42, 0.22);
   --app-shell-shadow-dark: 0 36px 78px rgba(0, 0, 0, 0.65);
+  --app-dock-height: clamp(4.8rem, 12vw, 5.6rem);
+  --app-dock-radius: 28px;
+  --app-dock-padding: clamp(0.45rem, 2vw, 0.7rem);
 }
 
 body.dark-mode {
@@ -60,7 +63,10 @@ body.dark-mode {
 body {
   min-height: 100dvh;
   margin: 0;
-  padding: var(--app-shell-padding) clamp(0.9rem, 4vw, 1.6rem) clamp(5.8rem, 9vw, 6.8rem);
+  padding:
+    calc(var(--app-shell-padding) + env(safe-area-inset-top, 0px))
+    clamp(0.9rem, 4vw, 1.6rem)
+    calc(max(var(--app-dock-height), clamp(5.8rem, 9vw, 6.8rem)) + env(safe-area-inset-bottom, 0px));
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -91,6 +97,10 @@ body.high-contrast {
 body.dark-mode.high-contrast {
   background: #000000;
   color: #ffffff;
+}
+
+body[data-disable-app-dock='true'] {
+  padding-bottom: calc(var(--app-shell-padding) + env(safe-area-inset-bottom, 0px));
 }
 
 #navbar-container,
@@ -504,6 +514,163 @@ body.dark-mode .navbar__drawer {
 }
 
 /* ------------------------------------------------------------
+   App dock
+------------------------------------------------------------- */
+.app-dock {
+  position: fixed;
+  left: 50%;
+  bottom: calc(env(safe-area-inset-bottom, 0px) + clamp(0.9rem, 3.6vw, 1.8rem));
+  transform: translateX(-50%);
+  width: min(100% - clamp(1.8rem, 8vw, 3rem), var(--app-shell-max));
+  padding: var(--app-dock-padding);
+  border-radius: var(--app-dock-radius);
+  background: var(--surface-elevated-light);
+  border: 1px solid var(--glass-border);
+  box-shadow: var(--app-shell-shadow);
+  backdrop-filter: blur(24px);
+  display: flex;
+  z-index: 1350;
+  transition: transform 0.3s ease, opacity 0.3s ease, box-shadow 0.3s ease;
+}
+
+body.dark-mode .app-dock {
+  background: rgba(13, 18, 35, 0.94);
+  border-color: rgba(114, 130, 208, 0.32);
+  box-shadow: var(--app-shell-shadow-dark);
+}
+
+body.high-contrast .app-dock {
+  background: #ffffff;
+  border-color: currentColor;
+  box-shadow: none;
+  color: #000000;
+}
+
+body.dark-mode.high-contrast .app-dock {
+  background: #000000;
+  color: #ffffff;
+  border-color: currentColor;
+}
+
+.app-dock__list {
+  --app-dock-count: 4;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  width: 100%;
+  grid-template-columns: repeat(var(--app-dock-count), minmax(0, 1fr));
+  gap: clamp(0.25rem, 2vw, 0.4rem);
+}
+
+.app-dock__item {
+  display: flex;
+}
+
+.app-dock__link {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.35rem;
+  padding: clamp(0.55rem, 2vw, 0.75rem) clamp(0.35rem, 2vw, 0.6rem);
+  border-radius: calc(var(--app-dock-radius) - 8px);
+  color: var(--text-subtle-light);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  text-decoration: none;
+  line-height: 1.1;
+  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+body.dark-mode .app-dock__link {
+  color: var(--text-subtle-dark);
+}
+
+.app-dock__icon {
+  display: grid;
+  place-items: center;
+  width: 2.4rem;
+  height: 2.4rem;
+  font-size: 1.25rem;
+  color: var(--text-muted-light);
+  transition: transform 0.2s ease, color 0.2s ease;
+}
+
+body.dark-mode .app-dock__icon {
+  color: var(--text-muted-dark);
+}
+
+.app-dock__icon i {
+  pointer-events: none;
+}
+
+.app-dock__label {
+  pointer-events: none;
+  text-align: center;
+}
+
+.app-dock__link:hover,
+.app-dock__link:focus-visible {
+  color: var(--accent-blue);
+}
+
+.app-dock__link:hover .app-dock__icon,
+.app-dock__link:focus-visible .app-dock__icon {
+  transform: translateY(-2px);
+  color: var(--accent-blue);
+}
+
+.app-dock__link[aria-current="page"],
+.app-dock__link.is-active {
+  background: linear-gradient(130deg, rgba(50, 95, 255, 0.2), rgba(255, 107, 129, 0.2));
+  color: var(--accent-blue);
+  box-shadow: 0 20px 38px rgba(50, 95, 255, 0.22);
+}
+
+.app-dock__link[aria-current="page"] .app-dock__icon,
+.app-dock__link.is-active .app-dock__icon {
+  transform: translateY(-2px);
+  color: var(--accent-blue);
+}
+
+.app-dock__link:focus-visible {
+  outline: 3px solid rgba(50, 95, 255, 0.45);
+  outline-offset: 3px;
+}
+
+body[data-disable-app-dock='true'] .app-dock {
+  display: none !important;
+}
+
+body.high-contrast .app-dock__link[aria-current="page"],
+body.high-contrast .app-dock__link.is-active {
+  background: currentColor;
+  color: #000000;
+}
+
+body.dark-mode.high-contrast .app-dock__link[aria-current="page"],
+body.dark-mode.high-contrast .app-dock__link.is-active {
+  color: #ffffff;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .app-dock,
+  .app-dock * {
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+  }
+}
+
+@media print {
+  .app-dock {
+    display: none !important;
+  }
+}
+
+/* ------------------------------------------------------------
    Footer
 ------------------------------------------------------------- */
 .site-footer {
@@ -515,6 +682,7 @@ body.dark-mode .navbar__drawer {
   display: flex;
   flex-direction: column;
   gap: 1.2rem;
+  margin-bottom: clamp(1.6rem, 5vw, 2.4rem);
 }
 
 body.dark-mode .site-footer {

--- a/site.js
+++ b/site.js
@@ -1,5 +1,40 @@
 (function initialiseSite() {
   const MOBILE_STYLESHEET_ID = 'routeflow-mobile-shell';
+  const APP_DOCK_ID = 'routeflow-app-dock';
+  const APP_DOCK_ITEMS = [
+    {
+      href: 'index.html',
+      label: 'Home',
+      icon: 'fa-solid fa-house',
+      matches: ['index.html', 'about.html', 'contact.html']
+    },
+    {
+      href: 'tracking.html',
+      label: 'Live',
+      icon: 'fa-solid fa-wifi',
+      matches: ['tracking.html', 'disruptions.html']
+    },
+    {
+      href: 'planning.html',
+      label: 'Plan',
+      icon: 'fa-solid fa-route',
+      matches: ['planning.html']
+    },
+    {
+      href: 'routes.html',
+      label: 'Explore',
+      icon: 'fa-solid fa-layer-group',
+      matches: ['routes.html', 'info.html', 'withdrawn.html', 'withdrawn table.html', 'fleet.html']
+    },
+    {
+      href: 'dashboard.html',
+      label: 'Account',
+      icon: 'fa-solid fa-circle-user',
+      matches: ['dashboard.html', 'profile.html', 'settings.html', 'admin.html', 'privacy.html', 'terms.html', 'password-reset.html']
+    }
+  ];
+
+  let appDockInitialised = false;
 
   const ensureMobileStylesheet = () => {
     if (document.getElementById(MOBILE_STYLESHEET_ID)) {
@@ -15,19 +50,189 @@
 
   const setCurrentYear = () => {
     const year = new Date().getFullYear();
-    document.querySelectorAll('[data-current-year]').forEach(node => {
+    document.querySelectorAll('[data-current-year]').forEach((node) => {
       node.textContent = year;
     });
   };
 
+  const normalisePath = (value) => {
+    if (typeof value !== 'string') {
+      return '';
+    }
+    return decodeURIComponent(value.trim().toLowerCase());
+  };
+
+  const currentPageName = () => {
+    const path = window.location?.pathname || '';
+    const segments = path.split('/').filter(Boolean);
+    const last = segments.pop();
+    if (!last) {
+      return 'index.html';
+    }
+    return normalisePath(last);
+  };
+
+  const buildDock = () => {
+    if (!document.body) {
+      return null;
+    }
+
+    const nav = document.createElement('nav');
+    nav.id = APP_DOCK_ID;
+    nav.className = 'app-dock';
+    nav.setAttribute('aria-label', 'RouteFlow quick navigation');
+    nav.dataset.appDock = 'true';
+
+    const list = document.createElement('ul');
+    list.className = 'app-dock__list';
+    list.setAttribute('role', 'list');
+
+    APP_DOCK_ITEMS.forEach((item) => {
+      const matches = Array.isArray(item.matches) && item.matches.length
+        ? item.matches
+        : [item.href];
+      const normalisedMatches = Array.from(new Set(matches
+        .map((match) => {
+          const segment = (match || '').toString().split('/').pop() || match;
+          return normalisePath(segment);
+        })
+        .filter(Boolean)));
+
+      const listItem = document.createElement('li');
+      listItem.className = 'app-dock__item';
+
+      const link = document.createElement('a');
+      link.className = 'app-dock__link';
+      link.href = item.href;
+      link.setAttribute('aria-label', item.label);
+      link.setAttribute('data-app-dock-link', item.href);
+      link.dataset.appDockMatches = normalisedMatches.join(',');
+
+      const iconWrapper = document.createElement('span');
+      iconWrapper.className = 'app-dock__icon';
+      if (item.icon) {
+        const icon = document.createElement('i');
+        icon.className = item.icon;
+        icon.setAttribute('aria-hidden', 'true');
+        iconWrapper.appendChild(icon);
+      }
+
+      const label = document.createElement('span');
+      label.className = 'app-dock__label';
+      label.textContent = item.label;
+
+      link.append(iconWrapper, label);
+      listItem.appendChild(link);
+      list.appendChild(listItem);
+    });
+
+    nav.appendChild(list);
+    nav.style.setProperty('--app-dock-count', String(APP_DOCK_ITEMS.length));
+    return nav;
+  };
+
+  const updateDockActiveState = (dock) => {
+    if (!dock) {
+      return;
+    }
+    const current = currentPageName();
+    dock.querySelectorAll('[data-app-dock-link]').forEach((link) => {
+      const matches = (link.dataset.appDockMatches || '')
+        .split(',')
+        .map((value) => normalisePath(value))
+        .filter(Boolean);
+      if (!matches.length) {
+        const fallback = normalisePath((link.getAttribute('href') || '').split('/').pop() || '');
+        if (fallback) {
+          matches.push(fallback);
+        }
+      }
+      const isActive = matches.includes(current);
+      link.classList.toggle('is-active', isActive);
+      if (isActive) {
+        link.setAttribute('aria-current', 'page');
+      } else {
+        link.removeAttribute('aria-current');
+      }
+    });
+  };
+
+  const ensureAppDock = () => {
+    if (!document.body) {
+      return;
+    }
+
+    if (document.body.dataset.disableAppDock === 'true') {
+      const existing = document.getElementById(APP_DOCK_ID);
+      if (existing) {
+        existing.remove();
+      }
+      delete document.body.dataset.hasAppDock;
+      return;
+    }
+
+    let dock = document.getElementById(APP_DOCK_ID);
+    let created = false;
+
+    if (!dock) {
+      dock = buildDock();
+      if (!dock) {
+        return;
+      }
+      document.body.appendChild(dock);
+      created = true;
+    }
+
+    document.body.dataset.hasAppDock = 'true';
+    dock.style.setProperty('--app-dock-count', String(APP_DOCK_ITEMS.length));
+    updateDockActiveState(dock);
+
+    if (created && !appDockInitialised) {
+      appDockInitialised = true;
+      try {
+        document.dispatchEvent(new CustomEvent('routeflow:app-dock-ready', { detail: { dock } }));
+      } catch (error) {
+        console.warn('RouteFlow site: failed to announce app dock readiness.', error);
+      }
+    }
+  };
+
+  const handleLocationChange = () => {
+    const dock = document.getElementById(APP_DOCK_ID);
+    if (!dock) {
+      ensureAppDock();
+      return;
+    }
+    updateDockActiveState(dock);
+  };
+
   ensureMobileStylesheet();
+  ensureAppDock();
 
   if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', () => {
       ensureMobileStylesheet();
       setCurrentYear();
+      ensureAppDock();
     }, { once: true });
   } else {
     setCurrentYear();
+    ensureAppDock();
   }
+
+  window.addEventListener('hashchange', handleLocationChange);
+  window.addEventListener('popstate', handleLocationChange);
+  document.addEventListener('routeflow:page-changed', handleLocationChange);
+
+  document.addEventListener('click', (event) => {
+    const link = event.target.closest('[data-app-dock-link]');
+    if (!link) {
+      return;
+    }
+    const dock = document.getElementById(APP_DOCK_ID);
+    if (!dock) {
+      return;
+    }
+    requestAnimationFrame(() => updateDockActiveState(dock));
+  });
 })();


### PR DESCRIPTION
## Summary
- introduce safe area aware spacing tokens in the mobile shell and adjust page padding to suit a bottom navigation surface
- add a glassmorphism-inspired floating app dock with accessible focus states and high-contrast support
- bootstrap the dock from `site.js`, tracking the current page and exposing a readiness event for other scripts

## Testing
- not run (static assets only)


------
https://chatgpt.com/codex/tasks/task_e_68d03e5e644c8322b2a6ade5434206e1