### PR TITLE
Ensure Mailjet embed uses exact snippet

### DIFF
--- a/index.html
+++ b/index.html
@@ -229,28 +229,8 @@
         <p>We only send high-signal updates: new datasets, layout upgrades and travel literacy packs.</p>
       </div>
       <div class="landing-updates__form">
-        <iframe
-          data-w-token="3bb4115e41c545cc2d79"
-          data-w-type="pop-in"
-          frameborder="0"
-          scrolling="yes"
-          marginheight="0"
-          marginwidth="0"
-          src="https://1xl3t.mjt.lu/wgt/1xl3t/0pom/form?c=c8d5af69"
-          width="100%"
-          style="height: 0;"
-        ></iframe>
-        <iframe
-          data-w-token="3bb4115e41c545cc2d79"
-          data-w-type="trigger"
-          frameborder="0"
-          scrolling="no"
-          marginheight="0"
-          marginwidth="0"
-          src="https://1xl3t.mjt.lu/wgt/1xl3t/0pom/trigger?c=488ee8a4"
-          width="100%"
-          style="height: 0;"
-        ></iframe>
+        <iframe data-w-token="3bb4115e41c545cc2d79" data-w-type="pop-in" frameborder="0" scrolling="yes" marginheight="0" marginwidth="0" src="https://1xl3t.mjt.lu/wgt/1xl3t/0pom/form?c=c8d5af69" width="100%" style="height: 0;"></iframe>
+        <iframe data-w-token="3bb4115e41c545cc2d79" data-w-type="trigger" frameborder="0" scrolling="no" marginheight="0" marginwidth="0" src="https://1xl3t.mjt.lu/wgt/1xl3t/0pom/trigger?c=488ee8a4" width="100%" style="height: 0;"></iframe>
         <script type="text/javascript" src="https://app.mailjet.com/pas-nc-pop-in-v1.js"></script>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- replace the newsletter sign-up iframe block with the precise Mailjet embed snippet provided

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e24f6f1c2083228a92e6e3f904f90c