### PR TITLE
Refresh theme with Horizon layout and unified footer

### DIFF
--- a/about.html
+++ b/about.html
@@ -13,8 +13,12 @@
 </head>
 <body class="site-body">
   <a href="#main-content" class="skip-link">Skip to main content</a>
-  <div id="navbar-container"></div>
+  <div class="site-shell">
+    <header class="site-shell__header">
+      <div id="navbar-container" class="site-shell__navbar"></div>
+    </header>
 
+    <div class="site-shell__main">
   <main id="main-content" class="site-main page-shell" aria-labelledby="aboutTitle">
     <section class="page-hero">
       <div class="page-hero__content">
@@ -102,38 +106,68 @@
     </section>
   </main>
 
-  <footer class="site-footer" aria-label="Footer">
-    <div class="site-footer__inner">
-      <div class="site-footer__brand">
-        <span class="site-footer__name">RouteFlow London</span>
-        <p class="site-footer__description">Playful transport guidance for explorers of every age.</p>
-      </div>
-      <nav class="site-footer__nav" aria-label="Explore">
-        <a href="index.html">Home</a>
-        <a href="dashboard.html">Dashboard</a>
-        <a href="tracking.html">Tracking</a>
-        <a href="planning.html">Planning</a>
-        <a href="routes.html">Routes</a>
-        <a href="info.html">Info hub</a>
-      </nav>
-      <nav class="site-footer__nav" aria-label="Support">
-        <a href="about.html">About</a>
-        <a href="contact.html">Contact</a>
-        <a href="privacy.html">Privacy</a>
-        <a href="terms.html">Terms</a>
-        <a href="settings.html">Settings</a>
-      </nav>
-      <div class="site-footer__social" aria-label="Social channels">
-        <a href="https://discord.gg/qVf3nN4Mgq" aria-label="RouteFlow London on Discord"><i class="fa-brands fa-discord"></i></a>
-        <a href="https://www.tiktok.com/@the_bus_father" aria-label="RouteFlow London on TikTok"><i class="fab fa-tiktok"></i></a>
-        <a href="https://www.instagram.com/thebusfatherofficial/profilecard/?igsh=NXcybzV3cTA2azBo" aria-label="RouteFlow London on Instagram"><i class="fab fa-instagram"></i></a>
-      </div>
     </div>
-    <div class="site-footer__meta">
-      <span>&copy; <span data-current-year></span> RouteFlow London. All rights reserved.</span>
-      <span>Made for London. Accessible for everyone.</span>
-    </div>
-  </footer>
+
+    <footer class="site-footer" aria-label="RouteFlow London footer">
+      <div class="site-footer__inner">
+        <div class="site-footer__brand">
+          <img src="images/New_Routflow_London_Logo.png" alt="RouteFlow London logo">
+          <div>
+            <h2>Stay curious about London’s transport</h2>
+            <p>RouteFlow London turns TfL feeds into playful guidance so planners, families and classrooms can travel with calm confidence.</p>
+            <div class="site-footer__social" role="list">
+              <a href="https://discord.gg/qVf3nN4Mgq" aria-label="RouteFlow London on Discord"><i class="fa-brands fa-discord"></i></a>
+              <a href="https://www.tiktok.com/@the_bus_father" aria-label="RouteFlow London on TikTok"><i class="fa-brands fa-tiktok"></i></a>
+              <a href="https://www.instagram.com/thebusfatherofficial/profilecard/?igsh=NXcybzV3cTA2azBo" aria-label="RouteFlow London on Instagram"><i class="fa-brands fa-instagram"></i></a>
+            </div>
+          </div>
+        </div>
+        <div class="site-footer__grid">
+          <div>
+            <h3 class="site-footer__heading">Plan journeys</h3>
+            <ul class="site-footer__links">
+              <li><a href="index.html">Home</a></li>
+              <li><a href="planning.html">Planning</a></li>
+              <li><a href="tracking.html">Tracking</a></li>
+            </ul>
+          </div>
+          <div>
+            <h3 class="site-footer__heading">Live insight</h3>
+            <ul class="site-footer__links">
+              <li><a href="dashboard.html">Dashboard</a></li>
+              <li><a href="routes.html">Routes</a></li>
+              <li><a href="disruptions.html">Disruptions</a></li>
+            </ul>
+          </div>
+          <div>
+            <h3 class="site-footer__heading">Community data</h3>
+            <ul class="site-footer__links">
+              <li><a href="info.html">Info hub</a></li>
+              <li><a href="fleet.html">Fleet</a></li>
+              <li><a href="withdrawn.html">Withdrawn</a></li>
+            </ul>
+          </div>
+          <div>
+            <h3 class="site-footer__heading">Company</h3>
+            <ul class="site-footer__links">
+              <li><a href="about.html">About</a></li>
+              <li><a href="contact.html">Contact</a></li>
+              <li><a href="privacy.html">Privacy</a></li>
+              <li><a href="terms.html">Terms</a></li>
+            </ul>
+          </div>
+        </div>
+        <div class="site-footer__bottom">
+          <p class="site-footer__legal">© <span data-current-year></span> RouteFlow London. Crafted for curious travellers.</p>
+          <div class="site-footer__meta">
+            <a href="privacy.html">Privacy</a>
+            <a href="terms.html">Terms</a>
+            <a href="contact.html">Contact</a>
+          </div>
+        </div>
+      </div>
+    </footer>
+  </div>
 
   <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-auth-compat.js"></script>

--- a/admin.html
+++ b/admin.html
@@ -14,40 +14,76 @@
 </head>
 <body class="site-body">
   <a href="#adminContent" class="skip-link">Skip to main content</a>
-  <div id="navbar-container"></div>
-  <main id="adminContent" class="site-main admin-page" aria-live="polite"></main>
-  <footer class="site-footer" aria-label="Footer">
-    <div class="site-footer__inner">
-      <div class="site-footer__brand">
-        <span class="site-footer__name">RouteFlow London</span>
-        <p class="site-footer__description">Playful transport guidance for explorers of every age.</p>
-      </div>
-      <nav class="site-footer__nav" aria-label="Explore">
-        <a href="index.html">Home</a>
-        <a href="dashboard.html">Dashboard</a>
-        <a href="tracking.html">Tracking</a>
-        <a href="planning.html">Planning</a>
-        <a href="routes.html">Routes</a>
-        <a href="info.html">Info hub</a>
-      </nav>
-      <nav class="site-footer__nav" aria-label="Support">
-        <a href="about.html">About</a>
-        <a href="contact.html">Contact</a>
-        <a href="privacy.html">Privacy</a>
-        <a href="terms.html">Terms</a>
-        <a href="settings.html">Settings</a>
-      </nav>
-      <div class="site-footer__social" aria-label="Social channels">
-        <a href="https://discord.gg/qVf3nN4Mgq" aria-label="RouteFlow London on Discord"><i class="fa-brands fa-discord"></i></a>
-        <a href="https://www.tiktok.com/@the_bus_father" aria-label="RouteFlow London on TikTok"><i class="fab fa-tiktok"></i></a>
-        <a href="https://www.instagram.com/thebusfatherofficial/profilecard/?igsh=NXcybzV3cTA2azBo" aria-label="RouteFlow London on Instagram"><i class="fab fa-instagram"></i></a>
-      </div>
+  <div class="site-shell">
+    <header class="site-shell__header">
+      <div id="navbar-container" class="site-shell__navbar"></div>
+    </header>
+
+    <div class="site-shell__main">
+      <main id="adminContent" class="site-main admin-page" aria-live="polite"></main>
     </div>
-    <div class="site-footer__meta">
-      <span>&copy; <span data-current-year></span> RouteFlow London. All rights reserved.</span>
-      <span>Made for London. Accessible for everyone.</span>
-    </div>
-  </footer>
+
+    <footer class="site-footer" aria-label="RouteFlow London footer">
+      <div class="site-footer__inner">
+        <div class="site-footer__brand">
+          <img src="images/New_Routflow_London_Logo.png" alt="RouteFlow London logo">
+          <div>
+            <h2>Stay curious about London’s transport</h2>
+            <p>RouteFlow London turns TfL feeds into playful guidance so planners, families and classrooms can travel with calm confidence.</p>
+            <div class="site-footer__social" role="list">
+              <a href="https://discord.gg/qVf3nN4Mgq" aria-label="RouteFlow London on Discord"><i class="fa-brands fa-discord"></i></a>
+              <a href="https://www.tiktok.com/@the_bus_father" aria-label="RouteFlow London on TikTok"><i class="fa-brands fa-tiktok"></i></a>
+              <a href="https://www.instagram.com/thebusfatherofficial/profilecard/?igsh=NXcybzV3cTA2azBo" aria-label="RouteFlow London on Instagram"><i class="fa-brands fa-instagram"></i></a>
+            </div>
+          </div>
+        </div>
+        <div class="site-footer__grid">
+          <div>
+            <h3 class="site-footer__heading">Plan journeys</h3>
+            <ul class="site-footer__links">
+              <li><a href="index.html">Home</a></li>
+              <li><a href="planning.html">Planning</a></li>
+              <li><a href="tracking.html">Tracking</a></li>
+            </ul>
+          </div>
+          <div>
+            <h3 class="site-footer__heading">Live insight</h3>
+            <ul class="site-footer__links">
+              <li><a href="dashboard.html">Dashboard</a></li>
+              <li><a href="routes.html">Routes</a></li>
+              <li><a href="disruptions.html">Disruptions</a></li>
+            </ul>
+          </div>
+          <div>
+            <h3 class="site-footer__heading">Community data</h3>
+            <ul class="site-footer__links">
+              <li><a href="info.html">Info hub</a></li>
+              <li><a href="fleet.html">Fleet</a></li>
+              <li><a href="withdrawn.html">Withdrawn</a></li>
+            </ul>
+          </div>
+          <div>
+            <h3 class="site-footer__heading">Company</h3>
+            <ul class="site-footer__links">
+              <li><a href="about.html">About</a></li>
+              <li><a href="contact.html">Contact</a></li>
+              <li><a href="privacy.html">Privacy</a></li>
+              <li><a href="terms.html">Terms</a></li>
+            </ul>
+          </div>
+        </div>
+        <div class="site-footer__bottom">
+          <p class="site-footer__legal">© <span data-current-year></span> RouteFlow London. Crafted for curious travellers.</p>
+          <div class="site-footer__meta">
+            <a href="privacy.html">Privacy</a>
+            <a href="terms.html">Terms</a>
+            <a href="contact.html">Contact</a>
+          </div>
+        </div>
+      </div>
+    </footer>
+  </div>
+
   <script src="navbar-loader.js" defer></script>
   <script type="module" src="admin.js"></script>
 </body>

--- a/contact.html
+++ b/contact.html
@@ -13,8 +13,12 @@
 </head>
 <body class="site-body">
   <a href="#main-content" class="skip-link">Skip to main content</a>
-  <div id="navbar-container"></div>
+  <div class="site-shell">
+    <header class="site-shell__header">
+      <div id="navbar-container" class="site-shell__navbar"></div>
+    </header>
 
+    <div class="site-shell__main">
   <main id="main-content" class="site-main page-shell" aria-labelledby="contactTitle">
     <section class="page-hero">
       <div class="page-hero__content">
@@ -101,38 +105,68 @@
     </section>
   </main>
 
-  <footer class="site-footer" aria-label="Footer">
-    <div class="site-footer__inner">
-      <div class="site-footer__brand">
-        <span class="site-footer__name">RouteFlow London</span>
-        <p class="site-footer__description">Playful transport guidance for explorers of every age.</p>
-      </div>
-      <nav class="site-footer__nav" aria-label="Explore">
-        <a href="index.html">Home</a>
-        <a href="dashboard.html">Dashboard</a>
-        <a href="tracking.html">Tracking</a>
-        <a href="planning.html">Planning</a>
-        <a href="routes.html">Routes</a>
-        <a href="info.html">Info hub</a>
-      </nav>
-      <nav class="site-footer__nav" aria-label="Support">
-        <a href="about.html">About</a>
-        <a href="contact.html">Contact</a>
-        <a href="privacy.html">Privacy</a>
-        <a href="terms.html">Terms</a>
-        <a href="settings.html">Settings</a>
-      </nav>
-      <div class="site-footer__social" aria-label="Social channels">
-        <a href="https://discord.gg/qVf3nN4Mgq" aria-label="RouteFlow London on Discord"><i class="fa-brands fa-discord"></i></a>
-        <a href="https://www.tiktok.com/@the_bus_father" aria-label="RouteFlow London on TikTok"><i class="fab fa-tiktok"></i></a>
-        <a href="https://www.instagram.com/thebusfatherofficial/profilecard/?igsh=NXcybzV3cTA2azBo" aria-label="RouteFlow London on Instagram"><i class="fab fa-instagram"></i></a>
-      </div>
     </div>
-    <div class="site-footer__meta">
-      <span>&copy; <span data-current-year></span> RouteFlow London. All rights reserved.</span>
-      <span>Made for London. Accessible for everyone.</span>
-    </div>
-  </footer>
+
+    <footer class="site-footer" aria-label="RouteFlow London footer">
+      <div class="site-footer__inner">
+        <div class="site-footer__brand">
+          <img src="images/New_Routflow_London_Logo.png" alt="RouteFlow London logo">
+          <div>
+            <h2>Stay curious about London’s transport</h2>
+            <p>RouteFlow London turns TfL feeds into playful guidance so planners, families and classrooms can travel with calm confidence.</p>
+            <div class="site-footer__social" role="list">
+              <a href="https://discord.gg/qVf3nN4Mgq" aria-label="RouteFlow London on Discord"><i class="fa-brands fa-discord"></i></a>
+              <a href="https://www.tiktok.com/@the_bus_father" aria-label="RouteFlow London on TikTok"><i class="fa-brands fa-tiktok"></i></a>
+              <a href="https://www.instagram.com/thebusfatherofficial/profilecard/?igsh=NXcybzV3cTA2azBo" aria-label="RouteFlow London on Instagram"><i class="fa-brands fa-instagram"></i></a>
+            </div>
+          </div>
+        </div>
+        <div class="site-footer__grid">
+          <div>
+            <h3 class="site-footer__heading">Plan journeys</h3>
+            <ul class="site-footer__links">
+              <li><a href="index.html">Home</a></li>
+              <li><a href="planning.html">Planning</a></li>
+              <li><a href="tracking.html">Tracking</a></li>
+            </ul>
+          </div>
+          <div>
+            <h3 class="site-footer__heading">Live insight</h3>
+            <ul class="site-footer__links">
+              <li><a href="dashboard.html">Dashboard</a></li>
+              <li><a href="routes.html">Routes</a></li>
+              <li><a href="disruptions.html">Disruptions</a></li>
+            </ul>
+          </div>
+          <div>
+            <h3 class="site-footer__heading">Community data</h3>
+            <ul class="site-footer__links">
+              <li><a href="info.html">Info hub</a></li>
+              <li><a href="fleet.html">Fleet</a></li>
+              <li><a href="withdrawn.html">Withdrawn</a></li>
+            </ul>
+          </div>
+          <div>
+            <h3 class="site-footer__heading">Company</h3>
+            <ul class="site-footer__links">
+              <li><a href="about.html">About</a></li>
+              <li><a href="contact.html">Contact</a></li>
+              <li><a href="privacy.html">Privacy</a></li>
+              <li><a href="terms.html">Terms</a></li>
+            </ul>
+          </div>
+        </div>
+        <div class="site-footer__bottom">
+          <p class="site-footer__legal">© <span data-current-year></span> RouteFlow London. Crafted for curious travellers.</p>
+          <div class="site-footer__meta">
+            <a href="privacy.html">Privacy</a>
+            <a href="terms.html">Terms</a>
+            <a href="contact.html">Contact</a>
+          </div>
+        </div>
+      </div>
+    </footer>
+  </div>
 
   <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-auth-compat.js"></script>

--- a/dashboard.html
+++ b/dashboard.html
@@ -13,7 +13,12 @@
 </head>
 <body class="site-body">
   <a href="#main-content" class="skip-link">Skip to main content</a>
-  <div id="navbar-container"></div>
+  <div class="site-shell">
+    <header class="site-shell__header">
+      <div id="navbar-container" class="site-shell__navbar"></div>
+    </header>
+
+    <div class="site-shell__main">
   <section
     class="auth-gate"
     id="dashboardAuthGate"
@@ -189,56 +194,74 @@
     </section>
   </main>
 
-  <dialog class="dashboard-dialog" id="miniGameDialog" aria-modal="true">
-    <form method="dialog" class="dashboard-dialog__surface">
-      <header class="dashboard-dialog__header">
-        <h2 id="miniGameTitle">Mini game</h2>
-        <button type="submit" class="dashboard-dialog__close" aria-label="Close mini game">
-          <i class="fa-solid fa-xmark" aria-hidden="true"></i>
-        </button>
-      </header>
-      <div class="dashboard-dialog__body" id="miniGameBody"></div>
-      <footer class="dashboard-dialog__footer">
-        <button type="submit" class="dashboard-dialog__button">Close</button>
-      </footer>
+    </div>
+
+    <footer class="site-footer" aria-label="RouteFlow London footer">
+      <div class="site-footer__inner">
+        <div class="site-footer__brand">
+          <img src="images/New_Routflow_London_Logo.png" alt="RouteFlow London logo">
+          <div>
+            <h2>Stay curious about London’s transport</h2>
+            <p>RouteFlow London turns TfL feeds into playful guidance so planners, families and classrooms can travel with calm confidence.</p>
+            <div class="site-footer__social" role="list">
+              <a href="https://discord.gg/qVf3nN4Mgq" aria-label="RouteFlow London on Discord"><i class="fa-brands fa-discord"></i></a>
+              <a href="https://www.tiktok.com/@the_bus_father" aria-label="RouteFlow London on TikTok"><i class="fa-brands fa-tiktok"></i></a>
+              <a href="https://www.instagram.com/thebusfatherofficial/profilecard/?igsh=NXcybzV3cTA2azBo" aria-label="RouteFlow London on Instagram"><i class="fa-brands fa-instagram"></i></a>
+            </div>
+          </div>
+        </div>
+        <div class="site-footer__grid">
+          <div>
+            <h3 class="site-footer__heading">Plan journeys</h3>
+            <ul class="site-footer__links">
+              <li><a href="index.html">Home</a></li>
+              <li><a href="planning.html">Planning</a></li>
+              <li><a href="tracking.html">Tracking</a></li>
+            </ul>
+          </div>
+          <div>
+            <h3 class="site-footer__heading">Live insight</h3>
+            <ul class="site-footer__links">
+              <li><a href="dashboard.html">Dashboard</a></li>
+              <li><a href="routes.html">Routes</a></li>
+              <li><a href="disruptions.html">Disruptions</a></li>
+            </ul>
+          </div>
+          <div>
+            <h3 class="site-footer__heading">Community data</h3>
+            <ul class="site-footer__links">
+              <li><a href="info.html">Info hub</a></li>
+              <li><a href="fleet.html">Fleet</a></li>
+              <li><a href="withdrawn.html">Withdrawn</a></li>
+            </ul>
+          </div>
+          <div>
+            <h3 class="site-footer__heading">Company</h3>
+            <ul class="site-footer__links">
+              <li><a href="about.html">About</a></li>
+              <li><a href="contact.html">Contact</a></li>
+              <li><a href="privacy.html">Privacy</a></li>
+              <li><a href="terms.html">Terms</a></li>
+            </ul>
+          </div>
+        </div>
+        <div class="site-footer__bottom">
+          <p class="site-footer__legal">© <span data-current-year></span> RouteFlow London. Crafted for curious travellers.</p>
+          <div class="site-footer__meta">
+            <a href="privacy.html">Privacy</a>
+            <a href="terms.html">Terms</a>
+            <a href="contact.html">Contact</a>
+          </div>
+        </div>
+      </div>
+    </footer>
+  </div>
     </form>
   </dialog>
 
   <div class="dashboard-toast" id="dashboardToast" role="status" aria-live="polite" hidden></div>
 
   <script src="main.js" defer></script>
-  <footer class="site-footer" aria-label="Footer">
-    <div class="site-footer__inner">
-      <div class="site-footer__brand">
-        <span class="site-footer__name">RouteFlow London</span>
-        <p class="site-footer__description">Playful transport guidance for explorers of every age.</p>
-      </div>
-      <nav class="site-footer__nav" aria-label="Explore">
-        <a href="index.html">Home</a>
-        <a href="dashboard.html">Dashboard</a>
-        <a href="tracking.html">Tracking</a>
-        <a href="planning.html">Planning</a>
-        <a href="routes.html">Routes</a>
-        <a href="info.html">Info hub</a>
-      </nav>
-      <nav class="site-footer__nav" aria-label="Support">
-        <a href="about.html">About</a>
-        <a href="contact.html">Contact</a>
-        <a href="privacy.html">Privacy</a>
-        <a href="terms.html">Terms</a>
-        <a href="settings.html">Settings</a>
-      </nav>
-      <div class="site-footer__social" aria-label="Social channels">
-        <a href="https://discord.gg/qVf3nN4Mgq" aria-label="RouteFlow London on Discord"><i class="fa-brands fa-discord"></i></a>
-        <a href="https://www.tiktok.com/@the_bus_father" aria-label="RouteFlow London on TikTok"><i class="fab fa-tiktok"></i></a>
-        <a href="https://www.instagram.com/thebusfatherofficial/profilecard/?igsh=NXcybzV3cTA2azBo" aria-label="RouteFlow London on Instagram"><i class="fab fa-instagram"></i></a>
-      </div>
-    </div>
-    <div class="site-footer__meta">
-      <span>&copy; <span data-current-year></span> RouteFlow London. All rights reserved.</span>
-      <span>Made for London. Accessible for everyone.</span>
-    </div>
-  </footer>
 
   <script src="navbar-loader.js" defer></script>
   <script src="auth-guard.js" defer></script>

--- a/disruptions.html
+++ b/disruptions.html
@@ -12,7 +12,12 @@
 </head>
 <body class="site-body">
   <a href="#main-content" class="skip-link">Skip to main content</a>
