### PR TITLE
Simplify palette and unlock fleet tools

### DIFF
--- a/components/navbar.html
+++ b/components/navbar.html
@@ -34,14 +34,14 @@
             <span class="navbar__profile-avatar" aria-hidden="true">
               <i class="fa-regular fa-circle-user"></i>
             </span>
-            <span class="navbar__profile-label" data-profile-label>Account</span>
+            <span class="navbar__profile-label" data-profile-label>Welcome</span>
             <span class="navbar__profile-chevron" aria-hidden="true">
               <i class="fa-solid fa-chevron-down"></i>
             </span>
           </button>
           <div class="navbar__profile-menu" data-profile-menu aria-hidden="true" data-open="false">
             <header class="navbar__profile-header">
-              <span class="navbar__profile-name" data-profile-name>Account</span>
+              <span class="navbar__profile-name" data-profile-name>Welcome</span>
               <span class="navbar__profile-email" data-profile-email hidden aria-hidden="true"></span>
             </header>
             <nav class="navbar__profile-panel" aria-label="Account menu" role="menu">
@@ -97,7 +97,7 @@
             <i class="fa-regular fa-circle-user"></i>
           </div>
           <div class="navbar__drawer-profile-text">
-            <span class="navbar__drawer-profile-name" data-profile-name>Account</span>
+            <span class="navbar__drawer-profile-name" data-profile-name>Welcome</span>
             <span class="navbar__drawer-profile-email" data-profile-email hidden aria-hidden="true"></span>
           </div>
         </div>

--- a/fleet.html
+++ b/fleet.html
@@ -45,7 +45,7 @@
       </div>
     </section>
 
-    <main id="fleetMain" class="fleet-page" data-auth-locked="true">
+    <main id="fleetMain" class="fleet-page">
       <section class="fleet-card fleet-hero" data-locked-section data-lock-label="Sign in">
         <div class="fleet-hero__heading">
           <p class="fleet-hero__eyebrow">Fleet database</p>
@@ -514,11 +514,19 @@
           }
         });
 
+        gate?.unlock({ reason: 'public', force: true });
+        if (heroLead) {
+          heroLead.textContent = 'Explore the full RouteFlow fleet catalogue. Sign in to contribute updates and manage submissions.';
+        }
+
         const handleAuthStateChange = (user) => {
           if (user) {
             gate?.unlock({ user });
           } else {
-            gate?.lock({ reason: 'signed-out', force: true });
+            gate?.unlock({ reason: 'public', force: true });
+            if (heroLead) {
+              heroLead.textContent = 'Explore the full RouteFlow fleet catalogue. Sign in to contribute updates and manage submissions.';
+            }
           }
         };
 

