### PR TITLE
Improve navigation clarity and layout responsiveness

### DIFF
--- a/about.html
+++ b/about.html
@@ -12,7 +12,6 @@
   <script src="site.js" defer></script>
 </head>
 <body>
-  <a class="skip-link" href="#main-content">Skip to main content</a>
   <div id="navbar-container"></div>
 
   <main id="main-content" class="page-shell" aria-labelledby="aboutTitle">

--- a/admin.html
+++ b/admin.html
@@ -14,7 +14,6 @@
   <script src="site.js" defer></script>
 </head>
 <body>
-  <a class="skip-link" href="#adminContent">Skip to admin console</a>
   <div id="navbar-container"></div>
   <main id="adminContent" class="admin-page" aria-live="polite"></main>
   <footer class="site-footer" aria-label="Footer">

--- a/contact.html
+++ b/contact.html
@@ -12,7 +12,6 @@
   <script src="site.js" defer></script>
 </head>
 <body>
-  <a class="skip-link" href="#main-content">Skip to main content</a>
   <div id="navbar-container"></div>
 
   <main id="main-content" class="page-shell" aria-labelledby="contactTitle">

--- a/dashboard.html
+++ b/dashboard.html
@@ -13,7 +13,6 @@
   <script src="site.js" defer></script>
 </head>
 <body>
-  <a class="skip-link" href="#main-content">Skip to main content</a>
   <div id="navbar-container"></div>
   <section
     class="auth-gate"

--- a/disruptions.html
+++ b/disruptions.html
@@ -12,7 +12,6 @@
   <script src="site.js" defer></script>
 </head>
 <body>
-  <a class="skip-link" href="#main-content">Skip to main content</a>
   <div id="navbar-container"></div>
   <main id="main-content" class="network-shell">
     <section class="network-hero">

--- a/fleet.html
+++ b/fleet.html
@@ -23,7 +23,6 @@
     <script src="site.js" defer></script>
   </head>
   <body>
-    <a class="skip-link" href="#fleetMain">Skip to fleet tools</a>
     <div id="navbar-container"></div>
     <section
       class="auth-gate"

--- a/index.html
+++ b/index.html
@@ -12,7 +12,6 @@
   <script src="site.js" defer></script>
 </head>
 <body>
-  <a class="skip-link" href="#main-content">Skip to main content</a>
   <div id="navbar-container"></div>
 
   <main id="main-content" class="landing" aria-labelledby="landing-title">

--- a/info.html
+++ b/info.html
@@ -12,7 +12,6 @@
   <script src="site.js" defer></script>
 </head>
 <body>
-  <a class="skip-link" href="#main-content">Skip to main content</a>
   <div id="navbar-container"></div>
 
   <main id="main-content" class="blog-shell" aria-labelledby="infoTitle">

--- a/mobile-app.css
+++ b/mobile-app.css
@@ -37,8 +37,8 @@
   --radius-md: 20px;
   --radius-lg: 26px;
   --radius-xl: 34px;
-  --content-max: min(420px, 100%);
-  --app-shell-max: min(420px, 100%);
+  --content-max: min(1200px, 100vw - clamp(1.5rem, 4vw, 3rem));
+  --app-shell-max: min(1200px, 100vw - clamp(1.5rem, 4vw, 3rem));
   --app-shell-spacing: clamp(1.1rem, 3.6vw, 1.6rem);
   --app-shell-padding: clamp(1.6rem, 6vw, 2.6rem);
   --app-shell-shadow: 0 30px 60px rgba(15, 23, 42, 0.22);
@@ -103,7 +103,11 @@ body[data-disable-app-dock='true'] {
   padding-bottom: calc(var(--app-shell-padding) + env(safe-area-inset-bottom, 0px));
 }
 
-#navbar-container,
+#navbar-container {
+  width: 100%;
+  max-width: none;
+}
+
 main,
 .site-footer,
 .auth-gate {
@@ -111,7 +115,6 @@ main,
   max-width: var(--app-shell-max);
 }
 