-  <div id="navbar-container"></div>
+  <div class="site-shell">
+    <header class="site-shell__header">
+      <div id="navbar-container" class="site-shell__navbar"></div>
+    </header>
+
+    <div class="site-shell__main">
   <main id="main-content" class="site-main network-shell">
     <section class="network-hero">
       <div>
@@ -57,38 +62,68 @@
     </section>
   </main>
 
-  <footer class="site-footer" aria-label="Footer">
-    <div class="site-footer__inner">
-      <div class="site-footer__brand">
-        <span class="site-footer__name">RouteFlow London</span>
-        <p class="site-footer__description">Playful transport guidance for explorers of every age.</p>
-      </div>
-      <nav class="site-footer__nav" aria-label="Explore">
-        <a href="index.html">Home</a>
-        <a href="dashboard.html">Dashboard</a>
-        <a href="tracking.html">Tracking</a>
-        <a href="planning.html">Planning</a>
-        <a href="routes.html">Routes</a>
-        <a href="info.html">Info hub</a>
-      </nav>
-      <nav class="site-footer__nav" aria-label="Support">
-        <a href="about.html">About</a>
-        <a href="contact.html">Contact</a>
-        <a href="privacy.html">Privacy</a>
-        <a href="terms.html">Terms</a>
-        <a href="settings.html">Settings</a>
-      </nav>
-      <div class="site-footer__social" aria-label="Social channels">
-        <a href="https://discord.gg/qVf3nN4Mgq" aria-label="RouteFlow London on Discord"><i class="fa-brands fa-discord"></i></a>
-        <a href="https://www.tiktok.com/@the_bus_father" aria-label="RouteFlow London on TikTok"><i class="fab fa-tiktok"></i></a>
-        <a href="https://www.instagram.com/thebusfatherofficial/profilecard/?igsh=NXcybzV3cTA2azBo" aria-label="RouteFlow London on Instagram"><i class="fab fa-instagram"></i></a>
-      </div>
     </div>
-    <div class="site-footer__meta">
-      <span>&copy; <span data-current-year></span> RouteFlow London. All rights reserved.</span>
-      <span>Made for London. Accessible for everyone.</span>
-    </div>
-  </footer>
+
+    <footer class="site-footer" aria-label="RouteFlow London footer">
+      <div class="site-footer__inner">
+        <div class="site-footer__brand">
+          <img src="images/New_Routflow_London_Logo.png" alt="RouteFlow London logo">
+          <div>
+            <h2>Stay curious about London’s transport</h2>
+            <p>RouteFlow London turns TfL feeds into playful guidance so planners, families and classrooms can travel with calm confidence.</p>
+            <div class="site-footer__social" role="list">
+              <a href="https://discord.gg/qVf3nN4Mgq" aria-label="RouteFlow London on Discord"><i class="fa-brands fa-discord"></i></a>
+              <a href="https://www.tiktok.com/@the_bus_father" aria-label="RouteFlow London on TikTok"><i class="fa-brands fa-tiktok"></i></a>
+              <a href="https://www.instagram.com/thebusfatherofficial/profilecard/?igsh=NXcybzV3cTA2azBo" aria-label="RouteFlow London on Instagram"><i class="fa-brands fa-instagram"></i></a>
+            </div>
+          </div>
+        </div>
+        <div class="site-footer__grid">
+          <div>
+            <h3 class="site-footer__heading">Plan journeys</h3>
+            <ul class="site-footer__links">
+              <li><a href="index.html">Home</a></li>
+              <li><a href="planning.html">Planning</a></li>
+              <li><a href="tracking.html">Tracking</a></li>
+            </ul>
+          </div>
+          <div>
+            <h3 class="site-footer__heading">Live insight</h3>
+            <ul class="site-footer__links">
+              <li><a href="dashboard.html">Dashboard</a></li>
+              <li><a href="routes.html">Routes</a></li>
+              <li><a href="disruptions.html">Disruptions</a></li>
+            </ul>
+          </div>
+          <div>
+            <h3 class="site-footer__heading">Community data</h3>
+            <ul class="site-footer__links">
+              <li><a href="info.html">Info hub</a></li>
+              <li><a href="fleet.html">Fleet</a></li>
+              <li><a href="withdrawn.html">Withdrawn</a></li>
+            </ul>
+          </div>
+          <div>
+            <h3 class="site-footer__heading">Company</h3>
+            <ul class="site-footer__links">
+              <li><a href="about.html">About</a></li>
+              <li><a href="contact.html">Contact</a></li>
+              <li><a href="privacy.html">Privacy</a></li>
+              <li><a href="terms.html">Terms</a></li>
+            </ul>
+          </div>
+        </div>
+        <div class="site-footer__bottom">
+          <p class="site-footer__legal">© <span data-current-year></span> RouteFlow London. Crafted for curious travellers.</p>
+          <div class="site-footer__meta">
+            <a href="privacy.html">Privacy</a>
+            <a href="terms.html">Terms</a>
+            <a href="contact.html">Contact</a>
+          </div>
+        </div>
+      </div>
+    </footer>
+  </div>
 
   <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-auth-compat.js"></script>

--- a/fleet.html
+++ b/fleet.html
@@ -23,7 +23,12 @@
   </head>
   <body class="site-body">
     <a href="#fleetMain" class="skip-link">Skip to main content</a>
-    <div id="navbar-container"></div>
+    <div class="site-shell">
+      <header class="site-shell__header">
+        <div id="navbar-container" class="site-shell__navbar"></div>
+      </header>
+
+      <div class="site-shell__main">
     <section
       class="auth-gate"
       id="fleetAuthGate"
@@ -446,38 +451,68 @@
 
     </main>
 
-    <footer class="site-footer" aria-label="Footer">
-      <div class="site-footer__inner">
-        <div class="site-footer__brand">
-          <span class="site-footer__name">RouteFlow London</span>
-          <p class="site-footer__description">Playful transport guidance for explorers of every age.</p>
-        </div>
-        <nav class="site-footer__nav" aria-label="Explore">
-          <a href="index.html">Home</a>
-          <a href="dashboard.html">Dashboard</a>
-          <a href="tracking.html">Tracking</a>
-          <a href="planning.html">Planning</a>
-          <a href="routes.html">Routes</a>
-          <a href="info.html">Info hub</a>
-        </nav>
-        <nav class="site-footer__nav" aria-label="Support">
-          <a href="about.html">About</a>
-          <a href="contact.html">Contact</a>
-          <a href="privacy.html">Privacy</a>
-          <a href="terms.html">Terms</a>
-          <a href="settings.html">Settings</a>
-        </nav>
-        <div class="site-footer__social" aria-label="Social channels">
-          <a href="https://discord.gg/qVf3nN4Mgq" aria-label="RouteFlow London on Discord"><i class="fa-brands fa-discord"></i></a>
-          <a href="https://www.tiktok.com/@the_bus_father" aria-label="RouteFlow London on TikTok"><i class="fab fa-tiktok"></i></a>
-          <a href="https://www.instagram.com/thebusfatherofficial/profilecard/?igsh=NXcybzV3cTA2azBo" aria-label="RouteFlow London on Instagram"><i class="fab fa-instagram"></i></a>
-        </div>
       </div>
-      <div class="site-footer__meta">
-        <span>&copy; <span data-current-year></span> RouteFlow London. All rights reserved.</span>
-        <span>Made for London. Accessible for everyone.</span>
-      </div>
-    </footer>
+
+      <footer class="site-footer" aria-label="RouteFlow London footer">
+        <div class="site-footer__inner">
+          <div class="site-footer__brand">
+            <img src="images/New_Routflow_London_Logo.png" alt="RouteFlow London logo">
+            <div>
+              <h2>Stay curious about London’s transport</h2>
+              <p>RouteFlow London turns TfL feeds into playful guidance so planners, families and classrooms can travel with calm confidence.</p>
+              <div class="site-footer__social" role="list">
+                <a href="https://discord.gg/qVf3nN4Mgq" aria-label="RouteFlow London on Discord"><i class="fa-brands fa-discord"></i></a>
+                <a href="https://www.tiktok.com/@the_bus_father" aria-label="RouteFlow London on TikTok"><i class="fa-brands fa-tiktok"></i></a>
+                <a href="https://www.instagram.com/thebusfatherofficial/profilecard/?igsh=NXcybzV3cTA2azBo" aria-label="RouteFlow London on Instagram"><i class="fa-brands fa-instagram"></i></a>
+              </div>
+            </div>
+          </div>
+          <div class="site-footer__grid">
+            <div>
+              <h3 class="site-footer__heading">Plan journeys</h3>
+              <ul class="site-footer__links">
+                <li><a href="index.html">Home</a></li>
+                <li><a href="planning.html">Planning</a></li>
+                <li><a href="tracking.html">Tracking</a></li>
+              </ul>
+            </div>
+            <div>
+              <h3 class="site-footer__heading">Live insight</h3>
+              <ul class="site-footer__links">
+                <li><a href="dashboard.html">Dashboard</a></li>
+                <li><a href="routes.html">Routes</a></li>
+                <li><a href="disruptions.html">Disruptions</a></li>
+              </ul>
+            </div>
+            <div>
+              <h3 class="site-footer__heading">Community data</h3>
+              <ul class="site-footer__links">
+                <li><a href="info.html">Info hub</a></li>
+                <li><a href="fleet.html">Fleet</a></li>
+                <li><a href="withdrawn.html">Withdrawn</a></li>
+              </ul>
+            </div>
+            <div>
+              <h3 class="site-footer__heading">Company</h3>
+              <ul class="site-footer__links">
+                <li><a href="about.html">About</a></li>
+                <li><a href="contact.html">Contact</a></li>
+                <li><a href="privacy.html">Privacy</a></li>
+                <li><a href="terms.html">Terms</a></li>
+              </ul>
+            </div>
+          </div>
+          <div class="site-footer__bottom">
+            <p class="site-footer__legal">© <span data-current-year></span> RouteFlow London. Crafted for curious travellers.</p>
+            <div class="site-footer__meta">
+              <a href="privacy.html">Privacy</a>
+              <a href="terms.html">Terms</a>
+              <a href="contact.html">Contact</a>
+            </div>
+          </div>
+        </div>
+      </footer>
+    </div>
 
     <div
       id="fleetToast"

--- a/index.html
+++ b/index.html
@@ -13,163 +13,183 @@
 </head>
 <body class="site-body">
   <a href="#main-content" class="skip-link">Skip to main content</a>
-  <div id="navbar-container"></div>
+  <div class="site-shell">
+    <header class="site-shell__header">
+      <div id="navbar-container" class="site-shell__navbar"></div>
+    </header>
 
-  <main id="main-content" class="site-main landing" aria-labelledby="landing-title">
+    <div class="site-shell__main">
+      <main id="main-content" class="site-main landing" aria-labelledby="landing-title">
     <section id="section-overview" class="landing-hero card landing-section" data-section="overview" data-animate>
       <div class="landing-hero__content">
-        <p class="landing-hero__eyebrow">London network command deck</p>
-        <h1 id="landing-title">RouteFlow Control keeps every journey aligned.</h1>
+        <p class="landing-hero__eyebrow">Everyday network companion</p>
+        <h1 id="landing-title">RouteFlow Horizon keeps London moving with calm, living maps.</h1>
         <p class="landing-hero__lead">
-          Bring TfL feeds, household plans and classroom challenges into a single command deck. RouteFlow London blends
-          operational clarity with playful storytelling so mobile and desktop dashboards feel like a live control room.
+          Swap panic for clarity. Horizon blends arrivals, disruption notes and community highlights into a warm, collaborative dashboard for planners, families and classroom missions alike.
         </p>
         <div class="landing-hero__actions" role="group">
           <a class="landing-hero__button landing-hero__button--primary" href="dashboard.html">
-            <i class="fa-solid fa-wave-square"></i>
-            Launch control room
+            <i class="fa-regular fa-compass"></i>
+            Start Horizon workspace
           </a>
           <a class="landing-hero__button" href="tracking.html">
-            <i class="fa-solid fa-satellite-dish"></i>
-            Track live arrivals
+            <i class="fa-solid fa-signal"></i>
+            View live network
           </a>
         </div>
-        <dl class="landing-hero__metrics" aria-label="RouteFlow stats">
+        <dl class="landing-hero__metrics" aria-label="RouteFlow Horizon highlights">
           <div>
-            <dt>Live feeds captured</dt>
-            <dd>18 TfL datasets</dd>
+            <dt>Live journeys</dt>
+            <dd>42,800 refreshed nightly</dd>
           </div>
           <div>
-            <dt>Journeys in sync</dt>
-            <dd>52,400 shared plans</dd>
+            <dt>Neighbourhood signals</dt>
+            <dd>18 borough spotlights</dd>
           </div>
           <div>
-            <dt>Community notes</dt>
-            <dd>Updated every hour</dd>
+            <dt>Safety check-ins</dt>
+            <dd>1,240 this week</dd>
           </div>
         </dl>
       </div>
       <div class="landing-hero__preview" aria-hidden="true">
         <div class="landing-preview">
           <header class="landing-preview__header">
-            <span class="landing-preview__label">Evening briefing</span>
-            <span class="landing-preview__level">Network amber</span>
+            <span class="landing-preview__label">Horizon signal</span>
+            <span class="landing-preview__level">Calm &amp; clear</span>
           </header>
           <div class="landing-preview__status">
-            <span class="landing-preview__badge">4 alerts tracking</span>
-            <span class="landing-preview__meta">Next sweep in 6 mins</span>
+            <span class="landing-preview__badge">2 mindful diversions</span>
+            <span class="landing-preview__meta">Next refresh in 05:00</span>
+          </div>
+          <div class="landing-preview__clusters">
+            <div class="landing-preview__cluster">
+              <span class="landing-preview__cluster-label">Live watchers</span>
+              <span class="landing-preview__cluster-value">162 planners</span>
+              <span class="landing-preview__cluster-trend"><i class="fa-solid fa-arrow-trend-up" aria-hidden="true"></i> +22 this hour</span>
+            </div>
+            <div class="landing-preview__cluster">
+              <span class="landing-preview__cluster-label">Community notes</span>
+              <span class="landing-preview__cluster-value">31 stories</span>
+              <span class="landing-preview__cluster-trend"><i class="fa-solid fa-sparkles" aria-hidden="true"></i> 9 school updates</span>
+            </div>
+            <div class="landing-preview__cluster">
+              <span class="landing-preview__cluster-label">Access checks</span>
+              <span class="landing-preview__cluster-value">54 verified</span>
+              <span class="landing-preview__cluster-trend"><i class="fa-solid fa-wheelchair-move" aria-hidden="true"></i> zero blockers</span>
+            </div>
           </div>
           <ol class="landing-preview__timeline">
             <li>
-              <span class="landing-preview__time">16:05</span>
-              <div>
-                <strong>Route 29 extras</strong>
-                <p>Duplicate allocation covers Camden Town crowding window.</p>
-              </div>
-            </li>
-            <li>
-              <span class="landing-preview__time">16:11</span>
+              <span class="landing-preview__time">07:42</span>
               <div>
                 <strong>Victoria line</strong>
-                <p>Minor dwell increases at Oxford Circus &mdash; reroute suggestion active.</p>
+                <p>Southbound dwell easing &mdash; Brixton hold cleared after two calm cycles.</p>
               </div>
             </li>
             <li>
-              <span class="landing-preview__time">16:18</span>
+              <span class="landing-preview__time">08:05</span>
               <div>
-                <strong>Learning badge</strong>
-                <p>Year 8 travel club logged two accessibility spot checks.</p>
+                <strong>Route 390 relief</strong>
+                <p>Extra decker dispatched; Holloway crowding back below threshold.</p>
+              </div>
+            </li>
+            <li>
+              <span class="landing-preview__time">08:18</span>
+              <div>
+                <strong>Learning mission</strong>
+                <p>Year 8 crew logged lift status video from King&#39;s Cross for morning briefings.</p>
               </div>
             </li>
           </ol>
           <footer class="landing-preview__footer">
-            <a class="landing-preview__cta" href="dashboard.html">Review operations board</a>
+            <a class="landing-preview__cta" href="dashboard.html">Open Horizon console</a>
           </footer>
         </div>
       </div>
     </section>
 
     <nav class="landing-quicknav card" aria-label="Page quick navigation" data-quicknav data-animate>
-      <h2 class="landing-quicknav__title">Jump to a mission segment</h2>
+      <h2 class="landing-quicknav__title">Explore Horizon</h2>
       <ul class="landing-quicknav__list" role="list">
-        <li><a href="#section-overview">Overview</a></li>
-        <li><a href="#section-pillars">Pillars</a></li>
-        <li><a href="#section-modes">Modes</a></li>
-        <li><a href="#section-devices">Devices</a></li>
-        <li><a href="#section-tools">Tools</a></li>
-        <li><a href="#section-briefings">Briefings</a></li>
-        <li><a href="#section-updates">Updates</a></li>
+        <li><a href="#section-overview">Horizon overview</a></li>
+        <li><a href="#section-pillars">Guiding principles</a></li>
+        <li><a href="#section-modes">Mission modes</a></li>
+        <li><a href="#section-devices">Device mesh</a></li>
+        <li><a href="#section-tools">Toolchain</a></li>
+        <li><a href="#section-briefings">Story studio</a></li>
+        <li><a href="#section-updates">Signal updates</a></li>
       </ul>
     </nav>
 
     <section id="section-pillars" class="landing-panels landing-section" aria-label="RouteFlow pillars" data-section="pillars" data-animate>
       <article class="landing-panel">
         <div class="landing-panel__icon" aria-hidden="true">
-          <i class="fa-solid fa-compass-drafting"></i>
+          <i class="fa-solid fa-wave-square"></i>
         </div>
         <div class="landing-panel__content">
-          <h2>Responsive mission views</h2>
-          <p>Switch between map, timeline and status boards that flex perfectly between widescreen desktops and handheld devices.</p>
+          <h2>Unified control loops</h2>
+          <p>Blend arrivals, dwell analytics and manual overrides without switching tabs &mdash; Horizon keeps planners and on-the-ground stewards in rhythm.</p>
         </div>
       </article>
       <article class="landing-panel">
         <div class="landing-panel__icon" aria-hidden="true">
-          <i class="fa-solid fa-people-group"></i>
+          <i class="fa-solid fa-layer-group"></i>
         </div>
         <div class="landing-panel__content">
-          <h2>Shared planning rituals</h2>
-          <p>Invite families, classrooms and teams to co-create itineraries, leaving comments that sync back to your RouteFlow database.</p>
+          <h2>Scenario layering</h2>
+          <p>Stack evacuation drills, school trips and community meetups to stress-test journeys before anyone taps in.</p>
         </div>
       </article>
       <article class="landing-panel">
         <div class="landing-panel__icon" aria-hidden="true">
-          <i class="fa-solid fa-lightbulb"></i>
+          <i class="fa-solid fa-sparkles"></i>
         </div>
         <div class="landing-panel__content">
-          <h2>Insightful storytelling</h2>
-          <p>Surface TfL performance trends with narrative cards tailored for assemblies, newsletters or on-the-go travel briefings.</p>
+          <h2>Story-driven analytics</h2>
+          <p>Transform cold metrics into narrative slides that celebrate achievements and highlight equity gaps.</p>
         </div>
       </article>
     </section>
 
     <section id="section-modes" class="landing-gamify card landing-section" aria-label="Operations modes" data-section="modes" data-animate>
       <header class="landing-gamify__header">
-        <p class="landing-gamify__eyebrow">From control room to classroom</p>
-        <h2>Translate live transport data into confident action.</h2>
-        <p>Use RouteFlow London to orchestrate departures, test emergency plans and celebrate learning milestones &mdash; all backed by the same database.</p>
+        <p class="landing-gamify__eyebrow">Mission control for humans</p>
+        <h2>Design rehearsals, resilience drills and playful briefings from one hub.</h2>
+        <p>Horizon converts raw feeds into cinematic surfaces for network controllers, teachers and community leads.</p>
       </header>
       <div class="landing-gamify__grid">
         <article class="landing-gamify__item">
-          <span class="landing-gamify__icon" aria-hidden="true"><i class="fa-solid fa-signal"></i></span>
-          <h3>Operations pulse</h3>
-          <p>Overlay live arrivals with service health and vehicle allocations so you know when to hold, dispatch or reroute.</p>
+          <span class="landing-gamify__icon" aria-hidden="true"><i class="fa-solid fa-diagram-project"></i></span>
+          <h3>Network rehearsals</h3>
+          <p>Simulate closures and crowding waves, then auto-generate holding patterns and depot alerts.</p>
         </article>
         <article class="landing-gamify__item">
           <span class="landing-gamify__icon" aria-hidden="true"><i class="fa-solid fa-shield-heart"></i></span>
-          <h3>Care journeys</h3>
-          <p>Custom access notes, assistance reminders and safeguarding prompts follow every saved route.</p>
+          <h3>Care guardianship</h3>
+          <p>Surface accessibility notes, quiet carriage options and wellbeing check-ins for every traveller.</p>
         </article>
         <article class="landing-gamify__item">
-          <span class="landing-gamify__icon" aria-hidden="true"><i class="fa-solid fa-chalkboard-user"></i></span>
-          <h3>Learning missions</h3>
-          <p>Gamified modules reward research, travel etiquette and on-the-ground observations to keep young travellers motivated.</p>
+          <span class="landing-gamify__icon" aria-hidden="true"><i class="fa-solid fa-trophy"></i></span>
+          <h3>Playful missions</h3>
+          <p>Reward curiosity with badges, quizzes and evidence uploads tied to the routes you approve.</p>
         </article>
         <article class="landing-gamify__item">
-          <span class="landing-gamify__icon" aria-hidden="true"><i class="fa-solid fa-notes-medical"></i></span>
-          <h3>Rapid response log</h3>
-          <p>Capture incident reports, upload media and assign follow-up tasks without leaving the RouteFlow workspace.</p>
+          <span class="landing-gamify__icon" aria-hidden="true"><i class="fa-solid fa-file-circle-check"></i></span>
+          <h3>Incident chronicles</h3>
+          <p>Capture voice notes, photos and follow-up tasks while keeping everyone aligned on next actions.</p>
         </article>
       </div>
     </section>
 
     <section id="section-devices" class="landing-devices landing-section" aria-label="Cross-platform layouts" data-section="devices" data-animate>
       <div class="landing-devices__card card">