--- a/navbar-loader.js
+++ b/navbar-loader.js
@@ -84,14 +84,19 @@
 
   function applySummaryToNavbar(navRoot, summary) {
     if (!navRoot) return;
-    const displayName = summary?.displayName || summary?.email || 'Account';
+    const email = typeof summary?.email === 'string' ? summary.email.trim() : '';
+    const preferredName = summary?.displayName?.trim();
+    const fallbackName = email ? email.split('@')[0] : '';
+    const rawName = preferredName || fallbackName;
+    const displayName = rawName || 'Explorer';
+    const greeting = `Welcome, ${displayName}`;
 
     navRoot.querySelectorAll('[data-profile-label]').forEach((label) => {
-      label.textContent = displayName;
+      label.textContent = greeting;
     });
 
     navRoot.querySelectorAll('[data-profile-name]').forEach((label) => {
-      label.textContent = displayName;
+      label.textContent = greeting;
     });
 
     navRoot.querySelectorAll('[data-profile-email]').forEach((emailEl) => {

--- a/navbar.css
+++ b/navbar.css
@@ -1,14 +1,14 @@
 :root {
-  --navbar-bg: rgba(255, 255, 255, 0.85);
-  --navbar-text: #111935;
-  --navbar-muted: rgba(17, 25, 53, 0.64);
-  --navbar-accent: #155eef;
-  --navbar-accent-dark: #0f4ad0;
-  --navbar-border: rgba(17, 25, 53, 0.08);
-  --navbar-shadow: 0 20px 60px rgba(15, 23, 42, 0.14);
+  --navbar-bg: rgba(255, 255, 255, 0.95);
+  --navbar-text: #0b1f4b;
+  --navbar-muted: rgba(11, 31, 75, 0.64);
+  --navbar-accent: #003688;
+  --navbar-accent-dark: #002a5c;
+  --navbar-border: rgba(0, 54, 136, 0.16);
+  --navbar-shadow: 0 18px 48px rgba(0, 54, 136, 0.18);
   --navbar-radius: 18px;
-  --navbar-drawer-bg: rgba(255, 255, 255, 0.96);
-  --navbar-drawer-border: rgba(17, 24, 39, 0.12);
+  --navbar-drawer-bg: rgba(255, 255, 255, 0.98);
+  --navbar-drawer-border: rgba(0, 54, 136, 0.16);
 }
 
 [hidden] {
@@ -38,22 +38,15 @@
   box-shadow: var(--navbar-shadow);
   color: var(--navbar-text);
   font-family: 'Inter', 'Segoe UI', system-ui, sans-serif;
-}
-
-body.dark-mode .navbar {
-  --navbar-bg: rgba(7, 11, 22, 0.88);
-  --navbar-text: #f6f7ff;
-  --navbar-muted: rgba(246, 247, 255, 0.7);
-  --navbar-border: rgba(119, 131, 182, 0.22);
-  --navbar-shadow: 0 24px 60px rgba(0, 0, 0, 0.55);
-  --navbar-drawer-bg: rgba(7, 11, 22, 0.94);
-  --navbar-drawer-border: rgba(129, 140, 248, 0.32);
+  width: 100%;
+  left: 0;
+  right: 0;
 }
 
 .navbar__inner {
-  width: min(1200px, 100vw - clamp(2rem, 7vw, 6rem));
+  width: min(1200px, 100%);
   margin: 0 auto;
-  padding: clamp(0.8rem, 2vw, 1.1rem) clamp(0.5rem, 3vw, 1rem);
+  padding: clamp(0.8rem, 2vw, 1.1rem) clamp(1rem, 4vw, 2rem);
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -124,7 +117,7 @@ body.dark-mode .navbar {
 .navbar__link:hover,
 .navbar__drawer-link:hover {
   color: var(--navbar-accent);
-  background: rgba(21, 94, 239, 0.12);
+  background: rgba(0, 54, 136, 0.12);
 }
 
 .navbar__link.is-active,
@@ -132,8 +125,8 @@ body.dark-mode .navbar {
 .navbar__drawer-link.is-active,
 .navbar__drawer-link[aria-current="page"] {
   color: var(--navbar-text);
-  background: rgba(21, 94, 239, 0.18);
-  box-shadow: 0 14px 28px rgba(21, 94, 239, 0.24);
+  background: rgba(211, 47, 47, 0.15);
+  box-shadow: 0 14px 28px rgba(211, 47, 47, 0.24);
 }
 
 .navbar__actions {
@@ -160,25 +153,25 @@ body.dark-mode .navbar {
 }
 
 .navbar__btn--ghost {
-  background: rgba(17, 25, 53, 0.05);
-  border-color: rgba(17, 25, 53, 0.08);
+  background: rgba(0, 54, 136, 0.08);
+  border-color: rgba(0, 54, 136, 0.12);
   color: var(--navbar-text);
 }
 
 .navbar__btn--ghost:hover,
 .navbar__btn--ghost:focus-visible {
-  background: rgba(17, 25, 53, 0.12);
+  background: rgba(0, 54, 136, 0.16);
 }
 
 .navbar__btn--primary {
-  background: var(--navbar-accent);
+  background: var(--accent-red, #d32f2f);
   color: #fff;
-  box-shadow: 0 16px 28px rgba(21, 94, 239, 0.24);
+  box-shadow: 0 16px 28px rgba(211, 47, 47, 0.28);
 }
 
 .navbar__btn--primary:hover,
 .navbar__btn--primary:focus-visible {
-  background: var(--navbar-accent-dark);
+  background: var(--accent-red-dark, #a61c1c);
 }
 
 .navbar__profile {
@@ -189,9 +182,9 @@ body.dark-mode .navbar {
   display: inline-flex;
   align-items: center;
   gap: 0.55rem;
-  border: 1px solid rgba(17, 25, 53, 0.12);
+  border: 1px solid rgba(0, 54, 136, 0.14);
   border-radius: 999px;
-  background: rgba(17, 25, 53, 0.05);
+  background: rgba(0, 54, 136, 0.08);
   padding: 0.5rem 0.9rem 0.5rem 0.6rem;
   font-weight: 600;
   color: var(--navbar-text);
@@ -201,8 +194,8 @@ body.dark-mode .navbar {
 
 .navbar__profile-toggle:hover,
 .navbar__profile-toggle:focus-visible {
-  border-color: rgba(21, 94, 239, 0.45);
-  background: rgba(21, 94, 239, 0.12);
+  border-color: rgba(0, 54, 136, 0.35);
+  background: rgba(0, 54, 136, 0.16);
 }
 
 .navbar__profile-menu {
@@ -213,7 +206,7 @@ body.dark-mode .navbar {
   background: var(--card-bg-light);
   border-radius: var(--navbar-radius);
   border: 1px solid var(--glass-border);
-  box-shadow: 0 20px 60px rgba(17, 24, 39, 0.15);
+  box-shadow: 0 20px 60px rgba(0, 54, 136, 0.18);
   padding: 1rem;
   display: grid;
   gap: 0.75rem;
@@ -224,8 +217,8 @@ body.dark-mode .navbar {
 }
 
 body.dark-mode .navbar__profile-menu {
-  background: rgba(7, 11, 22, 0.94);
-  border-color: rgba(119, 131, 182, 0.2);
+  background: var(--card-bg-light);
+  border-color: var(--glass-border);
 }
 
 .navbar__profile-menu[data-open="true"] {
@@ -299,8 +292,8 @@ body.dark-mode .navbar__profile-email {
 
 .navbar__profile-item:hover,
 .navbar__profile-item:focus-visible {
-  background: rgba(21, 94, 239, 0.12);
-  border-color: rgba(21, 94, 239, 0.18);
+  background: rgba(0, 54, 136, 0.12);
+  border-color: rgba(0, 54, 136, 0.2);
   color: var(--navbar-text);
 }
 
@@ -313,13 +306,13 @@ body.dark-mode .navbar__profile-email {
 .navbar__profile-item--destructive,
 .navbar__drawer-action--destructive,
 .navbar__drawer-button--destructive {
-  color: #c92a2a;
+  color: var(--accent-red, #d32f2f);
 }
 
 .navbar__profile-item--destructive:hover,
 .navbar__profile-item--destructive:focus-visible {
-  background: rgba(201, 42, 42, 0.12);
-  border-color: rgba(201, 42, 42, 0.24);
+  background: rgba(211, 47, 47, 0.12);
+  border-color: rgba(211, 47, 47, 0.24);
 }
 
 .navbar__profile-item--destructive i {
@@ -345,7 +338,7 @@ body.dark-mode .navbar__drawer-button--destructive:focus-visible {
 .navbar__toggle {
   display: none;
   border: none;
-  background: rgba(17, 25, 53, 0.08);
+  background: rgba(0, 54, 136, 0.12);
   color: inherit;
   width: 44px;
   height: 44px;
@@ -374,7 +367,7 @@ body.dark-mode .navbar__drawer-button--destructive:focus-visible {
   background: var(--navbar-drawer-bg);
   border-left: 1px solid var(--navbar-drawer-border);
   border-radius: 24px 0 0 24px;
-  box-shadow: -24px 0 60px rgba(17, 24, 39, 0.16);
+  box-shadow: -24px 0 60px rgba(0, 54, 136, 0.18);
   backdrop-filter: blur(28px);
   transform: translateX(100%);
   transition: transform 0.28s cubic-bezier(0.25, 0.8, 0.25, 1);
@@ -435,7 +428,7 @@ body.dark-mode .navbar__drawer::before {
 
 .navbar__drawer-close {
   border: none;
-  background: rgba(17, 25, 53, 0.08);
+  background: rgba(0, 54, 136, 0.12);
   color: inherit;
   font-size: 1.35rem;
   width: 44px;
@@ -448,7 +441,7 @@ body.dark-mode .navbar__drawer::before {
 
 .navbar__drawer-close:hover,
 .navbar__drawer-close:focus-visible {
-  background: rgba(21, 94, 239, 0.18);
+  background: rgba(0, 54, 136, 0.22);
   color: var(--navbar-text);
 }
 
@@ -467,13 +460,13 @@ body.dark-mode .navbar__drawer::before {
 }
 
 .navbar__drawer-scroll::-webkit-scrollbar-thumb {
-  background: rgba(17, 25, 53, 0.2);
+  background: rgba(0, 54, 136, 0.25);
   border-radius: 999px;
 }
 
 .navbar__drawer-scroll {
   scrollbar-width: thin;
-  scrollbar-color: rgba(17, 25, 53, 0.25) transparent;
+  scrollbar-color: rgba(0, 54, 136, 0.25) transparent;
 }
 
 .navbar__drawer-profile {
@@ -481,9 +474,9 @@ body.dark-mode .navbar__drawer::before {
   gap: 1rem;
   padding: clamp(1.1rem, 4vw, 1.4rem);
   border-radius: clamp(18px, 4vw, 22px);
-  background: rgba(21, 94, 239, 0.12);
-  border: 1px solid rgba(21, 94, 239, 0.2);
-  box-shadow: 0 24px 54px rgba(21, 94, 239, 0.2);
+  background: rgba(0, 54, 136, 0.12);
+  border: 1px solid rgba(0, 54, 136, 0.22);
+  box-shadow: 0 24px 54px rgba(0, 54, 136, 0.22);
 }
 
 .navbar__drawer-profile-header {
@@ -496,7 +489,7 @@ body.dark-mode .navbar__drawer::before {
   width: clamp(52px, 12vw, 62px);
   height: clamp(52px, 12vw, 62px);
   border-radius: 18px;
-  background: rgba(21, 94, 239, 0.16);
+  background: rgba(0, 54, 136, 0.16);
   color: var(--navbar-accent);
   display: grid;
   place-items: center;
@@ -531,14 +524,14 @@ body.dark-mode .navbar__drawer::before {
   color: var(--navbar-accent);
   font-weight: 600;
   padding: 0.55rem 1.2rem;
-  box-shadow: 0 16px 34px rgba(21, 94, 239, 0.24);
+  box-shadow: 0 16px 34px rgba(0, 54, 136, 0.22);
   cursor: pointer;
   transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
 }
 
 .navbar__drawer-profile-manage:hover,
 .navbar__drawer-profile-manage:focus-visible {
-  background: rgba(21, 94, 239, 0.18);
+  background: rgba(0, 54, 136, 0.18);
   color: var(--navbar-text);
   transform: translateY(-1px);
 }
@@ -573,7 +566,7 @@ body.dark-mode .navbar__drawer::before {
   padding: 0.95rem 1.1rem;
   border-radius: clamp(16px, 4vw, 18px);
   background: rgba(255, 255, 255, 0.92);
-  box-shadow: 0 18px 46px rgba(17, 24, 39, 0.16);
+  box-shadow: 0 18px 46px rgba(0, 54, 136, 0.16);
   color: var(--navbar-text);
   font-weight: 600;
   text-decoration: none;
@@ -591,7 +584,7 @@ body.dark-mode .navbar__drawer::before {
 
 .navbar__drawer-link:hover,
 .navbar__drawer-link:focus-visible {
-  background: rgba(21, 94, 239, 0.2);
+  background: rgba(0, 54, 136, 0.18);
   color: var(--navbar-text);
   transform: translateX(6px);
 }
@@ -652,16 +645,16 @@ body.dark-mode .navbar__drawer::before {
 }
 
 .navbar__drawer-action:focus-visible {
-  outline: 2px solid rgba(21, 94, 239, 0.55);
+  outline: 2px solid rgba(0, 54, 136, 0.55);
   outline-offset: 3px;
 }
 
 .navbar__drawer-button {
   padding: 0.72rem 1.25rem;
   border-radius: inherit;
-  border: 1px solid rgba(17, 25, 53, 0.08);
+  border: 1px solid rgba(0, 54, 136, 0.12);
   background: rgba(255, 255, 255, 0.9);
-  box-shadow: 0 18px 42px rgba(17, 24, 39, 0.14);
+  box-shadow: 0 18px 42px rgba(0, 54, 136, 0.14);
   font-weight: 600;
   font-size: 0.96rem;
   transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
@@ -669,44 +662,44 @@ body.dark-mode .navbar__drawer::before {
 
 .navbar__drawer-button:hover,
 .navbar__drawer-button:focus-visible {
-  background: rgba(21, 94, 239, 0.16);
+  background: rgba(0, 54, 136, 0.18);
   color: var(--navbar-text);
   transform: translateY(-1px);
 }
 
 .navbar__drawer-button--primary {
-  background: var(--navbar-accent);
-  border-color: var(--navbar-accent);
+  background: var(--accent-red, #d32f2f);
+  border-color: var(--accent-red, #d32f2f);
   color: #fff;
-  box-shadow: 0 20px 44px rgba(21, 94, 239, 0.32);
+  box-shadow: 0 20px 44px rgba(211, 47, 47, 0.3);
 }
 
 .navbar__drawer-button--primary:hover,
 .navbar__drawer-button--primary:focus-visible {
-  background: var(--navbar-accent-dark);
+  background: var(--accent-red-dark, #a61c1c);
 }
 
 .navbar__drawer-button--ghost {
-  background: rgba(17, 25, 53, 0.06);
-  border-color: rgba(17, 25, 53, 0.12);
+  background: rgba(0, 54, 136, 0.08);
+  border-color: rgba(0, 54, 136, 0.12);
 }
 
 .navbar__drawer-button--ghost:hover,
 .navbar__drawer-button--ghost:focus-visible {
-  background: rgba(17, 25, 53, 0.12);
+  background: rgba(0, 54, 136, 0.16);
 }
 
 .navbar__drawer-button--destructive {
-  background: rgba(201, 42, 42, 0.12);
-  border-color: rgba(201, 42, 42, 0.3);
-  color: #c92a2a;
-  box-shadow: 0 18px 44px rgba(201, 42, 42, 0.22);
+  background: rgba(211, 47, 47, 0.12);
+  border-color: rgba(211, 47, 47, 0.28);
+  color: var(--accent-red, #d32f2f);
+  box-shadow: 0 18px 44px rgba(211, 47, 47, 0.24);
 }
 
 .navbar__drawer-button--destructive:hover,
 .navbar__drawer-button--destructive:focus-visible {
-  background: rgba(201, 42, 42, 0.2);
-  color: #b42323;
+  background: rgba(211, 47, 47, 0.2);
+  color: var(--accent-red-dark, #a61c1c);
 }
 
 body.dark-mode .navbar__drawer-close {
@@ -901,18 +894,6 @@ body.dark-mode .navbar__drawer-button--destructive:focus-visible {
 }
 
 @media (max-width: 640px) {
-  body:not(.dark-mode) .navbar {
-    --navbar-bg: rgba(2, 6, 23, 0.72);
-    --navbar-text: #f8fafc;
-    --navbar-muted: rgba(226, 232, 255, 0.82);
-    --navbar-accent: #38bdf8;
-    --navbar-accent-dark: #2563eb;
-    --navbar-border: rgba(148, 163, 184, 0.28);
-    --navbar-shadow: 0 32px 70px rgba(2, 6, 23, 0.55);
-    --navbar-drawer-bg: rgba(2, 6, 23, 0.92);
-    --navbar-drawer-border: rgba(148, 163, 184, 0.34);
-  }
-
   .navbar__inner {
     width: 100%;
     padding-inline: clamp(1rem, 6vw, 1.4rem);
@@ -932,9 +913,9 @@ body.dark-mode .navbar__drawer-button--destructive:focus-visible {
 
   .navbar__toggle {
     border-radius: 16px;
-    border: 1px solid rgba(148, 163, 184, 0.32);
+    border: 1px solid rgba(0, 54, 136, 0.22);
     padding: 0.55rem;
-    background: rgba(15, 23, 42, 0.45);
+    background: rgba(0, 54, 136, 0.14);
     color: inherit;
   }
 
@@ -942,52 +923,5 @@ body.dark-mode .navbar__drawer-button--destructive:focus-visible {
     width: 20px;
     height: 2px;
     background: currentColor;
-  }
-
-  body:not(.dark-mode) .navbar__btn--ghost {
-    background: rgba(148, 163, 184, 0.16);
-    border-color: rgba(148, 163, 184, 0.3);
-    color: #f8fafc;
-  }
-
-  body:not(.dark-mode) .navbar__btn--primary {
-    background: linear-gradient(92deg, #38bdf8 0%, #6366f1 100%);
-    box-shadow: 0 22px 44px rgba(99, 102, 241, 0.32);
-  }
-
-  body:not(.dark-mode) .navbar__drawer {
-    background: rgba(2, 6, 23, 0.92);
-    border-color: rgba(148, 163, 184, 0.34);
-  }
-
-  body:not(.dark-mode) .navbar__drawer-section-title {
-    color: rgba(226, 232, 255, 0.82);
-  }
-
-  body:not(.dark-mode) .navbar__drawer-link,
-  body:not(.dark-mode) .navbar__drawer-action,
-  body:not(.dark-mode) .navbar__drawer-button {
-    color: #f8fafc;
-  }
-
-  body:not(.dark-mode) .navbar__drawer-link:hover,
-  body:not(.dark-mode) .navbar__drawer-link:focus-visible {
-    background: rgba(56, 189, 248, 0.18);
-    color: #38bdf8;
-  }
-
-  body:not(.dark-mode) .navbar__drawer-button--ghost {
-    background: rgba(148, 163, 184, 0.18);
-    border-color: rgba(148, 163, 184, 0.32);
-  }
-
-  body:not(.dark-mode) .navbar__drawer-button--primary {
-    background: linear-gradient(92deg, #38bdf8 0%, #6366f1 100%);
-    box-shadow: 0 22px 44px rgba(99, 102, 241, 0.32);
-  }
-
-  body:not(.dark-mode) .navbar__drawer-profile-manage {
-    background: rgba(148, 163, 184, 0.18);
-    color: #f8fafc;
   }
 }

--- a/style.css
+++ b/style.css
@@ -7,47 +7,53 @@
    Core design tokens
 ------------------------------------------------------------- */
 :root {
-  --primary: #003688;
-  --primary-dark: #002866;
-  --accent-blue: #003688;
-  --accent-blue-dark: #002866;
-  --accent-red: #ff4757;
-  --accent-red-dark: #e63d4b;
+  --rf-blue: #003688;
+  --rf-blue-dark: #002a5c;
+  --rf-red: #d32f2f;
+  --rf-red-dark: #a61c1c;
+  --rf-white: #ffffff;
 
-  --background-light: #f3f5fb;
-  --foreground-light: #111935;
-  --background-dark: #050913;
-  --foreground-dark: #f6f7ff;
+  --primary: var(--rf-blue);
+  --primary-dark: var(--rf-blue-dark);
+  --accent-blue: var(--rf-blue);
+  --accent-blue-dark: var(--rf-blue-dark);
+  --accent-red: var(--rf-red);
+  --accent-red-dark: var(--rf-red-dark);
 
-  --card-bg-light: #ffffff;
-  --card-bg-dark: #0f162b;
+  --background-light: var(--rf-white);
+  --foreground-light: #0b1f4b;
+  --background-dark: var(--rf-white);
+  --foreground-dark: #0b1f4b;
 
-  --surface-muted-light: #e6e9f6;
-  --surface-muted-dark: #121c33;
-  --surface-elevated-light: rgba(255, 255, 255, 0.8);
-  --surface-elevated-dark: rgba(11, 18, 32, 0.85);
+  --card-bg-light: var(--rf-white);
+  --card-bg-dark: var(--rf-white);
 
-  --glass-border: rgba(21, 38, 75, 0.08);
-  --glass-border-dark: rgba(201, 214, 255, 0.12);
-  --border-strong-light: rgba(15, 23, 42, 0.12);
-  --border-strong-dark: rgba(206, 213, 236, 0.18);
+  --surface-muted-light: #e6eef9;
+  --surface-muted-dark: #e6eef9;
+  --surface-elevated-light: rgba(255, 255, 255, 0.95);
+  --surface-elevated-dark: rgba(255, 255, 255, 0.95);
 
-  --text-muted-light: rgba(17, 25, 53, 0.7);
-  --text-subtle-light: rgba(17, 25, 53, 0.55);
-  --text-muted-dark: rgba(246, 247, 255, 0.76);
-  --text-subtle-dark: rgba(246, 247, 255, 0.6);
+  --glass-border: rgba(0, 54, 136, 0.12);
+  --glass-border-dark: rgba(0, 54, 136, 0.12);
+  --border-strong-light: rgba(0, 54, 136, 0.18);
+  --border-strong-dark: rgba(0, 54, 136, 0.18);
 
-  --shadow-soft: 0 30px 80px rgba(17, 24, 39, 0.12);
-  --shadow-soft-dark: 0 34px 88px rgba(0, 0, 0, 0.6);
-  --shadow-medium: 0 14px 40px rgba(17, 24, 39, 0.14);
-  --shadow-medium-dark: 0 18px 48px rgba(3, 6, 16, 0.55);
+  --text-muted-light: rgba(11, 31, 75, 0.72);
+  --text-subtle-light: rgba(11, 31, 75, 0.6);
+  --text-muted-dark: rgba(11, 31, 75, 0.72);
+  --text-subtle-dark: rgba(11, 31, 75, 0.6);
+
+  --shadow-soft: 0 24px 64px rgba(0, 54, 136, 0.14);
+  --shadow-soft-dark: 0 24px 64px rgba(0, 54, 136, 0.14);
+  --shadow-medium: 0 14px 40px rgba(0, 54, 136, 0.16);
+  --shadow-medium-dark: 0 14px 40px rgba(0, 54, 136, 0.16);
 
   --radius-sm: 12px;
   --radius-md: 18px;
   --radius-lg: 26px;
   --radius-xl: 36px;
 
-  --transition: 0.28s cubic-bezier(.4, 0, .2, 1);
+  --transition: 0.24s cubic-bezier(.4, 0, .2, 1);
   --content-max: min(1200px, 100vw - clamp(2rem, 7vw, 7rem));
   --grid-gap: clamp(1.2rem, 3vw, 2.2rem);
   --section-gap: clamp(2.6rem, 6vw, 4.2rem);
@@ -63,29 +69,38 @@ body {
   font-weight: 400;
   line-height: 1.65;
   letter-spacing: 0.01em;
-  background: radial-gradient(circle at top left, rgba(0, 54, 136, 0.12) 0%, transparent 60%),
-              radial-gradient(circle at 110% 12%, rgba(255, 71, 87, 0.08) 0%, transparent 58%),
-              var(--background-light);
+  background: var(--background-light);
   color: var(--foreground-light);
   -webkit-font-smoothing: antialiased;
   transition: background var(--transition), color var(--transition);
+  overflow-x: hidden;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+li,
+blockquote {
+  overflow-wrap: anywhere;
 }
 
 body.dark-mode {
-  background: radial-gradient(circle at top, rgba(0, 54, 136, 0.26) 0%, transparent 50%),
-              radial-gradient(circle at 18% 78%, rgba(255, 71, 87, 0.16) 0%, transparent 62%),
-              var(--background-dark);
-  color: var(--foreground-dark);
+  background: var(--background-light);
+  color: var(--foreground-light);
 
-  --surface-muted-light: var(--surface-muted-dark);
-  --surface-elevated-light: var(--surface-elevated-dark);
-  --glass-border: var(--glass-border-dark);
-  --border-strong-light: var(--border-strong-dark);
-  --text-muted-light: var(--text-muted-dark);
-  --text-subtle-light: var(--text-subtle-dark);
-  --card-bg-light: var(--card-bg-dark);
-  --shadow-soft: var(--shadow-soft-dark);
-  --shadow-medium: var(--shadow-medium-dark);
+  --surface-muted-light: var(--surface-muted-light);
+  --surface-elevated-light: var(--surface-elevated-light);
+  --glass-border: var(--glass-border);
+  --border-strong-light: var(--border-strong-light);
+  --text-muted-light: var(--text-muted-light);
+  --text-subtle-light: var(--text-subtle-light);
+  --card-bg-light: var(--card-bg-light);
+  --shadow-soft: var(--shadow-soft);
+  --shadow-medium: var(--shadow-medium);
 }
 
 body.high-contrast {
@@ -264,7 +279,7 @@ body.dark-mode .auth-gate__panel::before {
   content: '';
   position: absolute;
   inset: 0;
-  background: rgba(5, 10, 24, 0.35);
+  background: rgba(0, 40, 90, 0.3);
   backdrop-filter: blur(2px);
   border-radius: inherit;
   z-index: 1;
@@ -276,7 +291,7 @@ body.dark-mode .auth-gate__panel::before {
   top: 1rem;
   right: 1rem;
   border-radius: 999px;
-  background: rgba(21, 94, 239, 0.18);
+  background: rgba(0, 54, 136, 0.18);
   color: var(--accent-blue);
   padding: 0.35rem 0.9rem;
   font-size: 0.75rem;


### PR DESCRIPTION
## Summary
- standardise the global design tokens to a fixed red, blue and white palette and keep headings within mobile layouts
- restyle the navbar to use the new palette, ensure it spans the viewport on small screens and greet signed-in users with “Welcome, Name”
- allow the fleet page to load for guests while keeping the hero messaging informative about signing in for submissions

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d0725d2b20832281cc7b6c426722fb