-#navbar-container,
 main,
 .site-footer {
   margin-inline: auto;
@@ -162,11 +165,11 @@ h4 {
 
 p {
   margin: 0;
-  color: var(--text-muted-light);
+  color: var(--foreground-light);
 }
 
 body.dark-mode p {
-  color: var(--text-muted-dark);
+  color: var(--foreground-dark);
 }
 
 a {

--- a/navbar.css
+++ b/navbar.css
@@ -116,7 +116,7 @@ body.dark-mode .navbar {
   border-radius: 999px;
   font-size: 0.98rem;
   font-weight: 600;
-  color: var(--navbar-muted);
+  color: var(--navbar-text);
   text-decoration: none;
   transition: color 0.16s ease, background-color 0.16s ease, box-shadow 0.16s ease;
 }

--- a/password-reset.html
+++ b/password-reset.html
@@ -12,7 +12,6 @@
   <script src="site.js" defer></script>
 </head>
 <body>
-  <a class="skip-link" href="#main-content">Skip to reset form</a>
   <div id="navbar-container"></div>
 
   <main id="main-content" class="page-shell" aria-labelledby="resetTitle">

--- a/planning.html
+++ b/planning.html
@@ -13,7 +13,6 @@
   <script src="site.js" defer></script>
 </head>
 <body>
-  <a class="skip-link" href="#main-content">Skip to main content</a>
   <div id="navbar-container"></div>
 
   <main id="main-content" class="planning-shell" aria-labelledby="planningTitle">

--- a/privacy.html
+++ b/privacy.html
@@ -12,7 +12,6 @@
   <script src="site.js" defer></script>
 </head>
 <body>
-  <a class="skip-link" href="#main-content">Skip to main content</a>
   <div id="navbar-container"></div>
 
   <main id="main-content" class="page-shell legal-shell" aria-labelledby="privacyTitle">

--- a/profile.html
+++ b/profile.html
@@ -12,7 +12,6 @@
   <script src="site.js" defer></script>
 </head>
 <body>
-  <a class="skip-link" href="#profileMain">Skip to profile content</a>
   <div id="navbar-container"></div>
   <main id="profileMain" class="profile-shell" aria-live="polite">
     <section class="profile-hero card" id="profileHero">

--- a/routes.html
+++ b/routes.html
@@ -13,7 +13,6 @@
   <script src="site.js" defer></script>
 </head>
 <body>
-  <a class="skip-link" href="#main-content">Skip to main content</a>
   <div id="navbar-container"></div>
 
   <main id="main-content" class="network-shell" aria-labelledby="routesTitle">

--- a/settings.html
+++ b/settings.html
@@ -13,7 +13,6 @@
   <script src="settings.js" defer></script>
 </head>
 <body>
-  <a class="skip-link" href="#main-content">Skip to main content</a>
   <div id="navbar-container"></div>
   <main id="main-content" class="settings-page" aria-labelledby="settingsTitle">
     <h1 id="settingsTitle">Settings</h1>

--- a/site.js
+++ b/site.js
@@ -21,12 +21,6 @@
       matches: ['planning.html']
     },
     {
-      href: 'routes.html',
-      label: 'Explore',
-      icon: 'fa-solid fa-layer-group',
-      matches: ['routes.html', 'info.html', 'withdrawn.html', 'withdrawn table.html', 'fleet.html']
-    },
-    {
       href: 'dashboard.html',
       label: 'Account',
       icon: 'fa-solid fa-circle-user',
@@ -36,6 +30,8 @@
 
   let appDockInitialised = false;
 
+  const MOBILE_DOCK_QUERY = window.matchMedia('(max-width: 900px)');
+
   const ensureMobileStylesheet = () => {
     if (document.getElementById(MOBILE_STYLESHEET_ID)) {
       return;
@@ -44,7 +40,7 @@
     link.id = MOBILE_STYLESHEET_ID;
     link.rel = 'stylesheet';
     link.href = 'mobile-app.css';
-    link.media = 'all';
+    link.media = 'screen and (max-width: 900px)';
     document.head.appendChild(link);
   };
 
@@ -162,6 +158,17 @@
       return;
     }
 
+    const prefersMobileDock = MOBILE_DOCK_QUERY.matches;
+
+    if (!prefersMobileDock) {
+      const existing = document.getElementById(APP_DOCK_ID);
+      if (existing) {
+        existing.remove();
+      }
+      delete document.body.dataset.hasAppDock;
+      return;
+    }
+
     if (document.body.dataset.disableAppDock === 'true') {
       const existing = document.getElementById(APP_DOCK_ID);
       if (existing) {
@@ -223,6 +230,16 @@
   window.addEventListener('hashchange', handleLocationChange);
   window.addEventListener('popstate', handleLocationChange);
   document.addEventListener('routeflow:page-changed', handleLocationChange);
+
+  const handleViewportChange = () => {
+    ensureAppDock();
+  };
+
+  if (typeof MOBILE_DOCK_QUERY.addEventListener === 'function') {
+    MOBILE_DOCK_QUERY.addEventListener('change', handleViewportChange);
+  } else if (typeof MOBILE_DOCK_QUERY.addListener === 'function') {
+    MOBILE_DOCK_QUERY.addListener(handleViewportChange);
+  }
 
   document.addEventListener('click', (event) => {
     const link = event.target.closest('[data-app-dock-link]');

--- a/terms.html
+++ b/terms.html
@@ -12,7 +12,6 @@
   <script src="site.js" defer></script>
 </head>
 <body>
-  <a class="skip-link" href="#main-content">Skip to main content</a>
   <div id="navbar-container"></div>
 
   <main id="main-content" class="page-shell legal-shell" aria-labelledby="termsTitle">

--- a/tracking.html
+++ b/tracking.html
@@ -23,7 +23,6 @@
     <script src="site.js" defer></script>
   </head>
   <body>
-    <a class="skip-link" href="#main-content">Skip to main content</a>
     <div id="navbar-container"></div>
 
     <main

--- a/withdrawn table.html
+++ b/withdrawn table.html
@@ -14,7 +14,6 @@
   <script src="site.js" defer></script>
 </head>
 <body>
-  <a class="skip-link" href="#main-content">Skip to main content</a>
   <div id="navbar-container"></div>
   <main id="main-content" class="network-shell" aria-labelledby="withdrawnTitle">
     <section class="network-hero">

--- a/withdrawn.html
+++ b/withdrawn.html
@@ -14,7 +14,6 @@
   <script src="site.js" defer></script>
 </head>
 <body>
-  <a class="skip-link" href="#main-content">Skip to main content</a>
   <div id="navbar-container"></div>
   <main id="main-content" class="network-shell" aria-labelledby="withdrawnTitle">
     <section class="network-hero">


### PR DESCRIPTION
## Summary
- widen the mobile shell layout so the navbar and content render at full width and improve body copy contrast
- remove skip-to-content anchors from each page and brighten navbar links for better readability
- limit the floating app dock to small screens, drop the Explore shortcut, and make the mobile stylesheet conditional

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d04a132970832298027e25fbb844b6