-        <h2>Beautiful on desktop, bold on mobile.</h2>
-        <p>Adaptive panels reshape into vertical stories on phones and detailed grids on tablets or widescreen monitors. Dark mode and reduced-motion modes are only a tap away.</p>
+        <h2>Responsive canvases on every device.</h2>
+        <p>From war-room displays to student tablets, Horizon morphs panels into focused stories with dark mode, readable fonts and reduced motion ready to go.</p>
         <ul class="landing-devices__list">
-          <li><i class="fa-solid fa-display" aria-hidden="true"></i> Command desks with wall displays</li>
-          <li><i class="fa-solid fa-tablet-screen-button" aria-hidden="true"></i> Tablets for on-the-go inspections</li>
-          <li><i class="fa-solid fa-mobile-screen-button" aria-hidden="true"></i> Quick-glance mobile summaries</li>
+          <li><i class="fa-solid fa-display" aria-hidden="true"></i> Wall-scale situation rooms</li>
+          <li><i class="fa-solid fa-tablet-screen-button" aria-hidden="true"></i> Field inspections with offline caching</li>
+          <li><i class="fa-solid fa-mobile-screen-button" aria-hidden="true"></i> Pocket summaries for duty managers</li>
         </ul>
       </div>
       <div class="landing-devices__mock card" aria-hidden="true">
@@ -181,15 +201,15 @@
           <div class="landing-devices__grid">
             <div>
               <strong>Alerts lane</strong>
-              <p>Timeline tiles glow red when thresholds cross, keeping attention on what matters.</p>
+              <p>Pulse tiles glow when service health shifts or intervention scripts trigger.</p>
             </div>
             <div>
               <strong>People view</strong>
-              <p>Monitor guardians, staff and students with quick messaging shortcuts and safety flags.</p>
+              <p>Map guardians, staff and pupils with instant messaging and safeguarding signals.</p>
             </div>
             <div>
               <strong>Performance cards</strong>
-              <p>Compare modal reliability, average dwell times and crowding to improve your plans.</p>
+              <p>Compare reliability, crowding and sentiment to inform your next briefing.</p>
             </div>
           </div>
         </div>
@@ -198,27 +218,27 @@
 
     <section id="section-tools" class="landing-tools card landing-section" aria-label="Core tools" data-section="tools" data-animate>
       <header class="landing-tools__header">
-        <p class="landing-tools__eyebrow">Pick your toolkit</p>
-        <h2>Every screen speaks to the same RouteFlow database.</h2>
-        <p class="landing-tools__lead">Journeys, fleet updates and classroom activities stay in sync on desktop dashboards, tablets and mobile checklists.</p>
+        <p class="landing-tools__eyebrow">Choose your control surface</p>
+        <h2>The Horizon toolchain keeps fleet, journeys and stories in sync.</h2>
+        <p class="landing-tools__lead">Every module speaks to the same datastore, so insights flow from dispatchers to classrooms without duplication.</p>
       </header>
       <div class="landing-tools__grid">
         <article class="landing-tool landing-tool--accent">
           <div class="landing-tool__icon" aria-hidden="true"><i class="fa-solid fa-bus"></i></div>
           <h3>Live tracking</h3>
-          <p>Filter arrivals by stop, line or fleet number and attach quick notes for your community.</p>
+          <p>Filter arrivals by stop, line or fleet number and annotate movements for your network family.</p>
           <a class="landing-tool__link" href="tracking.html">Monitor arrivals</a>
         </article>
         <article class="landing-tool">
           <div class="landing-tool__icon" aria-hidden="true"><i class="fa-solid fa-map-location-dot"></i></div>
           <h3>Journey studio</h3>
-          <p>Plan multi-modal trips with step-free, quiet-route and dwell-time options at your fingertips.</p>
+          <p>Design multi-modal trips with step-free, quiet route and dwell-time constraints baked in.</p>
           <a class="landing-tool__link" href="planning.html">Plan a journey</a>
         </article>
         <article class="landing-tool">
           <div class="landing-tool__icon" aria-hidden="true"><i class="fa-solid fa-layer-group"></i></div>
           <h3>Network intelligence</h3>
-          <p>Explore fleet breakdowns, disruption archives and success stories to inform your next move.</p>
+          <p>Explore fleet breakdowns, disruption archives and success stories to guide your next move.</p>
           <a class="landing-tool__link" href="routes.html">Explore the data</a>
         </article>
       </div>
@@ -226,21 +246,21 @@
 
     <section id="section-briefings" class="landing-blog card landing-section" aria-label="Latest briefings" data-section="briefings" data-animate>
       <header class="landing-blog__header">
-        <p class="landing-blog__eyebrow">Knowledge transmissions</p>
-        <h2>Briefings, analysis and community success stories</h2>
-        <p>Everything you publish through the admin console updates instantly across the platform for both desktop and mobile readers.</p>
+        <p class="landing-blog__eyebrow">Story studio transmissions</p>
+        <h2>Briefings, deep dives and community spotlights</h2>
+        <p>Curate dispatches once inside the admin console and watch them shimmer across dashboards, mobile digests and classroom screens.</p>
       </header>
       <div class="landing-blog__grid" data-blog-list data-blog-limit="3" data-blog-variant="card" data-blog-empty="Check back soon for new stories."></div>
       <footer class="landing-blog__footer">
         <a class="landing-blog__cta" href="info.html">Browse the knowledge base</a>
-        <span class="landing-blog__hint">Curate new articles, imagery and badges directly from the database-backed admin view.</span>
+        <span class="landing-blog__hint">Publish new articles, artwork and mission badges directly from Horizon Studio.</span>
       </footer>
     </section>
 
     <section id="section-updates" class="landing-updates card landing-section" aria-label="Newsletter" data-section="updates" data-animate>
       <div class="landing-updates__content">
         <h2>Stay ahead of the next service change</h2>
-        <p>We only send high-signal updates: new datasets, layout upgrades and travel literacy packs.</p>
+        <p>Receive high-signal updates on dataset releases, interface upgrades and travel literacy kits.</p>
       </div>
       <div class="landing-updates__form">
         <form id="newsletter-form" class="landing-updates__newsletter" novalidate data-newsletter-form>
@@ -254,45 +274,74 @@
               </button>
             </div>
           </div>
-          <p class="landing-updates__privacy">We respect your inbox. Expect at most one mission briefing per week.</p>
+          <p class="landing-updates__privacy">Only handcrafted dispatches &mdash; at most one luminous update per week.</p>
           <p class="landing-updates__message" data-newsletter-message aria-live="polite"></p>
         </form>
       </div>
     </section>
-  </main>
+      </main>
+    </div>
 
-  <footer class="site-footer" aria-label="Footer">
-    <div class="site-footer__inner">
-      <div class="site-footer__brand">
-        <span class="site-footer__name">RouteFlow London</span>
-        <p class="site-footer__description">Real-time TfL intelligence for curious travellers.</p>
+    <footer class="site-footer" aria-label="RouteFlow London footer">
+      <div class="site-footer__inner">
+        <div class="site-footer__brand">
+          <img src="images/New_Routflow_London_Logo.png" alt="RouteFlow London logo">
+          <div>
+            <h2>Stay curious about London’s transport</h2>
+            <p>RouteFlow London turns TfL feeds into playful guidance so planners, families and classrooms can travel with calm confidence.</p>
+            <div class="site-footer__social" role="list">
+              <a href="https://discord.gg/qVf3nN4Mgq" aria-label="RouteFlow London on Discord"><i class="fa-brands fa-discord"></i></a>
+              <a href="https://www.tiktok.com/@the_bus_father" aria-label="RouteFlow London on TikTok"><i class="fa-brands fa-tiktok"></i></a>
+              <a href="https://www.instagram.com/thebusfatherofficial/profilecard/?igsh=NXcybzV3cTA2azBo" aria-label="RouteFlow London on Instagram"><i class="fa-brands fa-instagram"></i></a>
+            </div>
+          </div>
+        </div>
+        <div class="site-footer__grid">
+          <div>
+            <h3 class="site-footer__heading">Plan journeys</h3>
+            <ul class="site-footer__links">
+              <li><a href="index.html">Home</a></li>
+              <li><a href="planning.html">Planning</a></li>
+              <li><a href="tracking.html">Tracking</a></li>
+            </ul>
+          </div>
+          <div>
+            <h3 class="site-footer__heading">Live insight</h3>
+            <ul class="site-footer__links">
+              <li><a href="dashboard.html">Dashboard</a></li>
+              <li><a href="routes.html">Routes</a></li>
+              <li><a href="disruptions.html">Disruptions</a></li>
+            </ul>
+          </div>
+          <div>
+            <h3 class="site-footer__heading">Community data</h3>
+            <ul class="site-footer__links">
+              <li><a href="info.html">Info hub</a></li>
+              <li><a href="fleet.html">Fleet</a></li>
+              <li><a href="withdrawn.html">Withdrawn</a></li>
+            </ul>
+          </div>
+          <div>
+            <h3 class="site-footer__heading">Company</h3>
+            <ul class="site-footer__links">
+              <li><a href="about.html">About</a></li>
+              <li><a href="contact.html">Contact</a></li>
+              <li><a href="privacy.html">Privacy</a></li>
+              <li><a href="terms.html">Terms</a></li>
+            </ul>
+          </div>
+        </div>
+        <div class="site-footer__bottom">
+          <p class="site-footer__legal">© <span data-current-year></span> RouteFlow London. Crafted for curious travellers.</p>
+          <div class="site-footer__meta">
+            <a href="privacy.html">Privacy</a>
+            <a href="terms.html">Terms</a>
+            <a href="contact.html">Contact</a>
+          </div>
+        </div>
       </div>
-      <nav class="site-footer__nav" aria-label="Explore">
-        <a href="index.html">Home</a>
-        <a href="dashboard.html">Dashboard</a>
-        <a href="tracking.html">Tracking</a>
-        <a href="planning.html">Planning</a>
-        <a href="routes.html">Routes</a>
-        <a href="info.html">Info hub</a>
-      </nav>
-      <nav class="site-footer__nav" aria-label="Support">
-        <a href="about.html">About</a>
-        <a href="contact.html">Contact</a>
-        <a href="privacy.html">Privacy</a>
-        <a href="terms.html">Terms</a>
-        <a href="settings.html">Settings</a>
-      </nav>
-      <div class="site-footer__social" aria-label="Social channels">
-        <a href="https://discord.gg/qVf3nN4Mgq" aria-label="RouteFlow London on Discord"><i class="fa-brands fa-discord"></i></a>
-        <a href="https://www.tiktok.com/@the_bus_father" aria-label="RouteFlow London on TikTok"><i class="fab fa-tiktok"></i></a>
-        <a href="https://www.instagram.com/thebusfatherofficial/profilecard/?igsh=NXcybzV3cTA2azBo" aria-label="RouteFlow London on Instagram"><i class="fab fa-instagram"></i></a>
-      </div>
-    </div>
-    <div class="site-footer__meta">
-      <span>&copy; <span data-current-year></span> RouteFlow London. All rights reserved.</span>
-      <span>Built for Londoners, accessible everywhere.</span>
-    </div>
-  </footer>
+    </footer>
+  </div>
 
   <script src="navbar-loader.js"></script>
   <script src="info.js" type="module"></script>

--- a/info.html
+++ b/info.html
@@ -13,8 +13,12 @@
 </head>
 <body class="site-body">
   <a href="#main-content" class="skip-link">Skip to main content</a>
-  <div id="navbar-container"></div>
+  <div class="site-shell">
+    <header class="site-shell__header">
+      <div id="navbar-container" class="site-shell__navbar"></div>
+    </header>
 
+    <div class="site-shell__main">
   <main id="main-content" class="site-main blog-shell" aria-labelledby="infoTitle">
     <section class="blog-hero card">
       <div class="blog-hero__content">
@@ -161,38 +165,68 @@
 
   </main>
 
-  <footer class="site-footer" aria-label="Footer">
-    <div class="site-footer__inner">
-      <div class="site-footer__brand">
-        <span class="site-footer__name">RouteFlow London</span>
-        <p class="site-footer__description">Playful transport guidance for explorers of every age.</p>
-      </div>
-      <nav class="site-footer__nav" aria-label="Explore">
-        <a href="index.html">Home</a>
-        <a href="dashboard.html">Dashboard</a>
-        <a href="tracking.html">Tracking</a>
-        <a href="planning.html">Planning</a>
-        <a href="routes.html">Routes</a>
-        <a href="info.html">Info hub</a>
-      </nav>
-      <nav class="site-footer__nav" aria-label="Support">
-        <a href="about.html">About</a>
-        <a href="contact.html">Contact</a>
-        <a href="privacy.html">Privacy</a>
-        <a href="terms.html">Terms</a>
-        <a href="settings.html">Settings</a>
-      </nav>
-      <div class="site-footer__social" aria-label="Social channels">
-        <a href="https://discord.gg/qVf3nN4Mgq" aria-label="RouteFlow London on Discord"><i class="fa-brands fa-discord"></i></a>
-        <a href="https://www.tiktok.com/@the_bus_father" aria-label="RouteFlow London on TikTok"><i class="fab fa-tiktok"></i></a>
-        <a href="https://www.instagram.com/thebusfatherofficial/profilecard/?igsh=NXcybzV3cTA2azBo" aria-label="RouteFlow London on Instagram"><i class="fab fa-instagram"></i></a>
-      </div>
     </div>
-    <div class="site-footer__meta">
-      <span>&copy; <span data-current-year></span> RouteFlow London. All rights reserved.</span>
-      <span>Made for London. Accessible for everyone.</span>
-    </div>
-  </footer>
+
+    <footer class="site-footer" aria-label="RouteFlow London footer">
+      <div class="site-footer__inner">
+        <div class="site-footer__brand">
+          <img src="images/New_Routflow_London_Logo.png" alt="RouteFlow London logo">
+          <div>
+            <h2>Stay curious about London’s transport</h2>
+            <p>RouteFlow London turns TfL feeds into playful guidance so planners, families and classrooms can travel with calm confidence.</p>
+            <div class="site-footer__social" role="list">
+              <a href="https://discord.gg/qVf3nN4Mgq" aria-label="RouteFlow London on Discord"><i class="fa-brands fa-discord"></i></a>
+              <a href="https://www.tiktok.com/@the_bus_father" aria-label="RouteFlow London on TikTok"><i class="fa-brands fa-tiktok"></i></a>
+              <a href="https://www.instagram.com/thebusfatherofficial/profilecard/?igsh=NXcybzV3cTA2azBo" aria-label="RouteFlow London on Instagram"><i class="fa-brands fa-instagram"></i></a>
+            </div>
+          </div>
+        </div>
+        <div class="site-footer__grid">
+          <div>
+            <h3 class="site-footer__heading">Plan journeys</h3>
+            <ul class="site-footer__links">
+              <li><a href="index.html">Home</a></li>
+              <li><a href="planning.html">Planning</a></li>
+              <li><a href="tracking.html">Tracking</a></li>
+            </ul>
+          </div>
+          <div>
+            <h3 class="site-footer__heading">Live insight</h3>
+            <ul class="site-footer__links">
+              <li><a href="dashboard.html">Dashboard</a></li>
+              <li><a href="routes.html">Routes</a></li>
+              <li><a href="disruptions.html">Disruptions</a></li>
+            </ul>
+          </div>
+          <div>
+            <h3 class="site-footer__heading">Community data</h3>
+            <ul class="site-footer__links">
+              <li><a href="info.html">Info hub</a></li>
+              <li><a href="fleet.html">Fleet</a></li>
+              <li><a href="withdrawn.html">Withdrawn</a></li>
+            </ul>
+          </div>
+          <div>
+            <h3 class="site-footer__heading">Company</h3>
+            <ul class="site-footer__links">
+              <li><a href="about.html">About</a></li>
+              <li><a href="contact.html">Contact</a></li>
+              <li><a href="privacy.html">Privacy</a></li>
+              <li><a href="terms.html">Terms</a></li>
+            </ul>
+          </div>
+        </div>
+        <div class="site-footer__bottom">
+          <p class="site-footer__legal">© <span data-current-year></span> RouteFlow London. Crafted for curious travellers.</p>
+          <div class="site-footer__meta">
+            <a href="privacy.html">Privacy</a>
+            <a href="terms.html">Terms</a>
+            <a href="contact.html">Contact</a>
+          </div>
+        </div>
+      </div>
+    </footer>
+  </div>
 
   <script src="navbar-loader.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-app-compat.js"></script>

--- a/landing.js
+++ b/landing.js
@@ -79,6 +79,8 @@ const initialiseQuickNav = () => {
     return () => {};
   }
 
+  nav.style.setProperty('--quicknav-count', String(sections.length));
+
   const setActive = (id) => {
     sections.forEach(({ link, id: entryId }) => {
       const isActive = entryId === id;
@@ -89,6 +91,13 @@ const initialiseQuickNav = () => {
         link.removeAttribute('aria-current');
       }
     });
+    const index = sections.findIndex((entry) => entry.id === id);
+    if (index >= 0) {
+      const ratio = sections.length ? (index + 1) / sections.length : 0;
+      nav.style.setProperty('--quicknav-index', String(index));
+      nav.style.setProperty('--quicknav-progress', ratio.toFixed(4));
+      nav.dataset.activeSection = id;
+    }
   };
 
   if (sections[0]) {

--- a/mobile-app.css
+++ b/mobile-app.css
@@ -1,7 +1,7 @@
 :root {
   --app-dock-height: 76px;
-  --app-dock-border: rgba(15, 76, 129, 0.14);
-  --app-dock-shadow: 0 24px 46px rgba(15, 76, 129, 0.18);
+  --app-dock-border: rgba(37, 99, 235, 0.18);
+  --app-dock-shadow: 0 24px 40px rgba(37, 99, 235, 0.18);
 }
 
 body[data-has-app-dock="true"] {
@@ -14,7 +14,7 @@ body[data-has-app-dock="true"] {
   bottom: max(1.2rem, env(safe-area-inset-bottom));
   transform: translateX(-50%);
   width: min(480px, calc(100% - 2.6rem));
-  background: rgba(255, 255, 255, 0.92);
+  background: rgba(255, 255, 255, 0.95);
   border-radius: 24px;
   border: 1px solid var(--app-dock-border);
   box-shadow: var(--app-dock-shadow);
@@ -44,7 +44,7 @@ body[data-has-app-dock="true"] {
   gap: 0.3rem;
   padding: 0.6rem 0.25rem;
   border-radius: 18px;
-  color: rgba(32, 19, 25, 0.72);
+  color: rgba(11, 18, 32, 0.74);
   font-weight: 600;
   font-size: 0.82rem;
   letter-spacing: 0.01em;
@@ -54,7 +54,7 @@ body[data-has-app-dock="true"] {
 
 .app-dock__icon {
   font-size: 1.2rem;
-  color: var(--calm-blue);
+  color: #2563eb;
   display: inline-flex;
 }
 
@@ -64,19 +64,19 @@ body[data-has-app-dock="true"] {
 
 .app-dock__link:hover,
 .app-dock__link:focus-visible {
-  color: var(--calm-blue);
-  background: rgba(15, 76, 129, 0.08);
+  color: #2563eb;
+  background: rgba(37, 99, 235, 0.14);
   transform: translateY(-2px);
   outline: none;
 }
 
 .app-dock__link.is-active {
-  color: var(--primary);
-  background: rgba(208, 0, 37, 0.12);
+  color: #1d4ed8;
+  background: rgba(37, 99, 235, 0.18);
 }
 
 .app-dock__link.is-active .app-dock__icon {
-  color: var(--primary);
+  color: #1d4ed8;
 }
 
 body.dark-mode[data-has-app-dock="true"] {
@@ -84,23 +84,23 @@ body.dark-mode[data-has-app-dock="true"] {
 }
 
 body.dark-mode .app-dock {
-  background: rgba(20, 12, 22, 0.92);
-  border-color: rgba(251, 247, 248, 0.12);
-  box-shadow: 0 24px 46px rgba(0, 0, 0, 0.38);
+  background: rgba(15, 23, 42, 0.9);
+  border-color: rgba(96, 165, 250, 0.24);
+  box-shadow: 0 24px 46px rgba(2, 6, 23, 0.5);
 }
 
 body.dark-mode .app-dock__link {
-  color: rgba(251, 247, 248, 0.72);
+  color: rgba(226, 232, 240, 0.78);
 }
 
 body.dark-mode .app-dock__link:hover,
 body.dark-mode .app-dock__link:focus-visible {
-  background: rgba(122, 185, 255, 0.18);
+  background: rgba(96, 165, 250, 0.24);
   color: #ffffff;
 }
 
 body.dark-mode .app-dock__link.is-active {
-  background: rgba(208, 0, 37, 0.32);
+  background: rgba(96, 165, 250, 0.3);
   color: #ffffff;
 }
 

--- a/password-reset.html
+++ b/password-reset.html
@@ -13,8 +13,12 @@
 </head>
 <body class="site-body">
   <a href="#main-content" class="skip-link">Skip to main content</a>
-  <div id="navbar-container"></div>
+  <div class="site-shell">
+    <header class="site-shell__header">
+      <div id="navbar-container" class="site-shell__navbar"></div>
+    </header>
 
+    <div class="site-shell__main">
   <main id="main-content" class="site-main page-shell" aria-labelledby="resetTitle">
     <section class="page-hero">
       <div class="page-hero__content">
@@ -36,38 +40,68 @@
     </section>
   </main>
 
-  <footer class="site-footer" aria-label="Footer">
-    <div class="site-footer__inner">
-      <div class="site-footer__brand">
-        <span class="site-footer__name">RouteFlow London</span>
-        <p class="site-footer__description">Playful transport guidance for explorers of every age.</p>
-      </div>
-      <nav class="site-footer__nav" aria-label="Explore">
-        <a href="index.html">Home</a>
-        <a href="dashboard.html">Dashboard</a>
-        <a href="tracking.html">Tracking</a>
-        <a href="planning.html">Planning</a>
-        <a href="routes.html">Routes</a>
-        <a href="info.html">Info hub</a>
-      </nav>
-      <nav class="site-footer__nav" aria-label="Support">
-        <a href="about.html">About</a>
-        <a href="contact.html">Contact</a>
-        <a href="privacy.html">Privacy</a>
-        <a href="terms.html">Terms</a>
-        <a href="settings.html">Settings</a>
-      </nav>
-      <div class="site-footer__social" aria-label="Social channels">
-        <a href="https://discord.gg/qVf3nN4Mgq" aria-label="RouteFlow London on Discord"><i class="fa-brands fa-discord"></i></a>
-        <a href="https://www.tiktok.com/@the_bus_father" aria-label="RouteFlow London on TikTok"><i class="fab fa-tiktok"></i></a>
-        <a href="https://www.instagram.com/thebusfatherofficial/profilecard/?igsh=NXcybzV3cTA2azBo" aria-label="RouteFlow London on Instagram"><i class="fab fa-instagram"></i></a>
-      </div>
     </div>
-    <div class="site-footer__meta">
-      <span>&copy; <span data-current-year></span> RouteFlow London. All rights reserved.</span>
-      <span>Made for London. Accessible for everyone.</span>
-    </div>
-  </footer>
+
+    <footer class="site-footer" aria-label="RouteFlow London footer">
+      <div class="site-footer__inner">
+        <div class="site-footer__brand">
+          <img src="images/New_Routflow_London_Logo.png" alt="RouteFlow London logo">
+          <div>
+            <h2>Stay curious about London’s transport</h2>
+            <p>RouteFlow London turns TfL feeds into playful guidance so planners, families and classrooms can travel with calm confidence.</p>
+            <div class="site-footer__social" role="list">
+              <a href="https://discord.gg/qVf3nN4Mgq" aria-label="RouteFlow London on Discord"><i class="fa-brands fa-discord"></i></a>
+              <a href="https://www.tiktok.com/@the_bus_father" aria-label="RouteFlow London on TikTok"><i class="fa-brands fa-tiktok"></i></a>
+              <a href="https://www.instagram.com/thebusfatherofficial/profilecard/?igsh=NXcybzV3cTA2azBo" aria-label="RouteFlow London on Instagram"><i class="fa-brands fa-instagram"></i></a>
+            </div>
+          </div>
+        </div>
+        <div class="site-footer__grid">
+          <div>
+            <h3 class="site-footer__heading">Plan journeys</h3>
+            <ul class="site-footer__links">
+              <li><a href="index.html">Home</a></li>
+              <li><a href="planning.html">Planning</a></li>
+              <li><a href="tracking.html">Tracking</a></li>
+            </ul>
+          </div>
+          <div>
+            <h3 class="site-footer__heading">Live insight</h3>
+            <ul class="site-footer__links">
+              <li><a href="dashboard.html">Dashboard</a></li>
+              <li><a href="routes.html">Routes</a></li>
+              <li><a href="disruptions.html">Disruptions</a></li>
+            </ul>
+          </div>
+          <div>
+            <h3 class="site-footer__heading">Community data</h3>
+            <ul class="site-footer__links">
+              <li><a href="info.html">Info hub</a></li>
+              <li><a href="fleet.html">Fleet</a></li>
+              <li><a href="withdrawn.html">Withdrawn</a></li>
+            </ul>
+          </div>
+          <div>
+            <h3 class="site-footer__heading">Company</h3>
+            <ul class="site-footer__links">
+              <li><a href="about.html">About</a></li>
+              <li><a href="contact.html">Contact</a></li>
+              <li><a href="privacy.html">Privacy</a></li>
+              <li><a href="terms.html">Terms</a></li>
+            </ul>
+          </div>
+        </div>
+        <div class="site-footer__bottom">
+          <p class="site-footer__legal">© <span data-current-year></span> RouteFlow London. Crafted for curious travellers.</p>
+          <div class="site-footer__meta">
+            <a href="privacy.html">Privacy</a>
+            <a href="terms.html">Terms</a>
+            <a href="contact.html">Contact</a>
+          </div>
+        </div>
+      </div>
+    </footer>
+  </div>
 
   <script src="main.js" defer></script>
   <script type="module">

--- a/planning.html
+++ b/planning.html
@@ -13,8 +13,12 @@
 </head>
 <body class="site-body">
   <a href="#main-content" class="skip-link">Skip to main content</a>
-  <div id="navbar-container"></div>
+  <div class="site-shell">
+    <header class="site-shell__header">
+      <div id="navbar-container" class="site-shell__navbar"></div>
+    </header>
 
+    <div class="site-shell__main">
   <main id="main-content" class="site-main planning-shell" aria-labelledby="planningTitle">
     <section class="planning-hero">
       <div class="planning-hero__content">
@@ -108,38 +112,68 @@
     </section>
   </main>
 
-  <footer class="site-footer" aria-label="Footer">
-    <div class="site-footer__inner">
-      <div class="site-footer__brand">
-        <span class="site-footer__name">RouteFlow London</span>
-        <p class="site-footer__description">Playful transport guidance for explorers of every age.</p>
-      </div>
-      <nav class="site-footer__nav" aria-label="Explore">
-        <a href="index.html">Home</a>
-        <a href="dashboard.html">Dashboard</a>
-        <a href="tracking.html">Tracking</a>
-        <a href="planning.html">Planning</a>
-        <a href="routes.html">Routes</a>
-        <a href="info.html">Info hub</a>
-      </nav>
-      <nav class="site-footer__nav" aria-label="Support">
-        <a href="about.html">About</a>
-        <a href="contact.html">Contact</a>
-        <a href="privacy.html">Privacy</a>
-        <a href="terms.html">Terms</a>
-        <a href="settings.html">Settings</a>
-      </nav>
-      <div class="site-footer__social" aria-label="Social channels">
-        <a href="https://discord.gg/qVf3nN4Mgq" aria-label="RouteFlow London on Discord"><i class="fa-brands fa-discord"></i></a>
-        <a href="https://www.tiktok.com/@the_bus_father" aria-label="RouteFlow London on TikTok"><i class="fab fa-tiktok"></i></a>
-        <a href="https://www.instagram.com/thebusfatherofficial/profilecard/?igsh=NXcybzV3cTA2azBo" aria-label="RouteFlow London on Instagram"><i class="fab fa-instagram"></i></a>
-      </div>
     </div>
-    <div class="site-footer__meta">
-      <span>&copy; <span data-current-year></span> RouteFlow London. All rights reserved.</span>
-      <span>Made for London. Accessible for everyone.</span>
-    </div>
-  </footer>
+
+    <footer class="site-footer" aria-label="RouteFlow London footer">
+      <div class="site-footer__inner">
+        <div class="site-footer__brand">
+          <img src="images/New_Routflow_London_Logo.png" alt="RouteFlow London logo">
+          <div>
+            <h2>Stay curious about London’s transport</h2>
+            <p>RouteFlow London turns TfL feeds into playful guidance so planners, families and classrooms can travel with calm confidence.</p>
+            <div class="site-footer__social" role="list">
+              <a href="https://discord.gg/qVf3nN4Mgq" aria-label="RouteFlow London on Discord"><i class="fa-brands fa-discord"></i></a>
+              <a href="https://www.tiktok.com/@the_bus_father" aria-label="RouteFlow London on TikTok"><i class="fa-brands fa-tiktok"></i></a>
+              <a href="https://www.instagram.com/thebusfatherofficial/profilecard/?igsh=NXcybzV3cTA2azBo" aria-label="RouteFlow London on Instagram"><i class="fa-brands fa-instagram"></i></a>
+            </div>
+          </div>
+        </div>
+        <div class="site-footer__grid">
+          <div>
+            <h3 class="site-footer__heading">Plan journeys</h3>
+            <ul class="site-footer__links">
+              <li><a href="index.html">Home</a></li>
+              <li><a href="planning.html">Planning</a></li>
+              <li><a href="tracking.html">Tracking</a></li>
+            </ul>
+          </div>
+          <div>
+            <h3 class="site-footer__heading">Live insight</h3>
+            <ul class="site-footer__links">
+              <li><a href="dashboard.html">Dashboard</a></li>
+              <li><a href="routes.html">Routes</a></li>
+              <li><a href="disruptions.html">Disruptions</a></li>
+            </ul>
+          </div>
+          <div>
+            <h3 class="site-footer__heading">Community data</h3>
+            <ul class="site-footer__links">
+              <li><a href="info.html">Info hub</a></li>
+              <li><a href="fleet.html">Fleet</a></li>
+              <li><a href="withdrawn.html">Withdrawn</a></li>
+            </ul>
+          </div>
+          <div>
+            <h3 class="site-footer__heading">Company</h3>
+            <ul class="site-footer__links">
+              <li><a href="about.html">About</a></li>
+              <li><a href="contact.html">Contact</a></li>
+              <li><a href="privacy.html">Privacy</a></li>
+              <li><a href="terms.html">Terms</a></li>
+            </ul>
+          </div>
+        </div>
+        <div class="site-footer__bottom">
+          <p class="site-footer__legal">© <span data-current-year></span> RouteFlow London. Crafted for curious travellers.</p>
+          <div class="site-footer__meta">
+            <a href="privacy.html">Privacy</a>
+            <a href="terms.html">Terms</a>
+            <a href="contact.html">Contact</a>
+          </div>
+        </div>
+      </div>
+    </footer>
+  </div>
 
   <script src="planning.js"></script>
   <script src="navbar-loader.js"></script>

--- a/privacy.html
+++ b/privacy.html
@@ -13,8 +13,12 @@
 </head>
 <body class="site-body">
   <a href="#main-content" class="skip-link">Skip to main content</a>
-  <div id="navbar-container"></div>
+  <div class="site-shell">
+    <header class="site-shell__header">
+      <div id="navbar-container" class="site-shell__navbar"></div>
+    </header>
 
+    <div class="site-shell__main">
   <main id="main-content" class="site-main page-shell legal-shell" aria-labelledby="privacyTitle">
     <section class="page-hero">
       <div class="page-hero__content">
@@ -124,38 +128,68 @@
     </div>
   </main>
 
-  <footer class="site-footer" aria-label="Footer">
-    <div class="site-footer__inner">
-      <div class="site-footer__brand">
-        <span class="site-footer__name">RouteFlow London</span>
-        <p class="site-footer__description">Playful transport guidance for explorers of every age.</p>
-      </div>
-      <nav class="site-footer__nav" aria-label="Explore">
-        <a href="index.html">Home</a>
-        <a href="dashboard.html">Dashboard</a>
-        <a href="tracking.html">Tracking</a>
-        <a href="planning.html">Planning</a>
-        <a href="routes.html">Routes</a>
-        <a href="info.html">Info hub</a>
-      </nav>
-      <nav class="site-footer__nav" aria-label="Support">
-        <a href="about.html">About</a>
-        <a href="contact.html">Contact</a>
-        <a href="privacy.html">Privacy</a>
-        <a href="terms.html">Terms</a>
-        <a href="settings.html">Settings</a>
-      </nav>
-      <div class="site-footer__social" aria-label="Social channels">
-        <a href="https://discord.gg/qVf3nN4Mgq" aria-label="RouteFlow London on Discord"><i class="fa-brands fa-discord"></i></a>
-        <a href="https://www.tiktok.com/@the_bus_father" aria-label="RouteFlow London on TikTok"><i class="fab fa-tiktok"></i></a>
-        <a href="https://www.instagram.com/thebusfatherofficial/profilecard/?igsh=NXcybzV3cTA2azBo" aria-label="RouteFlow London on Instagram"><i class="fab fa-instagram"></i></a>
-      </div>
     </div>
-    <div class="site-footer__meta">
-      <span>&copy; <span data-current-year></span> RouteFlow London. All rights reserved.</span>
-      <span>Made for London. Accessible for everyone.</span>
-    </div>
-  </footer>
+
+    <footer class="site-footer" aria-label="RouteFlow London footer">
+      <div class="site-footer__inner">
+        <div class="site-footer__brand">
+          <img src="images/New_Routflow_London_Logo.png" alt="RouteFlow London logo">
+          <div>
+            <h2>Stay curious about London’s transport</h2>
+            <p>RouteFlow London turns TfL feeds into playful guidance so planners, families and classrooms can travel with calm confidence.</p>
+            <div class="site-footer__social" role="list">
+              <a href="https://discord.gg/qVf3nN4Mgq" aria-label="RouteFlow London on Discord"><i class="fa-brands fa-discord"></i></a>
+              <a href="https://www.tiktok.com/@the_bus_father" aria-label="RouteFlow London on TikTok"><i class="fa-brands fa-tiktok"></i></a>
+              <a href="https://www.instagram.com/thebusfatherofficial/profilecard/?igsh=NXcybzV3cTA2azBo" aria-label="RouteFlow London on Instagram"><i class="fa-brands fa-instagram"></i></a>
+            </div>
+          </div>
+        </div>
+        <div class="site-footer__grid">
+          <div>
+            <h3 class="site-footer__heading">Plan journeys</h3>
+            <ul class="site-footer__links">
+              <li><a href="index.html">Home</a></li>
+              <li><a href="planning.html">Planning</a></li>
+              <li><a href="tracking.html">Tracking</a></li>
+            </ul>
+          </div>
+          <div>
+            <h3 class="site-footer__heading">Live insight</h3>
+            <ul class="site-footer__links">
+              <li><a href="dashboard.html">Dashboard</a></li>
+              <li><a href="routes.html">Routes</a></li>
+              <li><a href="disruptions.html">Disruptions</a></li>
+            </ul>
+          </div>
+          <div>
+            <h3 class="site-footer__heading">Community data</h3>
+            <ul class="site-footer__links">
+              <li><a href="info.html">Info hub</a></li>
+              <li><a href="fleet.html">Fleet</a></li>
+              <li><a href="withdrawn.html">Withdrawn</a></li>
+            </ul>
+          </div>
+          <div>
+            <h3 class="site-footer__heading">Company</h3>
+            <ul class="site-footer__links">
+              <li><a href="about.html">About</a></li>
+              <li><a href="contact.html">Contact</a></li>
+              <li><a href="privacy.html">Privacy</a></li>
+              <li><a href="terms.html">Terms</a></li>
+            </ul>
+          </div>
+        </div>
+        <div class="site-footer__bottom">
+          <p class="site-footer__legal">© <span data-current-year></span> RouteFlow London. Crafted for curious travellers.</p>
+          <div class="site-footer__meta">
+            <a href="privacy.html">Privacy</a>
+            <a href="terms.html">Terms</a>
+            <a href="contact.html">Contact</a>
+          </div>
+        </div>
+      </div>
+    </footer>
+  </div>
 
   <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-auth-compat.js"></script>

--- a/profile.html
+++ b/profile.html
@@ -12,7 +12,12 @@
 </head>
 <body class="site-body">
   <a href="#profileMain" class="skip-link">Skip to main content</a>
-  <div id="navbar-container"></div>
+  <div class="site-shell">
+    <header class="site-shell__header">
+      <div id="navbar-container" class="site-shell__navbar"></div>
+    </header>
+
+    <div class="site-shell__main">
   <main id="profileMain" class="site-main profile-shell" aria-live="polite">
     <section class="profile-hero card" id="profileHero">
       <div class="profile-hero__avatar">
@@ -231,38 +236,68 @@
     </section>
   </main>
 
-  <footer class="site-footer" aria-label="Footer">
-    <div class="site-footer__inner">
-      <div class="site-footer__brand">
-        <span class="site-footer__name">RouteFlow London</span>
-        <p class="site-footer__description">Playful transport guidance for explorers of every age.</p>
-      </div>
-      <nav class="site-footer__nav" aria-label="Explore">
-        <a href="index.html">Home</a>
-        <a href="dashboard.html">Dashboard</a>
-        <a href="tracking.html">Tracking</a>
-        <a href="planning.html">Planning</a>
-        <a href="routes.html">Routes</a>
-        <a href="info.html">Info hub</a>
-      </nav>
-      <nav class="site-footer__nav" aria-label="Support">
-        <a href="about.html">About</a>
-        <a href="contact.html">Contact</a>
-        <a href="privacy.html">Privacy</a>
-        <a href="terms.html">Terms</a>
-        <a href="settings.html">Settings</a>
-      </nav>
-      <div class="site-footer__social" aria-label="Social channels">
-        <a href="https://discord.gg/qVf3nN4Mgq" aria-label="RouteFlow London on Discord"><i class="fa-brands fa-discord"></i></a>
-        <a href="https://www.tiktok.com/@the_bus_father" aria-label="RouteFlow London on TikTok"><i class="fab fa-tiktok"></i></a>
-        <a href="https://www.instagram.com/thebusfatherofficial/profilecard/?igsh=NXcybzV3cTA2azBo" aria-label="RouteFlow London on Instagram"><i class="fab fa-instagram"></i></a>
-      </div>
     </div>
-    <div class="site-footer__meta">
-      <span>&copy; <span data-current-year></span> RouteFlow London. All rights reserved.</span>
-      <span>Made for London. Accessible for everyone.</span>
-    </div>
-  </footer>
+
+    <footer class="site-footer" aria-label="RouteFlow London footer">
+      <div class="site-footer__inner">
+        <div class="site-footer__brand">
+          <img src="images/New_Routflow_London_Logo.png" alt="RouteFlow London logo">
+          <div>
+            <h2>Stay curious about London’s transport</h2>
+            <p>RouteFlow London turns TfL feeds into playful guidance so planners, families and classrooms can travel with calm confidence.</p>
+            <div class="site-footer__social" role="list">
+              <a href="https://discord.gg/qVf3nN4Mgq" aria-label="RouteFlow London on Discord"><i class="fa-brands fa-discord"></i></a>
+              <a href="https://www.tiktok.com/@the_bus_father" aria-label="RouteFlow London on TikTok"><i class="fa-brands fa-tiktok"></i></a>
+              <a href="https://www.instagram.com/thebusfatherofficial/profilecard/?igsh=NXcybzV3cTA2azBo" aria-label="RouteFlow London on Instagram"><i class="fa-brands fa-instagram"></i></a>
+            </div>
+          </div>
+        </div>
+        <div class="site-footer__grid">
+          <div>
+            <h3 class="site-footer__heading">Plan journeys</h3>
+            <ul class="site-footer__links">
+              <li><a href="index.html">Home</a></li>
+              <li><a href="planning.html">Planning</a></li>
+              <li><a href="tracking.html">Tracking</a></li>
+            </ul>
+          </div>
+          <div>
+            <h3 class="site-footer__heading">Live insight</h3>
+            <ul class="site-footer__links">
+              <li><a href="dashboard.html">Dashboard</a></li>
+              <li><a href="routes.html">Routes</a></li>
+              <li><a href="disruptions.html">Disruptions</a></li>
+            </ul>
+          </div>
+          <div>
+            <h3 class="site-footer__heading">Community data</h3>
+            <ul class="site-footer__links">
+              <li><a href="info.html">Info hub</a></li>
+              <li><a href="fleet.html">Fleet</a></li>
+              <li><a href="withdrawn.html">Withdrawn</a></li>
+            </ul>
+          </div>
+          <div>
+            <h3 class="site-footer__heading">Company</h3>
+            <ul class="site-footer__links">
+              <li><a href="about.html">About</a></li>
+              <li><a href="contact.html">Contact</a></li>
+              <li><a href="privacy.html">Privacy</a></li>
+              <li><a href="terms.html">Terms</a></li>
+            </ul>
+          </div>
+        </div>
+        <div class="site-footer__bottom">
+          <p class="site-footer__legal">© <span data-current-year></span> RouteFlow London. Crafted for curious travellers.</p>
+          <div class="site-footer__meta">
+            <a href="privacy.html">Privacy</a>
+            <a href="terms.html">Terms</a>
+            <a href="contact.html">Contact</a>
+          </div>
+        </div>
+      </div>
+    </footer>
+  </div>
 
   <script src="main.js" defer></script>
   <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-storage-compat.js" defer></script>

--- a/routes.html
+++ b/routes.html
@@ -13,8 +13,12 @@
 </head>
 <body class="site-body">
   <a href="#main-content" class="skip-link">Skip to main content</a>
-  <div id="navbar-container"></div>
+  <div class="site-shell">
+    <header class="site-shell__header">
+      <div id="navbar-container" class="site-shell__navbar"></div>
+    </header>
 
+    <div class="site-shell__main">
   <main id="main-content" class="site-main network-shell" aria-labelledby="routesTitle">
     <section class="network-hero">
       <h1 id="routesTitle">Explore active London bus routes.</h1>
@@ -57,38 +61,68 @@
     </section>
   </main>
 
-  <footer class="site-footer" aria-label="Footer">
-    <div class="site-footer__inner">
-      <div class="site-footer__brand">
-        <span class="site-footer__name">RouteFlow London</span>
-        <p class="site-footer__description">Playful transport guidance for explorers of every age.</p>
-      </div>
-      <nav class="site-footer__nav" aria-label="Explore">
-        <a href="index.html">Home</a>
-        <a href="dashboard.html">Dashboard</a>
-        <a href="tracking.html">Tracking</a>
-        <a href="planning.html">Planning</a>
-        <a href="routes.html">Routes</a>
-        <a href="info.html">Info hub</a>
-      </nav>
-      <nav class="site-footer__nav" aria-label="Support">
-        <a href="about.html">About</a>
-        <a href="contact.html">Contact</a>
-        <a href="privacy.html">Privacy</a>
-        <a href="terms.html">Terms</a>
-        <a href="settings.html">Settings</a>
-      </nav>
-      <div class="site-footer__social" aria-label="Social channels">
-        <a href="https://discord.gg/qVf3nN4Mgq" aria-label="RouteFlow London on Discord"><i class="fa-brands fa-discord"></i></a>
-        <a href="https://www.tiktok.com/@the_bus_father" aria-label="RouteFlow London on TikTok"><i class="fab fa-tiktok"></i></a>
-        <a href="https://www.instagram.com/thebusfatherofficial/profilecard/?igsh=NXcybzV3cTA2azBo" aria-label="RouteFlow London on Instagram"><i class="fab fa-instagram"></i></a>
-      </div>
     </div>
-    <div class="site-footer__meta">
-      <span>&copy; <span data-current-year></span> RouteFlow London. All rights reserved.</span>
-      <span>Made for London. Accessible for everyone.</span>
-    </div>
-  </footer>
+
+    <footer class="site-footer" aria-label="RouteFlow London footer">
+      <div class="site-footer__inner">
+        <div class="site-footer__brand">
+          <img src="images/New_Routflow_London_Logo.png" alt="RouteFlow London logo">
+          <div>
+            <h2>Stay curious about London’s transport</h2>
+            <p>RouteFlow London turns TfL feeds into playful guidance so planners, families and classrooms can travel with calm confidence.</p>
+            <div class="site-footer__social" role="list">
+              <a href="https://discord.gg/qVf3nN4Mgq" aria-label="RouteFlow London on Discord"><i class="fa-brands fa-discord"></i></a>
+              <a href="https://www.tiktok.com/@the_bus_father" aria-label="RouteFlow London on TikTok"><i class="fa-brands fa-tiktok"></i></a>
+              <a href="https://www.instagram.com/thebusfatherofficial/profilecard/?igsh=NXcybzV3cTA2azBo" aria-label="RouteFlow London on Instagram"><i class="fa-brands fa-instagram"></i></a>
+            </div>
+          </div>
+        </div>
+        <div class="site-footer__grid">
+          <div>
+            <h3 class="site-footer__heading">Plan journeys</h3>
+            <ul class="site-footer__links">
+              <li><a href="index.html">Home</a></li>
+              <li><a href="planning.html">Planning</a></li>
+              <li><a href="tracking.html">Tracking</a></li>
+            </ul>
+          </div>
+          <div>
+            <h3 class="site-footer__heading">Live insight</h3>
+            <ul class="site-footer__links">
+              <li><a href="dashboard.html">Dashboard</a></li>
+              <li><a href="routes.html">Routes</a></li>
+              <li><a href="disruptions.html">Disruptions</a></li>
+            </ul>
+          </div>
+          <div>
+            <h3 class="site-footer__heading">Community data</h3>
+            <ul class="site-footer__links">
+              <li><a href="info.html">Info hub</a></li>
+              <li><a href="fleet.html">Fleet</a></li>
+              <li><a href="withdrawn.html">Withdrawn</a></li>
+            </ul>
+          </div>
+          <div>
+            <h3 class="site-footer__heading">Company</h3>
+            <ul class="site-footer__links">
+              <li><a href="about.html">About</a></li>
+              <li><a href="contact.html">Contact</a></li>
+              <li><a href="privacy.html">Privacy</a></li>
+              <li><a href="terms.html">Terms</a></li>
+            </ul>
+          </div>
+        </div>
+        <div class="site-footer__bottom">
+          <p class="site-footer__legal">© <span data-current-year></span> RouteFlow London. Crafted for curious travellers.</p>
+          <div class="site-footer__meta">
+            <a href="privacy.html">Privacy</a>
+            <a href="terms.html">Terms</a>
+            <a href="contact.html">Contact</a>
+          </div>
+        </div>
+      </div>
+    </footer>
+  </div>
 
   <div class="route-overlay" id="routeOverlay" data-route-overlay-dismiss hidden>
     <div class="route-overlay__dialog" role="dialog" aria-modal="true" aria-labelledby="routeOverlayTitle" aria-describedby="routeOverlayStatus">

--- a/settings.html
+++ b/settings.html
@@ -13,7 +13,12 @@
 </head>
 <body class="site-body">
   <a href="#main-content" class="skip-link">Skip to main content</a>
-  <div id="navbar-container"></div>
+  <div class="site-shell">
+    <header class="site-shell__header">
+      <div id="navbar-container" class="site-shell__navbar"></div>
+    </header>
+
+    <div class="site-shell__main">
   <main id="main-content" class="site-main settings-page" aria-labelledby="settingsTitle">
     <h1 id="settingsTitle">Settings</h1>
     <p class="settings-description settings-lead">
@@ -102,38 +107,68 @@
     </form>
   </main>
 
-  <footer class="site-footer" aria-label="Footer">
-    <div class="site-footer__inner">
-      <div class="site-footer__brand">
-        <span class="site-footer__name">RouteFlow London</span>
-        <p class="site-footer__description">Playful transport guidance for explorers of every age.</p>
-      </div>
-      <nav class="site-footer__nav" aria-label="Explore">
-        <a href="index.html">Home</a>
-        <a href="dashboard.html">Dashboard</a>
-        <a href="tracking.html">Tracking</a>
-        <a href="planning.html">Planning</a>
-        <a href="routes.html">Routes</a>
-        <a href="info.html">Info hub</a>
-      </nav>
-      <nav class="site-footer__nav" aria-label="Support">
-        <a href="about.html">About</a>
-        <a href="contact.html">Contact</a>
-        <a href="privacy.html">Privacy</a>
-        <a href="terms.html">Terms</a>
-        <a href="settings.html">Settings</a>
-      </nav>
-      <div class="site-footer__social" aria-label="Social channels">
-        <a href="https://discord.gg/qVf3nN4Mgq" aria-label="RouteFlow London on Discord"><i class="fa-brands fa-discord"></i></a>
-        <a href="https://www.tiktok.com/@the_bus_father" aria-label="RouteFlow London on TikTok"><i class="fab fa-tiktok"></i></a>
-        <a href="https://www.instagram.com/thebusfatherofficial/profilecard/?igsh=NXcybzV3cTA2azBo" aria-label="RouteFlow London on Instagram"><i class="fab fa-instagram"></i></a>
-      </div>
     </div>
-    <div class="site-footer__meta">
-      <span>&copy; <span data-current-year></span> RouteFlow London. All rights reserved.</span>
-      <span>Made for London. Accessible for everyone.</span>
-    </div>
-  </footer>
+
+    <footer class="site-footer" aria-label="RouteFlow London footer">
+      <div class="site-footer__inner">
+        <div class="site-footer__brand">
+          <img src="images/New_Routflow_London_Logo.png" alt="RouteFlow London logo">
+          <div>
+            <h2>Stay curious about London’s transport</h2>
+            <p>RouteFlow London turns TfL feeds into playful guidance so planners, families and classrooms can travel with calm confidence.</p>
+            <div class="site-footer__social" role="list">
+              <a href="https://discord.gg/qVf3nN4Mgq" aria-label="RouteFlow London on Discord"><i class="fa-brands fa-discord"></i></a>
+              <a href="https://www.tiktok.com/@the_bus_father" aria-label="RouteFlow London on TikTok"><i class="fa-brands fa-tiktok"></i></a>
+              <a href="https://www.instagram.com/thebusfatherofficial/profilecard/?igsh=NXcybzV3cTA2azBo" aria-label="RouteFlow London on Instagram"><i class="fa-brands fa-instagram"></i></a>
+            </div>
+          </div>
+        </div>
+        <div class="site-footer__grid">
+          <div>
+            <h3 class="site-footer__heading">Plan journeys</h3>
+            <ul class="site-footer__links">
+              <li><a href="index.html">Home</a></li>
+              <li><a href="planning.html">Planning</a></li>
+              <li><a href="tracking.html">Tracking</a></li>
+            </ul>
+          </div>
+          <div>
+            <h3 class="site-footer__heading">Live insight</h3>
+            <ul class="site-footer__links">
+              <li><a href="dashboard.html">Dashboard</a></li>
+              <li><a href="routes.html">Routes</a></li>
+              <li><a href="disruptions.html">Disruptions</a></li>
+            </ul>
+          </div>
+          <div>
+            <h3 class="site-footer__heading">Community data</h3>
+            <ul class="site-footer__links">
+              <li><a href="info.html">Info hub</a></li>
+              <li><a href="fleet.html">Fleet</a></li>
+              <li><a href="withdrawn.html">Withdrawn</a></li>
+            </ul>
+          </div>
+          <div>
+            <h3 class="site-footer__heading">Company</h3>
+            <ul class="site-footer__links">
+              <li><a href="about.html">About</a></li>
+              <li><a href="contact.html">Contact</a></li>
+              <li><a href="privacy.html">Privacy</a></li>
+              <li><a href="terms.html">Terms</a></li>
+            </ul>
+          </div>
+        </div>
+        <div class="site-footer__bottom">
+          <p class="site-footer__legal">© <span data-current-year></span> RouteFlow London. Crafted for curious travellers.</p>
+          <div class="site-footer__meta">
+            <a href="privacy.html">Privacy</a>
+            <a href="terms.html">Terms</a>
+            <a href="contact.html">Contact</a>
+          </div>
+        </div>
+      </div>
+    </footer>
+  </div>
 
   <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-auth-compat.js"></script>

--- a/style.css
+++ b/style.css
@@ -4,74 +4,78 @@
 */
 
 :root {
-  --primary: #d00025;
-  --primary-dark: #820012;
-  --accent-blue: #ff9e1b;
-  --accent-blue-dark: #f26419;
-  --accent-blue-rgb: 255, 158, 27;
-  --accent-blue-dark-rgb: 242, 100, 25;
-  --accent-blue-tint-rgb: 255, 226, 191;
-  --accent-red: #d00025;
-  --accent-red-dark: #860017;
-  --accent-red-rgb: 208, 0, 37;
-  --navbar-accent: #3b0b15;
-  --navbar-accent-dark: #22060c;
+  --primary: #2563eb;
+  --primary-dark: #1d4ed8;
+  --accent-blue: #22d3ee;
+  --accent-blue-dark: #0ea5e9;
+  --accent-blue-rgb: 34, 211, 238;
+  --accent-blue-dark-rgb: 14, 165, 233;
+  --accent-blue-tint-rgb: 96, 165, 250;
+  --accent-red: #f97316;
+  --accent-red-dark: #ea580c;
+  --accent-red-rgb: 249, 115, 22;
+  --navbar-accent: #ffffff;
+  --navbar-accent-dark: rgba(15, 23, 42, 0.92);
 
-  --calm-blue: #0f4c81;
-  --calm-blue-bright: #1f6fb2;
-  --calm-blue-light: #e8f1ff;
-  --calm-blue-soft: #f4f7ff;
-  --calm-blue-rgb: 15, 76, 129;
-  --calm-blue-light-rgb: 232, 241, 255;
-  --calm-blue-tint-rgb: 210, 229, 255;
+  --calm-blue: #1e3a8a;
+  --calm-blue-bright: #3b82f6;
+  --calm-blue-light: rgba(148, 163, 184, 0.25);
+  --calm-blue-soft: rgba(15, 23, 42, 0.08);
+  --calm-blue-rgb: 59, 130, 246;
+  --calm-blue-light-rgb: 148, 163, 184;
+  --calm-blue-tint-rgb: 79, 70, 229;
 
-  --background-light: #f7f5f4;
-  --foreground-light: #201319;
-  --background-dark: #1a0b12;
-  --foreground-dark: #fbf7f8;
+  --background-light: #f7f9ff;
+  --foreground-light: #0b1220;
+  --background-dark: #0f172a;
+  --foreground-dark: #f8fafc;
 
-  --card-bg-light: #ffffff;
-  --card-bg-dark: rgba(32, 12, 19, 0.95);
-  --surface-muted-light: rgba(208, 0, 37, 0.08);
-  --surface-muted-dark: rgba(255, 158, 27, 0.18);
-  --surface-strong-light: rgba(208, 0, 37, 0.16);
-  --surface-strong-dark: rgba(255, 158, 27, 0.3);
-  --border-soft-light: rgba(208, 0, 37, 0.12);
-  --border-soft-dark: rgba(251, 247, 248, 0.18);
-  --border-strong-light: rgba(208, 0, 37, 0.28);
-  --border-strong-dark: rgba(251, 247, 248, 0.4);
-  --text-muted-light: rgba(32, 19, 25, 0.74);
-  --text-subtle-light: rgba(32, 19, 25, 0.56);
-  --text-muted-dark: rgba(251, 247, 248, 0.86);
-  --text-subtle-dark: rgba(251, 247, 248, 0.64);
+  --card-bg-light: rgba(255, 255, 255, 0.9);
+  --card-bg-dark: rgba(15, 23, 42, 0.85);
+  --surface-muted-light: rgba(37, 99, 235, 0.08);
+  --surface-muted-dark: rgba(34, 211, 238, 0.12);
+  --surface-strong-light: rgba(37, 99, 235, 0.16);
+  --surface-strong-dark: rgba(34, 211, 238, 0.22);
+  --border-soft-light: rgba(15, 23, 42, 0.1);
+  --border-soft-dark: rgba(226, 232, 240, 0.24);
+  --border-strong-light: rgba(37, 99, 235, 0.25);
+  --border-strong-dark: rgba(34, 211, 238, 0.35);
+  --text-muted-light: rgba(11, 18, 32, 0.78);
+  --text-subtle-light: rgba(11, 18, 32, 0.58);
+  --text-muted-dark: rgba(248, 250, 252, 0.86);
+  --text-subtle-dark: rgba(248, 250, 252, 0.65);
 
-  --shadow-soft: 0 20px 42px rgba(var(--calm-blue-rgb), 0.14);
-  --shadow-medium: 0 30px 60px rgba(var(--calm-blue-rgb), 0.18);
-  --shadow-strong: 0 44px 90px rgba(var(--calm-blue-rgb), 0.22);
+  --shadow-soft: 0 24px 48px rgba(15, 23, 42, 0.08);
+  --shadow-medium: 0 36px 68px rgba(15, 23, 42, 0.12);
+  --shadow-strong: 0 48px 92px rgba(15, 23, 42, 0.16);
 
-  --radius-2xs: 0.4rem;
-  --radius-xs: 0.6rem;
-  --radius-sm: 0.9rem;
-  --radius-md: 1.4rem;
-  --radius-lg: 2.3rem;
-  --radius-xl: 3.4rem;
+  --radius-2xs: 0.5rem;
+  --radius-xs: 0.75rem;
+  --radius-sm: 1rem;
+  --radius-md: 1.5rem;
+  --radius-lg: 2.25rem;
+  --radius-xl: 3.5rem;
 
-  --space-2xs: 0.35rem;
-  --space-xs: 0.65rem;
-  --space-sm: 0.95rem;
-  --space-md: 1.35rem;
-  --space-lg: 2.1rem;
-  --space-xl: 2.8rem;
-  --space-2xl: 4.1rem;
+  --space-2xs: 0.4rem;
+  --space-xs: 0.7rem;
+  --space-sm: 1rem;
+  --space-md: 1.5rem;
+  --space-lg: 2.4rem;
+  --space-xl: 3.2rem;
+  --space-2xl: 4.6rem;
 
-  --content-max: min(1180px, 100vw - 2.75rem);
-  --content-wide: min(1320px, 100vw - 2.75rem);
-  --section-gap: clamp(2.4rem, 5vw, 4.6rem);
-  --transition: 0.28s cubic-bezier(.16, .84, .44, 1);
+  --content-max: min(1120px, 100vw - 2.5rem);
+  --content-wide: min(1280px, 100vw - 2.5rem);
+  --section-gap: clamp(2.5rem, 6vw, 4.8rem);
+  --transition: 0.3s cubic-bezier(0.16, 1, 0.3, 1);
 
   --font-display: 'Space Grotesk', 'Manrope', 'Segoe UI', system-ui, sans-serif;
   --font-sans: 'Manrope', 'Segoe UI', -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
   --font-readable: 'Space Grotesk', 'Manrope', 'Segoe UI', sans-serif;
+
+  --pointer-x: 50vw;
+  --pointer-y: 50vh;
+  --pointer-opacity: 0;
 }
 
 *, *::before, *::after {
@@ -99,9 +103,9 @@ body {
 body.site-body {
   position: relative;
   background:
-    radial-gradient(circle at 12% 18%, rgba(var(--calm-blue-tint-rgb), 0.36), transparent 62%),
-    radial-gradient(circle at 82% 12%, rgba(var(--accent-blue-tint-rgb), 0.3), transparent 58%),
-    linear-gradient(180deg, #ffffff 0%, rgba(244, 247, 255, 0.78) 28%, rgba(247, 245, 244, 0.92) 100%);
+    radial-gradient(1200px 820px at 18% -12%, rgba(var(--accent-blue-tint-rgb), 0.25), transparent 68%),
+    radial-gradient(1040px 760px at 82% 6%, rgba(var(--accent-red-rgb), 0.18), transparent 72%),
+    linear-gradient(180deg, #fefbff 0%, var(--background-light) 46%, #eef2ff 100%);
   color: var(--foreground-light);
   overflow-x: hidden;
 }
@@ -110,26 +114,24 @@ body.site-body::before,
 body.site-body::after {
   content: '';
   position: fixed;
-  width: min(820px, 72vw);
-  height: min(820px, 72vw);
-  border-radius: 50%;
-  opacity: 0.5;
-  filter: blur(0.8px);
-  z-index: 0;
+  inset: 0;
   pointer-events: none;
-  transition: opacity var(--transition), transform var(--transition);
+  z-index: 0;
 }
 
 body.site-body::before {
-  top: -28vh;
-  left: -18vw;
-  background: radial-gradient(circle, rgba(var(--accent-blue-rgb), 0.18) 0%, rgba(255, 255, 255, 0) 70%);
+  background: radial-gradient(520px 520px at var(--pointer-x) var(--pointer-y), rgba(var(--accent-blue-rgb), 0.18), transparent 68%);
+  opacity: var(--pointer-opacity);
+  mix-blend-mode: multiply;
+  transition: opacity 0.5s ease, transform 0.5s ease;
 }
 
 body.site-body::after {
-  bottom: -36vh;
-  right: -12vw;
-  background: radial-gradient(circle, rgba(var(--calm-blue-rgb), 0.16) 0%, rgba(255, 255, 255, 0) 70%);
+  background:
+    radial-gradient(720px 640px at 10% 110%, rgba(var(--accent-blue-dark-rgb), 0.16), transparent 78%),
+    radial-gradient(680px 560px at 110% 20%, rgba(var(--accent-red-rgb), 0.14), transparent 70%);
+  opacity: 0.8;
+  mix-blend-mode: screen;
 }
 
 body.site-body > :not(.app-dock):not(.skip-link) {
@@ -163,9 +165,9 @@ body.site-body > :not(.app-dock):not(.skip-link) {
 
 body.dark-mode {
   background:
-    radial-gradient(circle at 12% 18%, rgba(255, 158, 27, 0.28), transparent 60%),
-    radial-gradient(circle at 88% 92%, rgba(208, 0, 37, 0.4), transparent 58%),
-    linear-gradient(165deg, #16040a 0%, #1f0912 55%, #2a0f1c 100%);
+    radial-gradient(circle at 12% 18%, rgba(37, 99, 235, 0.28), transparent 60%),
+    radial-gradient(circle at 88% 92%, rgba(249, 115, 22, 0.32), transparent 58%),
+    linear-gradient(165deg, #0f172a 0%, #0b1120 50%, #020617 100%);
   color: var(--foreground-dark);
 
   --background-light: var(--background-dark);
@@ -177,23 +179,23 @@ body.dark-mode {
   --border-strong-light: var(--border-strong-dark);
   --text-muted-light: var(--text-muted-dark);
   --text-subtle-light: var(--text-subtle-dark);
-  --shadow-soft: 0 26px 48px rgba(0, 0, 0, 0.34);
-  --shadow-medium: 0 34px 64px rgba(0, 0, 0, 0.42);
-  --shadow-strong: 0 48px 96px rgba(0, 0, 0, 0.52);
+  --shadow-soft: 0 24px 48px rgba(2, 6, 23, 0.48);
+  --shadow-medium: 0 34px 72px rgba(2, 6, 23, 0.56);
+  --shadow-strong: 0 48px 108px rgba(2, 6, 23, 0.62);
 
-  --calm-blue: #7ab9ff;
-  --calm-blue-bright: #4f9ff0;
-  --calm-blue-light: #14263b;
-  --calm-blue-soft: #0f1827;
-  --calm-blue-rgb: 122, 185, 255;
-  --calm-blue-light-rgb: 20, 38, 59;
-  --calm-blue-tint-rgb: 71, 117, 173;
+  --calm-blue: #60a5fa;
+  --calm-blue-bright: #38bdf8;
+  --calm-blue-light: rgba(14, 165, 233, 0.12);
+  --calm-blue-soft: rgba(15, 23, 42, 0.4);
+  --calm-blue-rgb: 96, 165, 250;
+  --calm-blue-light-rgb: 14, 165, 233;
+  --calm-blue-tint-rgb: 94, 234, 212;
 }
 
 body.dark-mode.site-body::before,
 body.dark-mode.site-body::after {
-  opacity: 0.32;
-  background: radial-gradient(circle, rgba(255, 255, 255, 0.08) 0%, rgba(26, 11, 18, 0) 72%);
+  opacity: 0.28;
+  background: radial-gradient(circle, rgba(59, 130, 246, 0.18) 0%, rgba(2, 6, 23, 0) 72%);
 }
 
 body.high-contrast {
@@ -253,6 +255,31 @@ img, svg, video {
   display: flex;
   flex-direction: column;
   gap: var(--section-gap);
+  flex: 1;
+}
+
+.site-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.site-shell__header {
+  position: relative;
+  z-index: 3;
+}
+
+.site-shell__navbar {
+  position: relative;
+  z-index: 3;
+}
+
+.site-shell__main {
+  flex: 1;
+  display: flex;
+}
+
+.site-shell__main > .site-main {
   flex: 1;
 }
 
@@ -386,17 +413,18 @@ table {
   width: 100%;
   border-collapse: collapse;
   font-size: 0.95rem;
+  color: var(--foreground-light);
 }
 
 th,
 td {
   padding: 0.9rem 1.2rem;
   text-align: left;
-  border-bottom: 1px solid var(--border-soft-light);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
 }
 
 th {
-  background: rgba(var(--accent-blue-rgb), 0.08);
+  background: rgba(var(--accent-blue-dark-rgb), 0.16);
   font-weight: 700;
   color: var(--foreground-light);
 }
@@ -406,30 +434,41 @@ td {
 }
 
 tbody tr:hover {
-  background: rgba(var(--calm-blue-rgb), 0.05);
+  background: rgba(var(--accent-blue-rgb), 0.12);
 }
 
 .card {
   position: relative;
-  background: linear-gradient(180deg, rgba(var(--calm-blue-rgb), 0.06), rgba(var(--calm-blue-rgb), 0))
-      var(--card-bg-light);
+  background: linear-gradient(160deg, rgba(255, 255, 255, 0.96) 0%, rgba(241, 245, 255, 0.96) 100%);
   border-radius: var(--radius-lg);
   padding: clamp(1.9rem, 4vw, 2.8rem);
-  border: 1px solid rgba(var(--calm-blue-rgb), 0.12);
+  border: 1px solid var(--border-soft-light);
   box-shadow: var(--shadow-soft);
   overflow: hidden;
+  backdrop-filter: blur(18px);
 }
 
 .card::before {
   content: '';
   position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(135deg, rgba(var(--accent-blue-rgb), 0.12), rgba(255, 255, 255, 0) 70%);
+  opacity: 0.9;
+  pointer-events: none;
+}
+
+.card::after {
+  content: '';
+  position: absolute;
   top: 0;
   left: 0;
   right: 0;
-  height: 0.45rem;
-  background: linear-gradient(90deg, var(--calm-blue) 0%, var(--calm-blue-bright) 50%, rgba(var(--calm-blue-light-rgb), 1) 100%);
+  height: 0.35rem;
   border-top-left-radius: inherit;
   border-top-right-radius: inherit;
+  background: linear-gradient(90deg, var(--primary) 0%, var(--accent-blue-dark) 50%, rgba(255, 255, 255, 0.5) 100%);
+  opacity: 0.8;
 }
 
 .card > * {
@@ -497,14 +536,15 @@ button.button,
   align-items: center;
   justify-content: center;
   gap: 0.55rem;
-  padding: 0.72rem 1.45rem;
+  padding: 0.78rem 1.6rem;
   border-radius: 999px;
-  border: 2px solid rgba(var(--calm-blue-rgb), 0.18);
+  border: 1px solid rgba(var(--accent-blue-tint-rgb), 0.24);
   font-weight: 700;
   letter-spacing: 0.01em;
-  background: #ffffff;
-  color: var(--calm-blue);
-  box-shadow: 0 10px 24px rgba(var(--calm-blue-rgb), 0.12);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.92), rgba(226, 232, 255, 0.7));
+  color: var(--foreground-light);
+  box-shadow: 0 16px 32px rgba(var(--accent-blue-dark-rgb), 0.16);
+  backdrop-filter: blur(10px);
   transition: transform var(--transition), box-shadow var(--transition), background var(--transition), border-color var(--transition), color var(--transition);
 }
 
@@ -515,10 +555,10 @@ button.button,
 .planning-submit,
 .auth-gate__cta,
 .dashboard-pill {
-  background: linear-gradient(90deg, var(--calm-blue), var(--calm-blue-bright));
+  background: linear-gradient(120deg, var(--primary) 0%, var(--accent-blue-dark) 60%, #38bdf8 100%);
   color: #ffffff;
   border-color: transparent;
-  box-shadow: 0 18px 34px rgba(var(--calm-blue-rgb), 0.22);
+  box-shadow: 0 24px 44px rgba(var(--accent-blue-dark-rgb), 0.32);
 }
 
 .button-secondary,
@@ -526,18 +566,18 @@ button.button,
 .navbar__drawer-button--ghost,
 .tracking-chip,
 .fleet-operators__tab {
-  background: rgba(var(--calm-blue-rgb), 0.1);
-  color: var(--calm-blue);
-  border-color: rgba(var(--calm-blue-rgb), 0.22);
-  box-shadow: none;
+  background: rgba(var(--accent-blue-rgb), 0.1);
+  color: var(--primary-dark);
+  border-color: rgba(var(--accent-blue-rgb), 0.26);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.4);
 }
 
 .button-danger,
 .navbar__profile-item--destructive,
 .navbar__drawer-button--destructive {
-  background: rgba(var(--accent-red-rgb), 0.15);
+  background: rgba(var(--accent-red-rgb), 0.16);
   color: var(--accent-red-dark);
-  border-color: rgba(var(--accent-red-rgb), 0.32);
+  border-color: rgba(var(--accent-red-rgb), 0.28);
 }
 
 .button:hover,
@@ -551,9 +591,9 @@ button.button:hover,
 .dashboard-pill:hover,
 .planning-submit:hover {
   transform: translateY(-2px);
-  box-shadow: 0 22px 44px rgba(var(--calm-blue-rgb), 0.2);
-  background: linear-gradient(90deg, rgba(255, 255, 255, 0.92), rgba(var(--calm-blue-tint-rgb), 0.6));
-  color: var(--calm-blue);
+  box-shadow: 0 26px 48px rgba(var(--accent-blue-dark-rgb), 0.24);
+  background: linear-gradient(120deg, rgba(var(--accent-blue-rgb), 0.18), rgba(var(--accent-blue-dark-rgb), 0.28));
+  color: var(--foreground-light);
 }
 
 .button:focus-visible,
@@ -564,14 +604,14 @@ button.button:hover,
 .tracking-chip:focus-visible,
 .fleet-operators__tab:focus-visible {
   outline: none;
-  border-color: rgba(var(--calm-blue-rgb), 0.5);
-  box-shadow: 0 0 0 4px rgba(var(--calm-blue-rgb), 0.22);
+  border-color: rgba(var(--accent-blue-dark-rgb), 0.6);
+  box-shadow: 0 0 0 4px rgba(var(--accent-blue-dark-rgb), 0.35);
 }
 
 [class*="__button"].is-active,
 .fleet-operators__tab.is-active {
-  background: linear-gradient(90deg, var(--primary), var(--accent-blue-dark));
-  color: #ffffff;
+  background: linear-gradient(115deg, var(--primary), var(--accent-blue-dark));
+  color: #f9faff;
   border-color: transparent;
 }
 
@@ -604,43 +644,44 @@ button.button:hover,
   position: sticky;
   top: 0;
   z-index: 1000;
-  background: #ffffff;
+  background: rgba(255, 255, 255, 0.92);
   color: var(--foreground-light);
-  border-bottom: 1px solid var(--border-soft-light);
-  box-shadow: 0 12px 30px rgba(var(--calm-blue-rgb), 0.08);
+  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+  box-shadow: 0 18px 38px rgba(15, 23, 42, 0.12);
+  backdrop-filter: blur(20px);
 }
 
 body.dark-mode .navbar {
-  background: rgba(18, 22, 36, 0.94);
+  background: rgba(15, 23, 42, 0.94);
   color: var(--foreground-dark);
-  border-bottom-color: rgba(251, 247, 248, 0.18);
-  box-shadow: 0 18px 34px rgba(0, 0, 0, 0.4);
+  border-bottom-color: rgba(96, 165, 250, 0.24);
+  box-shadow: 0 22px 44px rgba(2, 6, 23, 0.5);
 }
 
 body.dark-mode .navbar__brand-tagline,
 body.dark-mode .navbar__segment-label {
-  color: rgba(251, 247, 248, 0.64);
+  color: rgba(226, 232, 240, 0.72);
 }
 
 body.dark-mode .navbar__link {
-  color: rgba(251, 247, 248, 0.82);
+  color: rgba(226, 232, 240, 0.86);
 }
 
 body.dark-mode .navbar__link:hover,
 body.dark-mode .navbar__link:focus-visible,
 body.dark-mode .navbar__link[aria-current="page"] {
-  background: rgba(251, 247, 248, 0.16);
+  background: rgba(96, 165, 250, 0.16);
   color: var(--foreground-dark);
 }
 
 body.dark-mode .navbar__profile-toggle {
-  border-color: rgba(251, 247, 248, 0.2);
-  background: rgba(251, 247, 248, 0.12);
+  border-color: rgba(148, 163, 184, 0.3);
+  background: rgba(51, 65, 85, 0.4);
   color: var(--foreground-dark);
 }
 
 body.dark-mode .navbar__profile-avatar {
-  background: rgba(251, 247, 248, 0.14);
+  background: rgba(96, 165, 250, 0.2);
   color: var(--foreground-dark);
 }
 
@@ -650,13 +691,13 @@ body.dark-mode .navbar__profile-item i {
 
 body.dark-mode .navbar__profile-item:hover,
 body.dark-mode .navbar__profile-item:focus-visible {
-  background: rgba(251, 247, 248, 0.16);
+  background: rgba(96, 165, 250, 0.2);
   color: var(--foreground-dark);
 }
 
 body.dark-mode .navbar__toggle {
-  border-color: rgba(251, 247, 248, 0.2);
-  background: rgba(251, 247, 248, 0.12);
+  border-color: rgba(148, 163, 184, 0.28);
+  background: rgba(51, 65, 85, 0.4);
 }
 
 body.dark-mode .navbar__toggle-bar {
@@ -664,9 +705,9 @@ body.dark-mode .navbar__toggle-bar {
 }
 
 body.dark-mode .navbar__drawer {
-  background: linear-gradient(180deg, #1a2234 0%, #111826 100%);
-  box-shadow: -18px 0 38px rgba(0, 0, 0, 0.4);
-  border-left-color: rgba(251, 247, 248, 0.12);
+  background: linear-gradient(180deg, #0f172a 0%, #111827 100%);
+  box-shadow: -18px 0 38px rgba(2, 6, 23, 0.6);
+  border-left-color: rgba(96, 165, 250, 0.2);
 }
 
 body.dark-mode .navbar__drawer-section-title {
@@ -674,12 +715,12 @@ body.dark-mode .navbar__drawer-section-title {
 }
 
 body.dark-mode .navbar__drawer-link {
-  color: rgba(251, 247, 248, 0.82);
+  color: rgba(226, 232, 240, 0.84);
 }
 
 body.dark-mode .navbar__drawer-link:hover,
 body.dark-mode .navbar__drawer-link:focus-visible {
-  background: rgba(251, 247, 248, 0.16);
+  background: rgba(96, 165, 250, 0.2);
   color: var(--foreground-dark);
 }
 
@@ -977,82 +1018,171 @@ body.dark-mode .navbar__drawer-link:focus-visible {
 /* Footer */
 
 .site-footer {
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.92) 0%, rgba(255, 158, 27, 0.08) 100%);
-  border-top: 3px solid var(--accent-red);
-  margin-top: auto;
+  margin-top: clamp(3rem, 7vw, 5rem);
+  padding: clamp(3rem, 7vw, 5rem) 0 clamp(1.6rem, 4vw, 2.8rem);
+  background: linear-gradient(180deg, rgba(226, 232, 255, 0.8) 0%, rgba(255, 255, 255, 0.95) 45%, rgba(248, 250, 255, 0.92) 100%);
+  border-top: 1px solid rgba(148, 163, 184, 0.24);
+  box-shadow: 0 -24px 40px rgba(15, 23, 42, 0.08);
+  position: relative;
+  overflow: hidden;
 }
 
-body.dark-mode .site-footer {
-  background: linear-gradient(180deg, rgba(5, 10, 48, 0.94) 0%, rgba(208, 0, 37, 0.6) 100%);
-  border-top-color: var(--accent-red);
+.site-footer::before {
+  content: '';
+  position: absolute;
+  inset: -40% -20% auto -20%;
+  height: 320px;
+  background: radial-gradient(480px 320px at 18% 20%, rgba(var(--accent-blue-rgb), 0.18), transparent 70%);
+  opacity: 0.6;
+  pointer-events: none;
 }
 
 .site-footer__inner {
   width: var(--content-wide);
   margin: 0 auto;
-  display: grid;
-  gap: 2rem;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  padding: clamp(2.2rem, 4vw, 3rem) clamp(1rem, 3vw, 1.6rem);
+  padding-inline: clamp(1rem, 3vw, 1.6rem);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(2rem, 4vw, 3rem);
 }
 
 .site-footer__brand {
   display: grid;
-  gap: 0.4rem;
+  grid-template-columns: minmax(220px, 0.9fr) minmax(320px, 1fr);
+  gap: clamp(1.4rem, 3vw, 2.4rem);
+  align-items: center;
 }
 
-.site-footer__name {
-  font-family: var(--font-display);
-  font-weight: 800;
-  font-size: 1.3rem;
+.site-footer__brand img {
+  width: 64px;
+  height: 64px;
+  border-radius: 18px;
+  box-shadow: 0 18px 30px rgba(var(--accent-blue-dark-rgb), 0.22);
 }
 
-.site-footer__description { color: rgba(29, 31, 42, 0.68); margin: 0; }
-
-.site-footer__nav { display: grid; gap: 0.65rem; }
-
-.site-footer__nav a {
-  color: var(--foreground-light);
-  font-weight: 600;
+.site-footer__brand h2 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2rem);
 }
 
-.site-footer__nav a:hover,
-.site-footer__nav a:focus-visible { color: var(--primary); }
+.site-footer__brand p {
+  margin: 0;
+  max-width: 48ch;
+}
 
 .site-footer__social {
   display: flex;
   gap: 0.8rem;
-  align-items: center;
 }
 
 .site-footer__social a {
   width: 40px;
   height: 40px;
-  border-radius: 50%;
+  border-radius: 12px;
   display: grid;
   place-items: center;
-  color: var(--primary);
   background: rgba(var(--accent-blue-rgb), 0.12);
-  transition: transform var(--transition), background var(--transition);
+  color: var(--primary);
+  border: 1px solid rgba(var(--accent-blue-rgb), 0.22);
+  transition: transform var(--transition), background var(--transition), color var(--transition);
 }
 
-.site-footer__social a:hover {
+.site-footer__social a:hover,
+.site-footer__social a:focus-visible {
   transform: translateY(-3px);
   background: linear-gradient(135deg, var(--primary), var(--accent-blue-dark));
   color: #ffffff;
 }
 
-.site-footer__meta {
-  border-top: 1px solid rgba(208, 0, 37, 0.12);
-  padding: 1.2rem clamp(1rem, 3vw, 1.6rem);
-  display: flex;
-  flex-wrap: wrap;
-  gap: 1rem;
-  justify-content: center;
-  font-size: 0.9rem;
-  color: var(--text-subtle-light);
+.site-footer__grid {
+  display: grid;
+  gap: clamp(1.5rem, 3vw, 2.6rem);
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
 }
 
+.site-footer__heading {
+  font-size: 0.9rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  margin-bottom: 0.8rem;
+  color: rgba(15, 23, 42, 0.6);
+}
+
+.site-footer__links {
+  display: grid;
+  gap: 0.55rem;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.site-footer__links a {
+  color: var(--text-muted-light);
+  font-weight: 600;
+}
+
+.site-footer__links a:hover,
+.site-footer__links a:focus-visible {
+  color: var(--primary);
+}
+
+.site-footer__bottom {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 0.8rem;
+  padding-top: clamp(1rem, 3vw, 1.6rem);
+  border-top: 1px solid rgba(148, 163, 184, 0.2);
+  color: rgba(15, 23, 42, 0.6);
+  font-size: 0.9rem;
+}
+
+.site-footer__legal {
+  margin: 0;
+}
+
+.site-footer__meta {
+  display: flex;
+  gap: 1.2rem;
+}
+
+.site-footer__meta a {
+  color: inherit;
+  font-weight: 600;
+}
+
+body.dark-mode .site-footer {
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.96) 0%, rgba(15, 23, 42, 1) 100%);
+  border-top-color: rgba(96, 165, 250, 0.3);
+  color: var(--foreground-dark);
+}
+
+body.dark-mode .site-footer__brand p,
+body.dark-mode .site-footer__links a,
+body.dark-mode .site-footer__bottom,
+body.dark-mode .site-footer__meta a {
+  color: rgba(226, 232, 240, 0.82);
+}
+
+body.dark-mode .site-footer__links a:hover,
+body.dark-mode .site-footer__links a:focus-visible,
+body.dark-mode .site-footer__meta a:hover,
+body.dark-mode .site-footer__meta a:focus-visible {
+  color: #60a5fa;
+}
+
+body.dark-mode .site-footer__social a {
+  background: rgba(96, 165, 250, 0.2);
+  border-color: rgba(96, 165, 250, 0.32);
+  color: #e2e8f0;
+}
+
+body.dark-mode .site-footer__social a:hover,
+body.dark-mode .site-footer__social a:focus-visible {
+  background: linear-gradient(135deg, #3b82f6, #0ea5e9);
+  color: #ffffff;
+}
+ 
 /* Landing */
 
 .landing {
@@ -1060,16 +1190,34 @@ body.dark-mode .site-footer {
 }
 
 .landing-quicknav {
+  --quicknav-progress: 0;
+  position: relative;
   display: grid;
-  gap: 1rem;
+  gap: 1.2rem;
   align-items: start;
-  background:
-    linear-gradient(135deg, rgba(var(--calm-blue-rgb), 0.12), rgba(var(--calm-blue-light-rgb), 0.78))
-    var(--card-bg-light);
+  background: linear-gradient(150deg, rgba(255, 255, 255, 0.96) 0%, rgba(231, 236, 255, 0.88) 100%);
   border-radius: var(--radius-xl);
-  border: 1px solid rgba(var(--calm-blue-rgb), 0.18);
-  box-shadow: 0 18px 42px rgba(var(--calm-blue-rgb), 0.16);
-  padding: clamp(1.8rem, 4vw, 2.6rem);
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  box-shadow: 0 32px 68px rgba(15, 23, 42, 0.16);
+  padding: clamp(1.9rem, 4vw, 2.7rem);
+  overflow: hidden;
+}
+
+.landing-quicknav::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, rgba(var(--accent-blue-rgb), 0.22), rgba(255, 255, 255, 0));
+  transform-origin: left center;
+  transform: scaleX(var(--quicknav-progress, 0));
+  opacity: 0.6;
+  transition: transform 0.5s var(--transition), opacity var(--transition);
+  pointer-events: none;
+}
+
+.landing-quicknav > * {
+  position: relative;
+  z-index: 1;
 }
 
 .landing-quicknav__title {
@@ -1083,8 +1231,8 @@ body.dark-mode .site-footer {
   padding: 0;
   list-style: none;
   display: grid;
-  gap: 0.75rem;
-  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.85rem;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
 }
 
 .landing-quicknav__list a {
@@ -1097,9 +1245,11 @@ body.dark-mode .site-footer {
   text-decoration: none;
   font-weight: 600;
   color: var(--foreground-light);
-  background: rgba(var(--calm-blue-light-rgb), 0.45);
-  border: 1px solid rgba(var(--calm-blue-rgb), 0.18);
-  transition: transform var(--transition), box-shadow var(--transition), background var(--transition), color var(--transition);
+  background: rgba(255, 255, 255, 0.86);
+  border: 1px solid rgba(148, 163, 184, 0.32);
+  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.12);
+  backdrop-filter: blur(12px);
+  transition: transform var(--transition), box-shadow var(--transition), background var(--transition), color var(--transition), border-color var(--transition);
 }
 
 .landing-quicknav__list a::after {
@@ -1107,7 +1257,7 @@ body.dark-mode .site-footer {
   position: absolute;
   inset: 0;
   border-radius: inherit;
-  background: linear-gradient(120deg, rgba(var(--accent-blue-rgb), 0.2), rgba(var(--accent-blue-dark-rgb), 0.25));
+  background: linear-gradient(130deg, rgba(var(--accent-blue-rgb), 0.16), rgba(var(--accent-blue-dark-rgb), 0.28));
   opacity: 0;
   transition: opacity var(--transition);
 }
@@ -1120,45 +1270,60 @@ body.dark-mode .site-footer {
 .landing-quicknav__list a:hover,
 .landing-quicknav__list a:focus-visible {
   transform: translateY(-2px);
-  box-shadow: 0 16px 30px rgba(var(--calm-blue-rgb), 0.22);
+  box-shadow: 0 24px 48px rgba(var(--accent-blue-dark-rgb), 0.22);
+  border-color: rgba(var(--accent-blue-dark-rgb), 0.35);
 }
 
 .landing-quicknav__list a.is-active {
   color: #ffffff;
-  background: linear-gradient(135deg, var(--primary), var(--accent-blue-dark));
+  background: linear-gradient(130deg, var(--primary), var(--accent-blue-dark));
   border-color: transparent;
+  box-shadow: 0 28px 52px rgba(var(--accent-blue-dark-rgb), 0.32);
 }
 
 .landing-quicknav__list a.is-active::after,
 .landing-quicknav__list a:hover::after,
 .landing-quicknav__list a:focus-visible::after {
-  opacity: 0.45;
+  opacity: 0.5;
 }
 
 .landing-quicknav__list a.is-active:hover {
-  box-shadow: 0 20px 42px rgba(var(--accent-blue-dark-rgb), 0.26);
+  box-shadow: 0 30px 58px rgba(var(--accent-blue-dark-rgb), 0.42);
 }
 
 .landing-hero {
   display: grid;
-  gap: clamp(2rem, 4vw, 3rem);
-  grid-template-columns: minmax(320px, 1.2fr) minmax(260px, 1fr);
-  background: linear-gradient(145deg, rgba(var(--calm-blue-rgb), 0.18), rgba(var(--calm-blue-light-rgb), 0.92));
-  padding: clamp(2.6rem, 6vw, 4.2rem);
+  gap: clamp(2.1rem, 4vw, 3.2rem);
+  grid-template-columns: minmax(340px, 1.15fr) minmax(260px, 1fr);
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.96) 0%, rgba(226, 232, 255, 0.88) 100%);
+  padding: clamp(2.8rem, 6vw, 4.4rem);
   border-radius: var(--radius-xl);
-  border: 1px solid rgba(var(--calm-blue-rgb), 0.24);
-  box-shadow: 0 32px 60px rgba(var(--calm-blue-rgb), 0.18);
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  box-shadow: 0 42px 96px rgba(15, 23, 42, 0.18);
   position: relative;
   overflow: hidden;
 }
 
-.landing-hero::after {
-  content: "";
+.landing-hero::before {
+  content: '';
   position: absolute;
-  inset: 1.5rem;
-  border-radius: calc(var(--radius-xl) - 1.5rem);
-  border: 1px solid rgba(255, 255, 255, 0.28);
-  opacity: 0.35;
+  inset: -25% -20% -30% -20%;
+  background:
+    radial-gradient(38rem 32rem at 20% 30%, rgba(var(--accent-blue-rgb), 0.22), transparent 60%),
+    radial-gradient(36rem 30rem at 110% -10%, rgba(var(--accent-red-rgb), 0.16), transparent 58%),
+    linear-gradient(140deg, rgba(148, 163, 184, 0.12), rgba(255, 255, 255, 0));
+  opacity: 0.8;
+  pointer-events: none;
+  filter: blur(0.4px);
+}
+
+.landing-hero::after {
+  content: '';
+  position: absolute;
+  inset: 1.2rem;
+  border-radius: calc(var(--radius-xl) - 1.2rem);
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  opacity: 0.6;
   pointer-events: none;
 }
 
@@ -1176,7 +1341,7 @@ body.dark-mode .site-footer {
   font-size: 0.78rem;
   letter-spacing: 0.22em;
   text-transform: uppercase;
-  color: var(--calm-blue);
+  color: rgba(var(--accent-blue-rgb), 0.9);
   margin: 0;
 }
 
@@ -1198,9 +1363,20 @@ body.dark-mode .site-footer {
 .landing-hero__metrics div {
   padding: 1rem 1.2rem;
   border-radius: var(--radius-sm);
-  background: linear-gradient(135deg, rgba(var(--calm-blue-rgb), 0.1), rgba(var(--calm-blue-light-rgb), 0.9));
-  border: 1px solid rgba(var(--calm-blue-rgb), 0.2);
-  box-shadow: 0 14px 26px rgba(var(--calm-blue-rgb), 0.12);
+  background: linear-gradient(150deg, rgba(255, 255, 255, 0.9), rgba(241, 245, 255, 0.8));
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.16);
+  position: relative;
+  overflow: hidden;
+}
+
+.landing-hero__metrics div::after {
+  content: '';
+  position: absolute;
+  inset: -40% -30%;
+  background: radial-gradient(18rem 14rem at 20% 20%, rgba(var(--accent-blue-rgb), 0.22), transparent 70%);
+  opacity: 0.5;
+  pointer-events: none;
 }
 
 .landing-hero__metrics dt {
@@ -1220,13 +1396,24 @@ body.dark-mode .site-footer {
 
 .landing-preview {
   border-radius: var(--radius-lg);
-  border: 1px solid rgba(var(--calm-blue-rgb), 0.24);
-  padding: 1.6rem;
-  background: linear-gradient(160deg, rgba(var(--calm-blue-rgb), 0.9), rgba(var(--calm-blue-rgb), 0.75));
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  padding: 1.8rem;
+  background: linear-gradient(160deg, rgba(255, 255, 255, 0.95), rgba(233, 237, 255, 0.9));
   display: grid;
   gap: 1.2rem;
-  color: #ffffff;
-  box-shadow: 0 24px 46px rgba(var(--calm-blue-rgb), 0.28);
+  color: var(--foreground-light);
+  box-shadow: 0 32px 60px rgba(15, 23, 42, 0.16);
+  position: relative;
+  overflow: hidden;
+}
+
+.landing-preview::after {
+  content: '';
+  position: absolute;
+  inset: -45% -35% 20% -20%;
+  background: radial-gradient(24rem 18rem at 10% 20%, rgba(var(--accent-blue-rgb), 0.24), transparent 70%);
+  opacity: 0.6;
+  pointer-events: none;
 }
 
 .landing-preview__header {
@@ -1234,7 +1421,7 @@ body.dark-mode .site-footer {
   justify-content: space-between;
   font-size: 0.9rem;
   font-weight: 600;
-  opacity: 0.9;
+  opacity: 0.92;
 }
 
 .landing-preview__status {
@@ -1244,7 +1431,7 @@ body.dark-mode .site-footer {
   gap: 1rem;
   padding: 0.65rem 0.95rem;
   border-radius: var(--radius-sm);
-  background: rgba(255, 255, 255, 0.2);
+  background: rgba(var(--accent-blue-rgb), 0.16);
   font-size: 0.85rem;
   font-weight: 600;
 }
@@ -1257,9 +1444,65 @@ body.dark-mode .site-footer {
   gap: 0.4rem;
   padding: 0.35rem 0.75rem;
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.32);
+  background: rgba(var(--accent-blue-rgb), 0.18);
+  color: var(--primary-dark);
   text-transform: uppercase;
   letter-spacing: 0.08em;
+  font-weight: 700;
+  font-size: 0.75rem;
+}
+
+.landing-preview__clusters {
+  display: grid;
+  gap: 0.9rem;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+}
+
+.landing-preview__cluster {
+  position: relative;
+  padding: 0.75rem 0.9rem;
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 16px 28px rgba(15, 23, 42, 0.12);
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  display: grid;
+  gap: 0.35rem;
+}
+
+.landing-preview__cluster::after {
+  content: '';
+  position: absolute;
+  inset: -40% -40% auto -30%;
+  height: 60%;
+  background: radial-gradient(14rem 12rem at 20% 20%, rgba(var(--accent-blue-rgb), 0.2), transparent 70%);
+  opacity: 0.45;
+  pointer-events: none;
+}
+
+.landing-preview__cluster > * {
+  position: relative;
+  z-index: 1;
+}
+
+.landing-preview__cluster-label {
+  font-size: 0.7rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  opacity: 0.72;
+}
+
+.landing-preview__cluster-value {
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: var(--foreground-light);
+}
+
+.landing-preview__cluster-trend {
+  font-size: 0.8rem;
+  opacity: 0.85;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
 }
 
 .landing-preview__timeline {
@@ -1339,11 +1582,11 @@ body.dark-mode .site-footer {
 }
 
 .landing-panel {
-  background: linear-gradient(180deg, #ffffff 0%, rgba(var(--calm-blue-light-rgb), 0.6) 100%);
+  background: linear-gradient(150deg, rgba(255, 255, 255, 0.94), rgba(240, 245, 255, 0.86));
   border-radius: var(--radius-md);
-  padding: 1.6rem;
-  border: 1px solid rgba(var(--calm-blue-rgb), 0.18);
-  box-shadow: 0 18px 34px rgba(var(--calm-blue-rgb), 0.12);
+  padding: 1.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.14);
   display: grid;
   gap: 0.75rem;
   align-content: start;
@@ -1353,21 +1596,21 @@ body.dark-mode .site-footer {
   width: 48px;
   height: 48px;
   border-radius: 16px;
-  background: rgba(var(--calm-blue-rgb), 0.14);
+  background: linear-gradient(135deg, rgba(var(--accent-blue-rgb), 0.18), rgba(var(--accent-blue-dark-rgb), 0.22));
   display: grid;
   place-items: center;
-  color: var(--calm-blue);
+  color: #1d4ed8;
   font-size: 1.25rem;
 }
 
 .landing-gamify {
-  background: linear-gradient(135deg, rgba(var(--calm-blue-rgb), 0.18), rgba(var(--calm-blue-light-rgb), 0.9));
+  background: linear-gradient(155deg, rgba(255, 255, 255, 0.96), rgba(235, 240, 255, 0.88));
   border-radius: var(--radius-xl);
-  border: 1px solid rgba(var(--calm-blue-rgb), 0.24);
-  box-shadow: 0 28px 54px rgba(var(--calm-blue-rgb), 0.16);
+  border: 1px solid rgba(148, 163, 184, 0.26);
+  box-shadow: 0 40px 80px rgba(15, 23, 42, 0.18);
   display: grid;
   gap: var(--space-lg);
-  padding: clamp(2.2rem, 5vw, 3.4rem);
+  padding: clamp(2.4rem, 5vw, 3.6rem);
 }
 
 .landing-gamify__grid {
@@ -1377,24 +1620,24 @@ body.dark-mode .site-footer {
 }
 
 .landing-gamify__item {
-  background: rgba(255, 255, 255, 0.96);
+  background: linear-gradient(155deg, rgba(255, 255, 255, 0.92), rgba(236, 243, 255, 0.84));
   border-radius: var(--radius-md);
-  border: 1px solid rgba(var(--calm-blue-rgb), 0.16);
-  padding: 1.4rem;
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  padding: 1.55rem;
   display: grid;
-  gap: 0.75rem;
-  color: var(--text-muted-light);
-  box-shadow: 0 16px 30px rgba(var(--calm-blue-rgb), 0.12);
+  gap: 0.85rem;
+  color: var(--foreground-light);
+  box-shadow: 0 28px 50px rgba(15, 23, 42, 0.16);
 }
 
 .landing-gamify__icon {
-  width: 44px;
-  height: 44px;
-  border-radius: 14px;
-  background: rgba(var(--calm-blue-rgb), 0.16);
+  width: 48px;
+  height: 48px;
+  border-radius: 16px;
+  background: linear-gradient(135deg, rgba(var(--accent-blue-rgb), 0.18), rgba(var(--accent-blue-dark-rgb), 0.22));
   display: grid;
   place-items: center;
-  color: var(--calm-blue);
+  color: #1d4ed8;
 }
 
 .landing-devices {
@@ -1406,18 +1649,32 @@ body.dark-mode .site-footer {
 .landing-devices__card,
 .landing-devices__mock {
   border-radius: var(--radius-lg);
-  border: 1px solid rgba(var(--calm-blue-rgb), 0.18);
-  box-shadow: 0 20px 40px rgba(var(--calm-blue-rgb), 0.14);
-  padding: 2rem;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: 0 30px 60px rgba(8, 8, 38, 0.42);
+  padding: 2.1rem;
 }
 
-.landing-devices__card { background: var(--calm-blue-soft); }
+.landing-devices__card {
+  background: linear-gradient(150deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.02));
+  color: var(--foreground-light);
+}
 
 .landing-devices__mock {
-  background: linear-gradient(145deg, rgba(var(--calm-blue-rgb), 0.88), rgba(var(--calm-blue-rgb), 0.72));
-  color: #ffffff;
+  background: linear-gradient(150deg, rgba(16, 20, 58, 0.95), rgba(8, 8, 28, 0.88));
+  color: var(--foreground-light);
   display: grid;
   gap: 1.4rem;
+  position: relative;
+  overflow: hidden;
+}
+
+.landing-devices__mock::after {
+  content: '';
+  position: absolute;
+  inset: -30% -20% 10% -25%;
+  background: radial-gradient(26rem 20rem at 25% 10%, rgba(var(--accent-blue-rgb), 0.35), transparent 70%);
+  opacity: 0.75;
+  pointer-events: none;
 }
 
 .landing-devices__list {
@@ -1442,8 +1699,8 @@ body.dark-mode .site-footer {
   border-radius: 50%;
   display: grid;
   place-items: center;
-  background: rgba(var(--calm-blue-rgb), 0.16);
-  color: var(--calm-blue);
+  background: linear-gradient(135deg, rgba(var(--accent-blue-rgb), 0.4), rgba(var(--accent-blue-dark-rgb), 0.25));
+  color: #050516;
 }
 
 .landing-devices__dots { display: inline-flex; gap: 0.4rem; }
@@ -1452,19 +1709,122 @@ body.dark-mode .site-footer {
   width: 10px;
   height: 10px;
   border-radius: 50%;
-  background: rgba(255, 255, 255, 0.6);
+  background: rgba(255, 255, 255, 0.65);
 }
 
 .landing-devices__grid { display: grid; gap: 1rem; }
 
-.landing-blog {
-  background: linear-gradient(135deg, rgba(208, 0, 37, 0.12), rgba(255, 255, 255, 0.95));
-  border: 1px solid rgba(208, 0, 37, 0.16);
+.landing-tools {
+  background: linear-gradient(155deg, rgba(15, 17, 48, 0.94), rgba(7, 8, 26, 0.98));
   border-radius: var(--radius-xl);
-  box-shadow: 0 24px 48px rgba(208, 0, 37, 0.18);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: 0 40px 82px rgba(5, 5, 22, 0.52);
   display: grid;
   gap: var(--space-lg);
-  padding: clamp(2.2rem, 5vw, 3.2rem);
+  padding: clamp(2.5rem, 6vw, 3.9rem);
+  position: relative;
+  overflow: hidden;
+}
+
+.landing-tools::after {
+  content: '';
+  position: absolute;
+  inset: -35% -30% 5% -10%;
+  background: radial-gradient(30rem 22rem at 82% 20%, rgba(var(--accent-blue-rgb), 0.28), transparent 70%);
+  opacity: 0.7;
+  pointer-events: none;
+}
+
+.landing-tools__header {
+  display: grid;
+  gap: 0.75rem;
+  max-width: 680px;
+}
+
+.landing-tools__eyebrow {
+  font-size: 0.78rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(var(--accent-blue-rgb), 0.8);
+}
+
+.landing-tools__lead {
+  color: var(--text-muted-light);
+  max-width: 60ch;
+}
+
+.landing-tools__grid {
+  display: grid;
+  gap: 1.2rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.landing-tool {
+  background: linear-gradient(150deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.02));
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  padding: 1.6rem;
+  box-shadow: 0 26px 48px rgba(8, 8, 38, 0.38);
+  display: grid;
+  gap: 0.85rem;
+  align-content: start;
+  transition: transform var(--transition), box-shadow var(--transition);
+}
+
+.landing-tool:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 36px 68px rgba(8, 8, 38, 0.45);
+}
+
+.landing-tool--accent {
+  background: linear-gradient(145deg, rgba(var(--accent-blue-rgb), 0.28), rgba(var(--accent-blue-dark-rgb), 0.34));
+  color: #050516;
+  border-color: transparent;
+}
+
+.landing-tool__icon {
+  width: 48px;
+  height: 48px;
+  border-radius: 16px;
+  background: linear-gradient(135deg, rgba(var(--accent-blue-rgb), 0.4), rgba(var(--accent-blue-dark-rgb), 0.22));
+  display: grid;
+  place-items: center;
+  color: #050516;
+  font-size: 1.2rem;
+}
+
+.landing-tool__link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  color: var(--foreground-light);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.landing-tool--accent .landing-tool__link {
+  color: #050516;
+}
+
+.landing-blog {
+  background: linear-gradient(160deg, rgba(17, 16, 52, 0.94), rgba(7, 8, 28, 0.98));
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: var(--radius-xl);
+  box-shadow: 0 36px 72px rgba(5, 5, 22, 0.5);
+  display: grid;
+  gap: var(--space-lg);
+  padding: clamp(2.6rem, 6vw, 3.8rem);
+  position: relative;
+  overflow: hidden;
+}
+
+.landing-blog::after {
+  content: '';
+  position: absolute;
+  inset: -40% -25% 10% -15%;
+  background: radial-gradient(28rem 20rem at 18% 15%, rgba(var(--accent-red-rgb), 0.28), transparent 70%);
+  opacity: 0.65;
+  pointer-events: none;
 }
 
 .landing-blog__header { display: grid; gap: 0.75rem; }
@@ -1510,11 +1870,11 @@ body.dark-mode .site-footer {
 .landing-updates__newsletter {
   display: grid;
   gap: 0.75rem;
-  background: linear-gradient(135deg, rgba(var(--calm-blue-rgb), 0.08), rgba(var(--calm-blue-light-rgb), 0.32));
+  background: linear-gradient(150deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.02));
   border-radius: var(--radius-lg);
-  padding: clamp(1.4rem, 3vw, 2rem);
-  border: 1px solid rgba(var(--calm-blue-rgb), 0.2);
-  box-shadow: 0 12px 28px rgba(var(--calm-blue-rgb), 0.18);
+  padding: clamp(1.6rem, 3vw, 2.2rem);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: 0 24px 48px rgba(8, 8, 38, 0.38);
 }
 
 .landing-updates__fields { display: grid; gap: 0.5rem; }
@@ -1534,10 +1894,11 @@ body.dark-mode .site-footer {
   flex: 1 1 220px;
   padding: 0.75rem 1rem;
   border-radius: var(--radius-sm);
-  border: 1px solid rgba(var(--calm-blue-rgb), 0.28);
+  border: 1px solid rgba(255, 255, 255, 0.2);
   font-size: 1rem;
-  background: rgba(255, 255, 255, 0.9);
+  background: rgba(8, 10, 24, 0.85);
   color: var(--foreground-light);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
 }
 
 .landing-updates__input-row input:focus-visible {
@@ -1582,42 +1943,40 @@ body.dark-mode .site-footer {
 }
 
 .landing-updates__message[data-tone='success'] {
-  color: #0a7a4d;
+  color: #58f0c6;
 }
 
 .landing-updates__message[data-tone='warning'] {
-  color: #9b2d2d;
+  color: #ff6f91;
 }
 
 body.dark-mode .landing-quicknav {
-  background:
-    linear-gradient(135deg, rgba(var(--calm-blue-rgb), 0.26), rgba(var(--calm-blue-light-rgb), 0.18))
-    rgba(24, 20, 32, 0.8);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  box-shadow: 0 22px 44px rgba(0, 0, 0, 0.45);
+  background: linear-gradient(150deg, rgba(12, 13, 36, 0.95), rgba(6, 7, 22, 0.98));
+  border-color: rgba(255, 255, 255, 0.12);
+  box-shadow: 0 34px 70px rgba(0, 0, 0, 0.55);
 }
 
 body.dark-mode .landing-quicknav__list a {
-  background: rgba(var(--calm-blue-light-rgb), 0.28);
-  border-color: rgba(var(--calm-blue-rgb), 0.32);
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.18);
 }
 
 body.dark-mode .landing-quicknav__list a.is-active {
-  box-shadow: 0 20px 42px rgba(var(--accent-blue-dark-rgb), 0.32);
+  box-shadow: 0 30px 58px rgba(var(--accent-blue-dark-rgb), 0.4);
 }
 
 body.dark-mode .landing-updates__newsletter {
-  background: linear-gradient(135deg, rgba(var(--calm-blue-rgb), 0.18), rgba(var(--calm-blue-light-rgb), 0.12));
-  border-color: rgba(255, 255, 255, 0.12);
-  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.45);
+  background: linear-gradient(150deg, rgba(17, 20, 60, 0.92), rgba(8, 9, 26, 0.94));
+  border-color: rgba(255, 255, 255, 0.16);
+  box-shadow: 0 32px 60px rgba(0, 0, 0, 0.5);
 }
 
 body.dark-mode .landing-updates__message[data-tone='success'] {
-  color: #7be3b4;
+  color: #73ffe0;
 }
 
 body.dark-mode .landing-updates__message[data-tone='warning'] {
-  color: #f8a7a7;
+  color: #ff8ab5;
 }
 
 @media (max-width: 720px) {
@@ -1636,10 +1995,10 @@ body.dark-mode .landing-updates__message[data-tone='warning'] {
   gap: var(--space-xl);
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
   border-radius: var(--radius-xl);
-  border: 1px solid rgba(208, 0, 37, 0.16);
-  background: linear-gradient(135deg, rgba(208, 0, 37, 0.14), rgba(255, 255, 255, 0.95));
-  box-shadow: 0 20px 44px rgba(208, 0, 37, 0.16);
-  padding: clamp(2rem, 5vw, 3.2rem);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: linear-gradient(155deg, rgba(16, 18, 54, 0.94), rgba(6, 8, 28, 0.98));
+  box-shadow: 0 34px 68px rgba(5, 5, 22, 0.52);
+  padding: clamp(2.2rem, 5vw, 3.4rem);
 }
 
 .page-hero__lead { font-size: 1.08rem; }
@@ -1656,11 +2015,13 @@ body.dark-mode .landing-updates__message[data-tone='warning'] {
   border: 1px solid var(--border-soft-light);
   padding: clamp(1.6rem, 4vw, 2.4rem);
   box-shadow: var(--shadow-soft);
+  backdrop-filter: blur(18px);
 }
 
 .page-card--highlight {
-  background: linear-gradient(140deg, rgba(var(--accent-blue-rgb), 0.14), rgba(255, 255, 255, 0.9));
-  border-color: rgba(var(--accent-blue-rgb), 0.22);
+  background: linear-gradient(150deg, rgba(var(--accent-blue-rgb), 0.22), rgba(var(--accent-blue-dark-rgb), 0.28));
+  border-color: transparent;
+  color: #050516;
   box-shadow: var(--shadow-medium);
 }
 
@@ -1681,10 +2042,11 @@ body.dark-mode .landing-updates__message[data-tone='warning'] {
 .page-grid--compact { gap: var(--space-md); }
 
 .page-mini-card {
-  background: linear-gradient(180deg, rgba(208, 0, 37, 0.08), rgba(255, 255, 255, 0.95));
+  background: linear-gradient(160deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.02));
   border-radius: var(--radius-md);
-  border: 1px solid rgba(208, 0, 37, 0.18);
-  padding: 1.2rem 1.4rem;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  padding: 1.3rem 1.6rem;
+  box-shadow: 0 20px 40px rgba(8, 8, 38, 0.35);
 }
 
 /* Auth gate */
@@ -1727,10 +2089,10 @@ body.dark-mode .landing-updates__message[data-tone='warning'] {
   display: grid;
   gap: var(--space-xl);
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  background: linear-gradient(140deg, rgba(var(--accent-blue-rgb), 0.14), rgba(255, 255, 255, 0.9));
+  background: linear-gradient(155deg, rgba(16, 18, 54, 0.94), rgba(6, 8, 28, 0.96));
   border-radius: var(--radius-xl);
-  border: 1px solid rgba(var(--accent-blue-rgb), 0.18);
-  box-shadow: var(--shadow-medium);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: 0 38px 72px rgba(5, 5, 22, 0.5);
 }
 
 .dashboard-hero__profile {
@@ -3343,6 +3705,30 @@ body.dark-mode .landing-updates__message[data-tone='warning'] {
   .fleet-toast {
     left: 1.2rem;
     right: 1.2rem;
+  }
+
+  .site-footer__brand {
+    grid-template-columns: 1fr;
+    text-align: center;
+    gap: 1.2rem;
+  }
+
+  .site-footer__brand img {
+    margin: 0 auto;
+  }
+
+  .site-footer__social {
+    justify-content: center;
+  }
+
+  .site-footer__grid {
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  }
+
+  .site-footer__bottom {
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
   }
 }
 

--- a/terms.html
+++ b/terms.html
@@ -13,8 +13,12 @@
 </head>
 <body class="site-body">
   <a href="#main-content" class="skip-link">Skip to main content</a>
-  <div id="navbar-container"></div>
+  <div class="site-shell">
+    <header class="site-shell__header">
+      <div id="navbar-container" class="site-shell__navbar"></div>
+    </header>
 
+    <div class="site-shell__main">
   <main id="main-content" class="site-main page-shell legal-shell" aria-labelledby="termsTitle">
     <section class="page-hero">
       <div class="page-hero__content">
@@ -130,38 +134,68 @@
     </div>
   </main>
 
-  <footer class="site-footer" aria-label="Footer">
-    <div class="site-footer__inner">
-      <div class="site-footer__brand">
-        <span class="site-footer__name">RouteFlow London</span>
-        <p class="site-footer__description">Playful transport guidance for explorers of every age.</p>
-      </div>
-      <nav class="site-footer__nav" aria-label="Explore">
-        <a href="index.html">Home</a>
-        <a href="dashboard.html">Dashboard</a>
-        <a href="tracking.html">Tracking</a>
-        <a href="planning.html">Planning</a>
-        <a href="routes.html">Routes</a>
-        <a href="info.html">Info hub</a>
-      </nav>
-      <nav class="site-footer__nav" aria-label="Support">
-        <a href="about.html">About</a>
-        <a href="contact.html">Contact</a>
-        <a href="privacy.html">Privacy</a>
-        <a href="terms.html">Terms</a>
-        <a href="settings.html">Settings</a>
-      </nav>
-      <div class="site-footer__social" aria-label="Social channels">
-        <a href="https://discord.gg/qVf3nN4Mgq" aria-label="RouteFlow London on Discord"><i class="fa-brands fa-discord"></i></a>
-        <a href="https://www.tiktok.com/@the_bus_father" aria-label="RouteFlow London on TikTok"><i class="fab fa-tiktok"></i></a>
-        <a href="https://www.instagram.com/thebusfatherofficial/profilecard/?igsh=NXcybzV3cTA2azBo" aria-label="RouteFlow London on Instagram"><i class="fab fa-instagram"></i></a>
-      </div>
     </div>
-    <div class="site-footer__meta">
-      <span>&copy; <span data-current-year></span> RouteFlow London. All rights reserved.</span>
-      <span>Made for London. Accessible for everyone.</span>
-    </div>
-  </footer>
+
+    <footer class="site-footer" aria-label="RouteFlow London footer">
+      <div class="site-footer__inner">
+        <div class="site-footer__brand">
+          <img src="images/New_Routflow_London_Logo.png" alt="RouteFlow London logo">
+          <div>
+            <h2>Stay curious about London’s transport</h2>
+            <p>RouteFlow London turns TfL feeds into playful guidance so planners, families and classrooms can travel with calm confidence.</p>
+            <div class="site-footer__social" role="list">
+              <a href="https://discord.gg/qVf3nN4Mgq" aria-label="RouteFlow London on Discord"><i class="fa-brands fa-discord"></i></a>
+              <a href="https://www.tiktok.com/@the_bus_father" aria-label="RouteFlow London on TikTok"><i class="fa-brands fa-tiktok"></i></a>
+              <a href="https://www.instagram.com/thebusfatherofficial/profilecard/?igsh=NXcybzV3cTA2azBo" aria-label="RouteFlow London on Instagram"><i class="fa-brands fa-instagram"></i></a>
+            </div>
+          </div>
+        </div>
+        <div class="site-footer__grid">
+          <div>
+            <h3 class="site-footer__heading">Plan journeys</h3>
+            <ul class="site-footer__links">
+              <li><a href="index.html">Home</a></li>
+              <li><a href="planning.html">Planning</a></li>
+              <li><a href="tracking.html">Tracking</a></li>
+            </ul>
+          </div>
+          <div>
+            <h3 class="site-footer__heading">Live insight</h3>
+            <ul class="site-footer__links">
+              <li><a href="dashboard.html">Dashboard</a></li>
+              <li><a href="routes.html">Routes</a></li>
+              <li><a href="disruptions.html">Disruptions</a></li>
+            </ul>
+          </div>
+          <div>
+            <h3 class="site-footer__heading">Community data</h3>
+            <ul class="site-footer__links">
+              <li><a href="info.html">Info hub</a></li>
+              <li><a href="fleet.html">Fleet</a></li>
+              <li><a href="withdrawn.html">Withdrawn</a></li>
+            </ul>
+          </div>
+          <div>
+            <h3 class="site-footer__heading">Company</h3>
+            <ul class="site-footer__links">
+              <li><a href="about.html">About</a></li>
+              <li><a href="contact.html">Contact</a></li>
+              <li><a href="privacy.html">Privacy</a></li>
+              <li><a href="terms.html">Terms</a></li>
+            </ul>
+          </div>
+        </div>
+        <div class="site-footer__bottom">
+          <p class="site-footer__legal">© <span data-current-year></span> RouteFlow London. Crafted for curious travellers.</p>
+          <div class="site-footer__meta">
+            <a href="privacy.html">Privacy</a>
+            <a href="terms.html">Terms</a>
+            <a href="contact.html">Contact</a>
+          </div>
+        </div>
+      </div>
+    </footer>
+  </div>
 
   <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-auth-compat.js"></script>

--- a/tracking.html
+++ b/tracking.html
@@ -23,8 +23,12 @@
   </head>
   <body class="site-body">
     <a href="#main-content" class="skip-link">Skip to main content</a>
-    <div id="navbar-container"></div>
+    <div class="site-shell">
+      <header class="site-shell__header">
+        <div id="navbar-container" class="site-shell__navbar"></div>
+      </header>
 
+      <div class="site-shell__main">
     <main
       id="main-content"
       class="site-main tracking-shell"
@@ -285,55 +289,68 @@
       </section>
     </main>
 
-    <footer class="site-footer" aria-label="Footer">
-      <div class="site-footer__inner">
-        <div class="site-footer__brand">
-          <span class="site-footer__name">RouteFlow London</span>
-          <p class="site-footer__description">
-            Playful transport guidance for explorers of every age.
-          </p>
-        </div>
-        <nav class="site-footer__nav" aria-label="Explore">
-          <a href="index.html">Home</a>
-          <a href="dashboard.html">Dashboard</a>
-          <a href="tracking.html">Tracking</a>
-          <a href="planning.html">Planning</a>
-          <a href="routes.html">Routes</a>
-          <a href="info.html">Info hub</a>
-        </nav>
-        <nav class="site-footer__nav" aria-label="Support">
-          <a href="about.html">About</a>
-          <a href="contact.html">Contact</a>
-          <a href="privacy.html">Privacy</a>
-          <a href="terms.html">Terms</a>
-          <a href="settings.html">Settings</a>
-        </nav>
-        <div class="site-footer__social" aria-label="Social channels">
-          <a
-            href="https://discord.gg/qVf3nN4Mgq"
-            aria-label="RouteFlow London on Discord"
-            ><i class="fa-brands fa-discord"></i
-          ></a>
-          <a
-            href="https://www.tiktok.com/@the_bus_father"
-            aria-label="RouteFlow London on TikTok"
-            ><i class="fab fa-tiktok"></i
-          ></a>
-          <a
-            href="https://www.instagram.com/thebusfatherofficial/profilecard/?igsh=NXcybzV3cTA2azBo"
-            aria-label="RouteFlow London on Instagram"
-            ><i class="fab fa-instagram"></i
-          ></a>
-        </div>
       </div>
-      <div class="site-footer__meta">
-        <span
-          >&copy; <span data-current-year></span> RouteFlow London. All rights
-          reserved.</span
-        >
-        <span>Made for London. Accessible for everyone.</span>
-      </div>
-    </footer>
+
+      <footer class="site-footer" aria-label="RouteFlow London footer">
+        <div class="site-footer__inner">
+          <div class="site-footer__brand">
+            <img src="images/New_Routflow_London_Logo.png" alt="RouteFlow London logo">
+            <div>
+              <h2>Stay curious about London’s transport</h2>
+              <p>RouteFlow London turns TfL feeds into playful guidance so planners, families and classrooms can travel with calm confidence.</p>
+              <div class="site-footer__social" role="list">
+                <a href="https://discord.gg/qVf3nN4Mgq" aria-label="RouteFlow London on Discord"><i class="fa-brands fa-discord"></i></a>
+                <a href="https://www.tiktok.com/@the_bus_father" aria-label="RouteFlow London on TikTok"><i class="fa-brands fa-tiktok"></i></a>
+                <a href="https://www.instagram.com/thebusfatherofficial/profilecard/?igsh=NXcybzV3cTA2azBo" aria-label="RouteFlow London on Instagram"><i class="fa-brands fa-instagram"></i></a>
+              </div>
+            </div>
+          </div>
+          <div class="site-footer__grid">
+            <div>
+              <h3 class="site-footer__heading">Plan journeys</h3>
+              <ul class="site-footer__links">
+                <li><a href="index.html">Home</a></li>
+                <li><a href="planning.html">Planning</a></li>
+                <li><a href="tracking.html">Tracking</a></li>
+              </ul>
+            </div>
+            <div>
+              <h3 class="site-footer__heading">Live insight</h3>
+              <ul class="site-footer__links">
+                <li><a href="dashboard.html">Dashboard</a></li>
+                <li><a href="routes.html">Routes</a></li>
+                <li><a href="disruptions.html">Disruptions</a></li>
+              </ul>
+            </div>
+            <div>
+              <h3 class="site-footer__heading">Community data</h3>
+              <ul class="site-footer__links">
+                <li><a href="info.html">Info hub</a></li>
+                <li><a href="fleet.html">Fleet</a></li>
+                <li><a href="withdrawn.html">Withdrawn</a></li>
+              </ul>
+            </div>
+            <div>
+              <h3 class="site-footer__heading">Company</h3>
+              <ul class="site-footer__links">
+                <li><a href="about.html">About</a></li>
+                <li><a href="contact.html">Contact</a></li>
+                <li><a href="privacy.html">Privacy</a></li>
+                <li><a href="terms.html">Terms</a></li>
+              </ul>
+            </div>
+          </div>
+          <div class="site-footer__bottom">
+            <p class="site-footer__legal">© <span data-current-year></span> RouteFlow London. Crafted for curious travellers.</p>
+            <div class="site-footer__meta">
+              <a href="privacy.html">Privacy</a>
+              <a href="terms.html">Terms</a>
+              <a href="contact.html">Contact</a>
+            </div>
+          </div>
+        </div>
+      </footer>
+    </div>
 
     <script src="tracking.js" defer></script>
     <script src="navbar-loader.js"></script>

--- a/withdrawn table.html
+++ b/withdrawn table.html
@@ -13,7 +13,12 @@
 </head>
 <body class="site-body">
   <a href="#main-content" class="skip-link">Skip to main content</a>
-  <div id="navbar-container"></div>
+  <div class="site-shell">
+    <header class="site-shell__header">
+      <div id="navbar-container" class="site-shell__navbar"></div>
+    </header>
+
+    <div class="site-shell__main">
   <main id="main-content" class="site-main network-shell" aria-labelledby="withdrawnTitle">
     <section class="network-hero">
       <div>
@@ -3672,38 +3677,68 @@
     </section>
   </main>
 
-  <footer class="site-footer" aria-label="Footer">
-    <div class="site-footer__inner">
-      <div class="site-footer__brand">
-        <span class="site-footer__name">RouteFlow London</span>
-        <p class="site-footer__description">Playful transport guidance for explorers of every age.</p>
-      </div>
-      <nav class="site-footer__nav" aria-label="Explore">
-        <a href="index.html">Home</a>
-        <a href="dashboard.html">Dashboard</a>
-        <a href="tracking.html">Tracking</a>
-        <a href="planning.html">Planning</a>
-        <a href="routes.html">Routes</a>
-        <a href="info.html">Info hub</a>
-      </nav>
-      <nav class="site-footer__nav" aria-label="Support">
-        <a href="about.html">About</a>
-        <a href="contact.html">Contact</a>
-        <a href="privacy.html">Privacy</a>
-        <a href="terms.html">Terms</a>
-        <a href="settings.html">Settings</a>
-      </nav>
-      <div class="site-footer__social" aria-label="Social channels">
-        <a href="https://discord.gg/qVf3nN4Mgq" aria-label="RouteFlow London on Discord"><i class="fa-brands fa-discord"></i></a>
-        <a href="https://www.tiktok.com/@the_bus_father" aria-label="RouteFlow London on TikTok"><i class="fab fa-tiktok"></i></a>
-        <a href="https://www.instagram.com/thebusfatherofficial/profilecard/?igsh=NXcybzV3cTA2azBo" aria-label="RouteFlow London on Instagram"><i class="fab fa-instagram"></i></a>
-      </div>
     </div>
-    <div class="site-footer__meta">
-      <span>&copy; <span data-current-year></span> RouteFlow London. All rights reserved.</span>
-      <span>Made for London. Accessible for everyone.</span>
-    </div>
-  </footer>
+
+    <footer class="site-footer" aria-label="RouteFlow London footer">
+      <div class="site-footer__inner">
+        <div class="site-footer__brand">
+          <img src="images/New_Routflow_London_Logo.png" alt="RouteFlow London logo">
+          <div>
+            <h2>Stay curious about London’s transport</h2>
+            <p>RouteFlow London turns TfL feeds into playful guidance so planners, families and classrooms can travel with calm confidence.</p>
+            <div class="site-footer__social" role="list">
+              <a href="https://discord.gg/qVf3nN4Mgq" aria-label="RouteFlow London on Discord"><i class="fa-brands fa-discord"></i></a>
+              <a href="https://www.tiktok.com/@the_bus_father" aria-label="RouteFlow London on TikTok"><i class="fa-brands fa-tiktok"></i></a>
+              <a href="https://www.instagram.com/thebusfatherofficial/profilecard/?igsh=NXcybzV3cTA2azBo" aria-label="RouteFlow London on Instagram"><i class="fa-brands fa-instagram"></i></a>
+            </div>
+          </div>
+        </div>
+        <div class="site-footer__grid">
+          <div>
+            <h3 class="site-footer__heading">Plan journeys</h3>
+            <ul class="site-footer__links">
+              <li><a href="index.html">Home</a></li>
+              <li><a href="planning.html">Planning</a></li>
+              <li><a href="tracking.html">Tracking</a></li>
+            </ul>
+          </div>
+          <div>
+            <h3 class="site-footer__heading">Live insight</h3>
+            <ul class="site-footer__links">
+              <li><a href="dashboard.html">Dashboard</a></li>
+              <li><a href="routes.html">Routes</a></li>
+              <li><a href="disruptions.html">Disruptions</a></li>
+            </ul>
+          </div>
+          <div>
+            <h3 class="site-footer__heading">Community data</h3>
+            <ul class="site-footer__links">
+              <li><a href="info.html">Info hub</a></li>
+              <li><a href="fleet.html">Fleet</a></li>
+              <li><a href="withdrawn.html">Withdrawn</a></li>
+            </ul>
+          </div>
+          <div>
+            <h3 class="site-footer__heading">Company</h3>
+            <ul class="site-footer__links">
+              <li><a href="about.html">About</a></li>
+              <li><a href="contact.html">Contact</a></li>
+              <li><a href="privacy.html">Privacy</a></li>
+              <li><a href="terms.html">Terms</a></li>
+            </ul>
+          </div>
+        </div>
+        <div class="site-footer__bottom">
+          <p class="site-footer__legal">© <span data-current-year></span> RouteFlow London. Crafted for curious travellers.</p>
+          <div class="site-footer__meta">
+            <a href="privacy.html">Privacy</a>
+            <a href="terms.html">Terms</a>
+            <a href="contact.html">Contact</a>
+          </div>
+        </div>
+      </div>
+    </footer>
+  </div>
 
   <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-auth-compat.js"></script>

--- a/withdrawn.html
+++ b/withdrawn.html
@@ -13,7 +13,12 @@
 </head>
 <body class="site-body">
   <a href="#main-content" class="skip-link">Skip to main content</a>
-  <div id="navbar-container"></div>
+  <div class="site-shell">
+    <header class="site-shell__header">
+      <div id="navbar-container" class="site-shell__navbar"></div>
+    </header>
+
+    <div class="site-shell__main">
   <main id="main-content" class="site-main network-shell" aria-labelledby="withdrawnTitle">
     <section class="network-hero">
       <div>
@@ -3672,38 +3677,68 @@
     </section>
   </main>
 
-  <footer class="site-footer" aria-label="Footer">
-    <div class="site-footer__inner">
-      <div class="site-footer__brand">
-        <span class="site-footer__name">RouteFlow London</span>
-        <p class="site-footer__description">Playful transport guidance for explorers of every age.</p>
-      </div>
-      <nav class="site-footer__nav" aria-label="Explore">
-        <a href="index.html">Home</a>
-        <a href="dashboard.html">Dashboard</a>
-        <a href="tracking.html">Tracking</a>
-        <a href="planning.html">Planning</a>
-        <a href="routes.html">Routes</a>
-        <a href="info.html">Info hub</a>
-      </nav>
-      <nav class="site-footer__nav" aria-label="Support">
-        <a href="about.html">About</a>
-        <a href="contact.html">Contact</a>
-        <a href="privacy.html">Privacy</a>
-        <a href="terms.html">Terms</a>
-        <a href="settings.html">Settings</a>
-      </nav>
-      <div class="site-footer__social" aria-label="Social channels">
-        <a href="https://discord.gg/qVf3nN4Mgq" aria-label="RouteFlow London on Discord"><i class="fa-brands fa-discord"></i></a>
-        <a href="https://www.tiktok.com/@the_bus_father" aria-label="RouteFlow London on TikTok"><i class="fab fa-tiktok"></i></a>
-        <a href="https://www.instagram.com/thebusfatherofficial/profilecard/?igsh=NXcybzV3cTA2azBo" aria-label="RouteFlow London on Instagram"><i class="fab fa-instagram"></i></a>
-      </div>
     </div>
-    <div class="site-footer__meta">
-      <span>&copy; <span data-current-year></span> RouteFlow London. All rights reserved.</span>
-      <span>Made for London. Accessible for everyone.</span>
-    </div>
-  </footer>
+
+    <footer class="site-footer" aria-label="RouteFlow London footer">
+      <div class="site-footer__inner">
+        <div class="site-footer__brand">
+          <img src="images/New_Routflow_London_Logo.png" alt="RouteFlow London logo">
+          <div>
+            <h2>Stay curious about London’s transport</h2>
+            <p>RouteFlow London turns TfL feeds into playful guidance so planners, families and classrooms can travel with calm confidence.</p>
+            <div class="site-footer__social" role="list">
+              <a href="https://discord.gg/qVf3nN4Mgq" aria-label="RouteFlow London on Discord"><i class="fa-brands fa-discord"></i></a>
+              <a href="https://www.tiktok.com/@the_bus_father" aria-label="RouteFlow London on TikTok"><i class="fa-brands fa-tiktok"></i></a>
+              <a href="https://www.instagram.com/thebusfatherofficial/profilecard/?igsh=NXcybzV3cTA2azBo" aria-label="RouteFlow London on Instagram"><i class="fa-brands fa-instagram"></i></a>
+            </div>
+          </div>
+        </div>
+        <div class="site-footer__grid">
+          <div>
+            <h3 class="site-footer__heading">Plan journeys</h3>
+            <ul class="site-footer__links">
+              <li><a href="index.html">Home</a></li>
+              <li><a href="planning.html">Planning</a></li>
+              <li><a href="tracking.html">Tracking</a></li>
+            </ul>
+          </div>
+          <div>
+            <h3 class="site-footer__heading">Live insight</h3>
+            <ul class="site-footer__links">
+              <li><a href="dashboard.html">Dashboard</a></li>
+              <li><a href="routes.html">Routes</a></li>
+              <li><a href="disruptions.html">Disruptions</a></li>
+            </ul>
+          </div>
+          <div>
+            <h3 class="site-footer__heading">Community data</h3>
+            <ul class="site-footer__links">
+              <li><a href="info.html">Info hub</a></li>
+              <li><a href="fleet.html">Fleet</a></li>
+              <li><a href="withdrawn.html">Withdrawn</a></li>
+            </ul>
+          </div>
+          <div>
+            <h3 class="site-footer__heading">Company</h3>
+            <ul class="site-footer__links">
+              <li><a href="about.html">About</a></li>
+              <li><a href="contact.html">Contact</a></li>
+              <li><a href="privacy.html">Privacy</a></li>
+              <li><a href="terms.html">Terms</a></li>
+            </ul>
+          </div>
+        </div>
+        <div class="site-footer__bottom">
+          <p class="site-footer__legal">© <span data-current-year></span> RouteFlow London. Crafted for curious travellers.</p>
+          <div class="site-footer__meta">
+            <a href="privacy.html">Privacy</a>
+            <a href="terms.html">Terms</a>
+            <a href="contact.html">Contact</a>
+          </div>
+        </div>
+      </div>
+    </footer>
+  </div>
 
   <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-auth-compat.js"></script>


### PR DESCRIPTION
## Summary
- Switch the global palette to a brighter Horizon treatment with updated gradients, cards, and landing components.
- Wrap every page in the new `site-shell` layout and share a consistent Horizon footer with navigation, company, and social links.
- Re-skin the mobile app dock controls so the compact navigation matches the refreshed desktop styling.

## Testing
- Not run (not requested).

------
https://chatgpt.com/codex/tasks/task_e_68e4d8c2a140832290af60c86f5d9093